### PR TITLE
refactor: cloud+ adapters resource usage hardening

### DIFF
--- a/app/shared/adapters/azure.py
+++ b/app/shared/adapters/azure.py
@@ -270,18 +270,16 @@ class AzureAdapter(BaseAdapter):
     def stream_cost_and_usage(
         self, start_date: datetime, end_date: datetime, granularity: str = "DAILY"
     ) -> AsyncGenerator[dict[str, Any], None]:
-        return self._stream_cost_and_usage_impl(start_date, end_date, granularity)
-
-    async def _stream_cost_and_usage_impl(
-        self, start_date: datetime, end_date: datetime, granularity: str = "DAILY"
-    ) -> AsyncGenerator[dict[str, Any], None]:
         """
         Stream Azure costs.
         Currently wraps the Query API (which is list-based) but yields individually to match interface.
         """
-        records = await self.get_cost_and_usage(start_date, end_date, granularity)
-        for record in records:
-            yield record
+        async def _iterate() -> AsyncGenerator[dict[str, Any], None]:
+            records = await self.get_cost_and_usage(start_date, end_date, granularity)
+            for row in records:
+                yield row
+
+        return _iterate()
 
     async def discover_resources(
         self, resource_type: str, region: str | None = None
@@ -289,6 +287,7 @@ class AzureAdapter(BaseAdapter):
         """
         Discover Azure resources with OTel tracing.
         """
+        self._clear_last_error()
         from app.shared.core.tracing import get_tracer
 
         tracer = get_tracer(__name__)
@@ -344,12 +343,16 @@ class AzureAdapter(BaseAdapter):
                     )
                 return resources
             except Exception as e:
+                self._set_last_error_from_exception(
+                    e, prefix="Azure resource discovery failed"
+                )
                 logger.error("azure_resource_discovery_failed", error=str(e))
                 return []
 
     async def get_resource_usage(
         self, service_name: str, resource_id: str | None = None
     ) -> list[dict[str, Any]]:
+        self._clear_last_error()
         target_service = service_name.strip()
         if not target_service:
             return []

--- a/app/shared/adapters/license_native_dispatch.py
+++ b/app/shared/adapters/license_native_dispatch.py
@@ -2,9 +2,127 @@ from __future__ import annotations
 
 from collections.abc import AsyncGenerator
 from datetime import datetime
-from typing import Any, Awaitable, Callable, Protocol, cast
+from typing import Any, Awaitable, Callable, TypeAlias
 
+from app.shared.adapters.feed_utils import as_float, parse_timestamp
+from app.shared.adapters.license_vendor_github import (
+    list_github_activity as _list_github_activity_impl,
+    revoke_github as vendor_revoke_github,
+)
+from app.shared.adapters.license_vendor_google import (
+    list_google_workspace_activity as _list_google_workspace_activity_impl,
+    revoke_google_workspace as vendor_revoke_google_workspace,
+    stream_google_workspace_license_costs as _stream_google_workspace_license_costs_impl,
+)
+from app.shared.adapters.license_vendor_microsoft import (
+    list_microsoft_365_activity as _list_microsoft_365_activity_impl,
+    revoke_microsoft_365 as vendor_revoke_microsoft_365,
+    stream_microsoft_365_license_costs as _stream_microsoft_365_license_costs_impl,
+)
+from app.shared.adapters.license_vendor_salesforce import (
+    list_salesforce_activity as _list_salesforce_activity_impl,
+    revoke_salesforce as vendor_revoke_salesforce,
+)
+from app.shared.adapters.license_vendor_slack import (
+    list_slack_activity as vendor_list_slack_activity,
+    revoke_slack as vendor_revoke_slack,
+)
+from app.shared.adapters.license_vendor_types import LicenseVendorRuntime
+from app.shared.adapters.license_vendor_verify import (
+    verify_github as vendor_verify_github,
+    verify_google_workspace as vendor_verify_google_workspace,
+    verify_microsoft_365 as vendor_verify_microsoft_365,
+    verify_salesforce as vendor_verify_salesforce,
+    verify_slack as vendor_verify_slack,
+    verify_zoom as vendor_verify_zoom,
+)
+from app.shared.adapters.license_vendor_zoom import (
+    list_zoom_activity as _list_zoom_activity_impl,
+    revoke_zoom as vendor_revoke_zoom,
+)
 from app.shared.core.exceptions import ExternalAPIError, UnsupportedVendorError
+
+VerifyFn: TypeAlias = Callable[[LicenseVendorRuntime], Awaitable[None]]
+StreamFn: TypeAlias = Callable[
+    [LicenseVendorRuntime, datetime, datetime],
+    AsyncGenerator[dict[str, Any], None],
+]
+RevokeWithSkuFn: TypeAlias = Callable[
+    [LicenseVendorRuntime, str, str | None], Awaitable[bool]
+]
+RevokeNoSkuFn: TypeAlias = Callable[[LicenseVendorRuntime, str], Awaitable[bool]]
+ActivityFn: TypeAlias = Callable[
+    [LicenseVendorRuntime], Awaitable[list[dict[str, Any]]]
+]
+
+
+async def vendor_stream_google_workspace_license_costs(
+    runtime: LicenseVendorRuntime, start_date: datetime, end_date: datetime
+) -> AsyncGenerator[dict[str, Any], None]:
+    async for row in _stream_google_workspace_license_costs_impl(
+        runtime,
+        start_date,
+        end_date,
+        as_float_fn=as_float,
+    ):
+        yield row
+
+
+async def vendor_stream_microsoft_365_license_costs(
+    runtime: LicenseVendorRuntime, start_date: datetime, end_date: datetime
+) -> AsyncGenerator[dict[str, Any], None]:
+    async for row in _stream_microsoft_365_license_costs_impl(
+        runtime,
+        start_date,
+        end_date,
+        as_float_fn=as_float,
+    ):
+        yield row
+
+
+async def vendor_list_google_workspace_activity(
+    runtime: LicenseVendorRuntime,
+) -> list[dict[str, Any]]:
+    return await _list_google_workspace_activity_impl(
+        runtime,
+        parse_timestamp_fn=parse_timestamp,
+    )
+
+
+async def vendor_list_microsoft_365_activity(
+    runtime: LicenseVendorRuntime,
+) -> list[dict[str, Any]]:
+    return await _list_microsoft_365_activity_impl(
+        runtime,
+        parse_timestamp_fn=parse_timestamp,
+    )
+
+
+async def vendor_list_github_activity(
+    runtime: LicenseVendorRuntime,
+) -> list[dict[str, Any]]:
+    return await _list_github_activity_impl(
+        runtime,
+        parse_timestamp_fn=parse_timestamp,
+    )
+
+
+async def vendor_list_zoom_activity(
+    runtime: LicenseVendorRuntime,
+) -> list[dict[str, Any]]:
+    return await _list_zoom_activity_impl(
+        runtime,
+        parse_timestamp_fn=parse_timestamp,
+    )
+
+
+async def vendor_list_salesforce_activity(
+    runtime: LicenseVendorRuntime,
+) -> list[dict[str, Any]]:
+    return await _list_salesforce_activity_impl(
+        runtime,
+        parse_timestamp_fn=parse_timestamp,
+    )
 
 _SUPPORTED_NATIVE_VENDORS: tuple[str, ...] = (
     "microsoft_365",
@@ -15,90 +133,40 @@ _SUPPORTED_NATIVE_VENDORS: tuple[str, ...] = (
     "salesforce",
 )
 
-_VERIFY_METHOD_BY_VENDOR: dict[str, str] = {
-    "microsoft_365": "_verify_microsoft_365",
-    "google_workspace": "_verify_google_workspace",
-    "github": "_verify_github",
-    "slack": "_verify_slack",
-    "zoom": "_verify_zoom",
-    "salesforce": "_verify_salesforce",
+_VERIFY_FN_BY_VENDOR: dict[str, VerifyFn] = {
+    "microsoft_365": vendor_verify_microsoft_365,
+    "google_workspace": vendor_verify_google_workspace,
+    "github": vendor_verify_github,
+    "slack": vendor_verify_slack,
+    "zoom": vendor_verify_zoom,
+    "salesforce": vendor_verify_salesforce,
 }
 
-_REVOKE_METHOD_BY_VENDOR: dict[str, tuple[str, bool]] = {
-    "google_workspace": ("_revoke_google_workspace", True),
-    "microsoft_365": ("_revoke_microsoft_365", True),
-    "github": ("_revoke_github", False),
-    "slack": ("_revoke_slack", False),
-    "zoom": ("_revoke_zoom", False),
-    "salesforce": ("_revoke_salesforce", False),
+_STREAM_FN_BY_VENDOR: dict[str, StreamFn] = {
+    "microsoft_365": vendor_stream_microsoft_365_license_costs,
+    "google_workspace": vendor_stream_google_workspace_license_costs,
 }
 
-_ACTIVITY_METHOD_BY_VENDOR: dict[str, str] = {
-    "google_workspace": "_list_google_workspace_activity",
-    "microsoft_365": "_list_microsoft_365_activity",
-    "github": "_list_github_activity",
-    "slack": "_list_slack_activity",
-    "zoom": "_list_zoom_activity",
-    "salesforce": "_list_salesforce_activity",
+_REVOKE_WITH_SKU_FN_BY_VENDOR: dict[str, RevokeWithSkuFn] = {
+    "google_workspace": vendor_revoke_google_workspace,
+    "microsoft_365": vendor_revoke_microsoft_365,
 }
 
-_STREAM_METHOD_BY_VENDOR: dict[str, str] = {
-    "microsoft_365": "_stream_microsoft_365_license_costs",
-    "google_workspace": "_stream_google_workspace_license_costs",
+_REVOKE_NO_SKU_FN_BY_VENDOR: dict[str, RevokeNoSkuFn] = {
+    "github": vendor_revoke_github,
+    "slack": vendor_revoke_slack,
+    "zoom": vendor_revoke_zoom,
+    "salesforce": vendor_revoke_salesforce,
 }
 
-
-class LicenseNativeDispatchRuntime(Protocol):
-    @property
-    def _vendor(self) -> str: ...
-
-    async def _verify_microsoft_365(self) -> None: ...
-
-    async def _verify_google_workspace(self) -> None: ...
-
-    async def _verify_github(self) -> None: ...
-
-    async def _verify_slack(self) -> None: ...
-
-    async def _verify_zoom(self) -> None: ...
-
-    async def _verify_salesforce(self) -> None: ...
-
-    def _stream_microsoft_365_license_costs(
-        self, start_date: datetime, end_date: datetime
-    ) -> AsyncGenerator[dict[str, Any], None]: ...
-
-    def _stream_google_workspace_license_costs(
-        self, start_date: datetime, end_date: datetime
-    ) -> AsyncGenerator[dict[str, Any], None]: ...
-
-    async def _revoke_google_workspace(
-        self, resource_id: str, sku_id: str | None = None
-    ) -> bool: ...
-
-    async def _revoke_microsoft_365(
-        self, resource_id: str, sku_id: str | None = None
-    ) -> bool: ...
-
-    async def _revoke_github(self, resource_id: str) -> bool: ...
-
-    async def _revoke_slack(self, resource_id: str) -> bool: ...
-
-    async def _revoke_zoom(self, resource_id: str) -> bool: ...
-
-    async def _revoke_salesforce(self, resource_id: str) -> bool: ...
-
-    async def _list_google_workspace_activity(self) -> list[dict[str, Any]]: ...
-
-    async def _list_microsoft_365_activity(self) -> list[dict[str, Any]]: ...
-
-    async def _list_github_activity(self) -> list[dict[str, Any]]: ...
-
-    async def _list_slack_activity(self) -> list[dict[str, Any]]: ...
-
-    async def _list_zoom_activity(self) -> list[dict[str, Any]]: ...
-
-    async def _list_salesforce_activity(self) -> list[dict[str, Any]]: ...
+_ACTIVITY_FN_BY_VENDOR: dict[str, ActivityFn] = {
+    "google_workspace": vendor_list_google_workspace_activity,
+    "microsoft_365": vendor_list_microsoft_365_activity,
+    "github": vendor_list_github_activity,
+    "slack": vendor_list_slack_activity,
+    "zoom": vendor_list_zoom_activity,
+    "salesforce": vendor_list_salesforce_activity,
+}
 
 
 def supported_native_vendors() -> tuple[str, ...]:
@@ -106,50 +174,33 @@ def supported_native_vendors() -> tuple[str, ...]:
 
 
 async def verify_native_vendor(
-    runtime: LicenseNativeDispatchRuntime, native_vendor: str
+    runtime: LicenseVendorRuntime, native_vendor: str
 ) -> None:
-    method_name = _VERIFY_METHOD_BY_VENDOR.get(native_vendor)
-    if method_name is None:
+    verify_fn = _VERIFY_FN_BY_VENDOR.get(native_vendor)
+    if verify_fn is None:
         raise ExternalAPIError(f"Unsupported native license vendor '{native_vendor}'")
-    verify_method = cast(Callable[[], Awaitable[None]], getattr(runtime, method_name))
-    await verify_method()
+    await verify_fn(runtime)
 
 
-def resolve_native_stream_method(
-    runtime: LicenseNativeDispatchRuntime, native_vendor: str
-) -> Callable[[datetime, datetime], AsyncGenerator[dict[str, Any], None]] | None:
-    method_name = _STREAM_METHOD_BY_VENDOR.get(native_vendor)
-    if method_name is None:
-        return None
-    return cast(
-        Callable[[datetime, datetime], AsyncGenerator[dict[str, Any], None]],
-        getattr(runtime, method_name),
-    )
+def resolve_native_stream_method(native_vendor: str) -> StreamFn | None:
+    return _STREAM_FN_BY_VENDOR.get(native_vendor)
 
 
 async def revoke_native_license(
-    runtime: LicenseNativeDispatchRuntime,
+    runtime: LicenseVendorRuntime,
     *,
     native_vendor: str | None,
     resource_id: str,
     sku_id: str | None,
 ) -> bool:
-    revoke_method = (
-        _REVOKE_METHOD_BY_VENDOR.get(native_vendor) if native_vendor is not None else None
-    )
-    if revoke_method is not None:
-        method_name, supports_sku = revoke_method
-        if supports_sku:
-            revoke_with_sku = cast(
-                Callable[[str, str | None], Awaitable[bool]],
-                getattr(runtime, method_name),
-            )
-            return await revoke_with_sku(resource_id, sku_id)
-        revoke_without_sku = cast(
-            Callable[[str], Awaitable[bool]],
-            getattr(runtime, method_name),
-        )
-        return await revoke_without_sku(resource_id)
+    if native_vendor is not None:
+        revoke_with_sku = _REVOKE_WITH_SKU_FN_BY_VENDOR.get(native_vendor)
+        if revoke_with_sku is not None:
+            return await revoke_with_sku(runtime, resource_id, sku_id)
+
+        revoke_no_sku = _REVOKE_NO_SKU_FN_BY_VENDOR.get(native_vendor)
+        if revoke_no_sku is not None:
+            return await revoke_no_sku(runtime, resource_id)
 
     raise UnsupportedVendorError(
         (
@@ -161,13 +212,9 @@ async def revoke_native_license(
 
 
 async def list_native_activity(
-    runtime: LicenseNativeDispatchRuntime, native_vendor: str
+    runtime: LicenseVendorRuntime, native_vendor: str
 ) -> list[dict[str, Any]]:
-    method_name = _ACTIVITY_METHOD_BY_VENDOR.get(native_vendor)
-    if method_name is None:
+    activity_fn = _ACTIVITY_FN_BY_VENDOR.get(native_vendor)
+    if activity_fn is None:
         return []
-    activity_method = cast(
-        Callable[[], Awaitable[list[dict[str, Any]]]],
-        getattr(runtime, method_name),
-    )
-    return await activity_method()
+    return await activity_fn(runtime)

--- a/tests/unit/services/adapters/test_adapter_helper_branches.py
+++ b/tests/unit/services/adapters/test_adapter_helper_branches.py
@@ -133,6 +133,20 @@ def test_platform_native_vendor_alias_mapping(
     assert adapter._native_vendor == expected
 
 
+def test_platform_native_handler_resolution_maps_supported_vendors() -> None:
+    adapter = PlatformAdapter(_platform_conn(auth_method="api_key", vendor="ledger"))
+    assert adapter._resolve_native_verify_handler("ledger_http") is not None
+    assert adapter._resolve_native_stream_handler("ledger_http") is not None
+    assert adapter._resolve_native_verify_handler("datadog") is not None
+    assert adapter._resolve_native_stream_handler("datadog") is not None
+    assert adapter._resolve_native_verify_handler("newrelic") is not None
+    assert adapter._resolve_native_stream_handler("newrelic") is not None
+    assert adapter._resolve_native_verify_handler("unknown") is None
+    assert adapter._resolve_native_stream_handler("unknown") is None
+    assert adapter._resolve_native_verify_handler(None) is None
+    assert adapter._resolve_native_stream_handler(None) is None
+
+
 def test_platform_helper_resolvers_cover_key_branches() -> None:
     adapter = PlatformAdapter(
         _platform_conn(
@@ -308,6 +322,20 @@ def test_hybrid_native_vendor_alias_mapping(
 ) -> None:
     adapter = HybridAdapter(_hybrid_conn(auth_method=auth_method, vendor=vendor))
     assert adapter._native_vendor == expected
+
+
+def test_hybrid_native_handler_resolution_maps_supported_vendors() -> None:
+    adapter = HybridAdapter(_hybrid_conn(auth_method="api_key", vendor="ledger"))
+    assert adapter._resolve_native_verify_handler("ledger_http") is not None
+    assert adapter._resolve_native_stream_handler("ledger_http") is not None
+    assert adapter._resolve_native_verify_handler("cloudkitty") is not None
+    assert adapter._resolve_native_stream_handler("cloudkitty") is not None
+    assert adapter._resolve_native_verify_handler("vmware") is not None
+    assert adapter._resolve_native_stream_handler("vmware") is not None
+    assert adapter._resolve_native_verify_handler("unknown") is None
+    assert adapter._resolve_native_stream_handler("unknown") is None
+    assert adapter._resolve_native_verify_handler(None) is None
+    assert adapter._resolve_native_stream_handler(None) is None
 
 
 def test_hybrid_helper_resolvers_cover_url_ssl_and_pricing_branches() -> None:

--- a/tests/unit/shared/adapters/test_license_native_dispatch.py
+++ b/tests/unit/shared/adapters/test_license_native_dispatch.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
-from collections.abc import AsyncGenerator
 from datetime import datetime
-from typing import Any
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
+import app.shared.adapters.license_native_dispatch as native_dispatch
 from app.shared.adapters.license_native_dispatch import (
     list_native_activity,
     resolve_native_stream_method,
@@ -18,103 +17,100 @@ from app.shared.core.exceptions import ExternalAPIError, UnsupportedVendorError
 
 
 class _Runtime:
-    def __init__(self) -> None:
-        self._vendor = "custom_vendor"
+    def __init__(self, vendor: str = "custom_vendor") -> None:
+        self._vendor = vendor
+        self._connector_config: dict[str, object] = {}
 
-        self._verify_microsoft_365 = AsyncMock()
-        self._verify_google_workspace = AsyncMock()
-        self._verify_github = AsyncMock()
-        self._verify_slack = AsyncMock()
-        self._verify_zoom = AsyncMock()
-        self._verify_salesforce = AsyncMock()
+    def _resolve_api_key(self) -> str:
+        return "token"
 
-        self._revoke_google_workspace = AsyncMock(return_value=True)
-        self._revoke_microsoft_365 = AsyncMock(return_value=True)
-        self._revoke_github = AsyncMock(return_value=True)
-        self._revoke_slack = AsyncMock(return_value=True)
-        self._revoke_zoom = AsyncMock(return_value=True)
-        self._revoke_salesforce = AsyncMock(return_value=True)
+    async def _get_json(
+        self,
+        url: str,
+        *,
+        headers: dict[str, str],
+        params: dict[str, object] | None = None,
+    ) -> dict[str, object]:
+        _ = url, headers, params
+        return {}
 
-        self._list_google_workspace_activity = AsyncMock(return_value=[{"vendor": "google_workspace"}])
-        self._list_microsoft_365_activity = AsyncMock(return_value=[{"vendor": "microsoft_365"}])
-        self._list_github_activity = AsyncMock(return_value=[{"vendor": "github"}])
-        self._list_slack_activity = AsyncMock(return_value=[{"vendor": "slack"}])
-        self._list_zoom_activity = AsyncMock(return_value=[{"vendor": "zoom"}])
-        self._list_salesforce_activity = AsyncMock(return_value=[{"vendor": "salesforce"}])
-
-    async def _stream_google_workspace_license_costs(
-        self, start_date: datetime, end_date: datetime
-    ) -> AsyncGenerator[dict[str, Any], None]:
-        _ = (start_date, end_date)
-        yield {"vendor": "google_workspace"}
-
-    async def _stream_microsoft_365_license_costs(
-        self, start_date: datetime, end_date: datetime
-    ) -> AsyncGenerator[dict[str, Any], None]:
-        _ = (start_date, end_date)
-        yield {"vendor": "microsoft_365"}
+    def _salesforce_instance_url(self) -> str:
+        return "https://example.my.salesforce.com"
 
 
 @pytest.mark.asyncio
 async def test_verify_native_vendor_dispatches_and_rejects_unknown_vendor() -> None:
     runtime = _Runtime()
+    verify_m365 = AsyncMock(return_value=None)
+    verify_google = AsyncMock(return_value=None)
+    verify_github = AsyncMock(return_value=None)
 
-    await verify_native_vendor(runtime, "microsoft_365")
-    await verify_native_vendor(runtime, "google_workspace")
-    await verify_native_vendor(runtime, "github")
+    with patch.dict(
+        native_dispatch._VERIFY_FN_BY_VENDOR,
+        {
+            "microsoft_365": verify_m365,
+            "google_workspace": verify_google,
+            "github": verify_github,
+        },
+        clear=False,
+    ):
+        await verify_native_vendor(runtime, "microsoft_365")
+        await verify_native_vendor(runtime, "google_workspace")
+        await verify_native_vendor(runtime, "github")
 
-    runtime._verify_microsoft_365.assert_awaited_once()
-    runtime._verify_google_workspace.assert_awaited_once()
-    runtime._verify_github.assert_awaited_once()
+    verify_m365.assert_awaited_once_with(runtime)
+    verify_google.assert_awaited_once_with(runtime)
+    verify_github.assert_awaited_once_with(runtime)
 
     with pytest.raises(ExternalAPIError, match="Unsupported native license vendor"):
         await verify_native_vendor(runtime, "unknown_vendor")
 
 
-@pytest.mark.asyncio
-async def test_resolve_native_stream_method_returns_known_handlers_only() -> None:
-    runtime = _Runtime()
+def test_resolve_native_stream_method_returns_known_handlers_only() -> None:
+    m365_stream = resolve_native_stream_method("microsoft_365")
+    google_stream = resolve_native_stream_method("google_workspace")
 
-    m365_stream = resolve_native_stream_method(runtime, "microsoft_365")
-    google_stream = resolve_native_stream_method(runtime, "google_workspace")
-
-    assert m365_stream is not None
-    assert google_stream is not None
-    m365_rows = [
-        row
-        async for row in m365_stream(datetime(2026, 1, 1), datetime(2026, 1, 31))
-    ]
-    google_rows = [
-        row
-        async for row in google_stream(datetime(2026, 1, 1), datetime(2026, 1, 31))
-    ]
-    assert m365_rows == [{"vendor": "microsoft_365"}]
-    assert google_rows == [{"vendor": "google_workspace"}]
-    assert resolve_native_stream_method(runtime, "slack") is None
-    assert resolve_native_stream_method(runtime, "unknown_vendor") is None
+    assert m365_stream is native_dispatch.vendor_stream_microsoft_365_license_costs
+    assert google_stream is native_dispatch.vendor_stream_google_workspace_license_costs
+    assert resolve_native_stream_method("slack") is None
+    assert resolve_native_stream_method("unknown_vendor") is None
 
 
 @pytest.mark.asyncio
 async def test_revoke_native_license_dispatches_sku_and_non_sku_paths() -> None:
     runtime = _Runtime()
+    revoke_with_sku = AsyncMock(return_value=True)
+    revoke_no_sku = AsyncMock(return_value=True)
 
-    result_google = await revoke_native_license(
-        runtime,
-        native_vendor="google_workspace",
-        resource_id="user-1",
-        sku_id="sku-1",
-    )
-    result_github = await revoke_native_license(
-        runtime,
-        native_vendor="github",
-        resource_id="user-2",
-        sku_id="ignored",
-    )
+    with (
+        patch.dict(
+            native_dispatch._REVOKE_WITH_SKU_FN_BY_VENDOR,
+            {"google_workspace": revoke_with_sku},
+            clear=False,
+        ),
+        patch.dict(
+            native_dispatch._REVOKE_NO_SKU_FN_BY_VENDOR,
+            {"github": revoke_no_sku},
+            clear=False,
+        ),
+    ):
+        result_google = await revoke_native_license(
+            runtime,
+            native_vendor="google_workspace",
+            resource_id="user-1",
+            sku_id="sku-1",
+        )
+        result_github = await revoke_native_license(
+            runtime,
+            native_vendor="github",
+            resource_id="user-2",
+            sku_id="ignored",
+        )
 
     assert result_google is True
     assert result_github is True
-    runtime._revoke_google_workspace.assert_awaited_once_with("user-1", "sku-1")
-    runtime._revoke_github.assert_awaited_once_with("user-2")
+    revoke_with_sku.assert_awaited_once_with(runtime, "user-1", "sku-1")
+    revoke_no_sku.assert_awaited_once_with(runtime, "user-2")
 
 
 @pytest.mark.asyncio
@@ -133,13 +129,19 @@ async def test_revoke_native_license_raises_for_unsupported_vendor() -> None:
 @pytest.mark.asyncio
 async def test_list_native_activity_dispatches_known_and_returns_empty_for_unknown() -> None:
     runtime = _Runtime()
+    list_slack = AsyncMock(return_value=[{"vendor": "slack"}])
 
-    rows = await list_native_activity(runtime, "slack")
+    with patch.dict(
+        native_dispatch._ACTIVITY_FN_BY_VENDOR,
+        {"slack": list_slack},
+        clear=False,
+    ):
+        rows = await list_native_activity(runtime, "slack")
     unknown_rows = await list_native_activity(runtime, "unknown_vendor")
 
     assert rows == [{"vendor": "slack"}]
     assert unknown_rows == []
-    runtime._list_slack_activity.assert_awaited_once()
+    list_slack.assert_awaited_once_with(runtime)
 
 
 def test_supported_native_vendors_is_stable() -> None:
@@ -151,3 +153,9 @@ def test_supported_native_vendors_is_stable() -> None:
         "zoom",
         "salesforce",
     )
+
+
+def test_stream_method_signature_accepts_runtime_and_dates() -> None:
+    stream_fn = resolve_native_stream_method("microsoft_365")
+    assert stream_fn is not None
+    _ = stream_fn(_Runtime(), datetime(2026, 1, 1), datetime(2026, 1, 31))

--- a/tests/unit/shared/adapters/test_resource_usage_projection.py
+++ b/tests/unit/shared/adapters/test_resource_usage_projection.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from app.shared.adapters.resource_usage_projection import (
+    discover_resources_from_cost_rows,
+)
+
+
+def test_discover_resources_from_cost_rows_rejects_unsupported_resource_type() -> None:
+    rows = [
+        {
+            "timestamp": "2026-01-10T00:00:00Z",
+            "service": "Example",
+            "resource_id": "res-1",
+            "cost_usd": 1.0,
+        }
+    ]
+    discovered = discover_resources_from_cost_rows(
+        cost_rows=rows,
+        resource_type="unsupported",
+        supported_resource_types={"all", "saas"},
+        default_provider="saas",
+        default_resource_type="saas_subscription",
+    )
+    assert discovered == []
+
+
+def test_discover_resources_from_cost_rows_aggregates_and_filters_region() -> None:
+    rows = [
+        {
+            "timestamp": datetime(2026, 1, 10, tzinfo=timezone.utc),
+            "provider": "saas",
+            "service": "GitHub",
+            "resource_id": "seat-1",
+            "usage_type": "subscription",
+            "cost_usd": 4.0,
+            "region": "us-east-1",
+            "source_adapter": "saas_feed",
+        },
+        {
+            "timestamp": "2026-01-11T00:00:00Z",
+            "provider": "saas",
+            "service": "GitHub",
+            "resource_id": "seat-1",
+            "usage_type": "subscription",
+            "cost_usd": 6.0,
+            "region": "us-east-1",
+            "source_adapter": "saas_feed",
+        },
+        {
+            "timestamp": "2026-01-09T00:00:00Z",
+            "provider": "saas",
+            "service": "GitHub",
+            "resource_id": "seat-2",
+            "usage_type": "subscription",
+            "cost_usd": 1.5,
+            "region": "eu-west-1",
+            "source_adapter": "saas_feed",
+        },
+    ]
+
+    discovered = discover_resources_from_cost_rows(
+        cost_rows=rows,
+        resource_type="saas",
+        supported_resource_types={"all", "saas"},
+        default_provider="saas",
+        default_resource_type="saas_subscription",
+        region="us-east-1",
+    )
+
+    assert len(discovered) == 1
+    assert discovered[0]["id"] == "seat-1"
+    assert discovered[0]["provider"] == "saas"
+    assert discovered[0]["type"] == "saas_subscription"
+    assert discovered[0]["region"] == "us-east-1"
+    assert discovered[0]["metadata"]["record_count"] == 2
+    assert discovered[0]["metadata"]["total_cost_usd"] == pytest.approx(10.0)
+    assert discovered[0]["metadata"]["last_seen_at"] == "2026-01-11T00:00:00+00:00"

--- a/tests/unit/shared/adapters/test_saas_adapter_branch_paths.py
+++ b/tests/unit/shared/adapters/test_saas_adapter_branch_paths.py
@@ -127,6 +127,20 @@ def test_saas_resolve_api_key_missing_and_blank() -> None:
         blank._resolve_api_key()
 
 
+def test_saas_native_handler_resolution_maps_supported_vendors() -> None:
+    adapter = SaaSAdapter(
+        _saas_credentials(platform="stripe", auth_method="api_key", api_key="sk_live")
+    )
+    assert adapter._resolve_native_verify_handler("stripe") is not None
+    assert adapter._resolve_native_stream_handler("stripe") is not None
+    assert adapter._resolve_native_verify_handler("salesforce") is not None
+    assert adapter._resolve_native_stream_handler("salesforce") is not None
+    assert adapter._resolve_native_verify_handler("unknown") is None
+    assert adapter._resolve_native_stream_handler("unknown") is None
+    assert adapter._resolve_native_verify_handler(None) is None
+    assert adapter._resolve_native_stream_handler(None) is None
+
+
 @pytest.mark.asyncio
 async def test_saas_verify_connection_manual_valid_and_generic_error_message_branch() -> None:
     valid = SaaSAdapter(


### PR DESCRIPTION
## Summary
- harden Cloud+ adapter behavior across AWS CUR/multitenant, Azure, GCP, SaaS, Platform, Hybrid
- unify resource discovery and resource-usage projection semantics
- modernize license native dispatch integration path
- extend adapter-focused unit coverage including new `resource_usage_projection` tests

## Linked issue
- Closes #192

## Validation
- `uv run ruff check` on touched adapter/test files
- `uv run mypy app/shared/adapters/aws_cur.py app/shared/adapters/aws_multitenant.py app/shared/adapters/azure.py app/shared/adapters/gcp.py app/shared/adapters/hybrid.py app/shared/adapters/license.py app/shared/adapters/license_native_dispatch.py app/shared/adapters/platform.py app/shared/adapters/resource_usage_projection.py app/shared/adapters/saas.py --hide-error-context --no-error-summary`
- `DEBUG=false uv run pytest -q --no-cov tests/unit/services/adapters/test_adapter_helper_branches.py tests/unit/services/adapters/test_cloud_plus_adapters.py tests/unit/services/adapters/test_license_activity_and_revoke.py tests/unit/services/adapters/test_license_verification_stream_branches.py tests/unit/shared/adapters/test_aws_cur.py tests/unit/shared/adapters/test_aws_multitenant_branch_paths.py tests/unit/shared/adapters/test_azure_adapter.py tests/unit/shared/adapters/test_gcp_adapter.py tests/unit/shared/adapters/test_license_native_dispatch.py tests/unit/shared/adapters/test_saas_adapter_branch_paths.py tests/unit/shared/adapters/test_resource_usage_projection.py`
  - result: `210 passed`
