### PR TITLE
docs: rename product branding to Valdrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <p align="center">
-  <img src="assets/valdrix_icon.png" alt="Valdrix" width="200" />
+  <img src="assets/valdrix_icon.png" alt="Valdrics" width="200" />
 </p>
 
-<h1 align="center">Valdrix</h1>
+<h1 align="center">Valdrics</h1>
 <h3 align="center">Optimize Cloud Value, Not Just Cost</h3>
 
 <p align="center">
@@ -52,7 +52,7 @@ Graphs give you... more questions.
 
 ## 🛡️ The Solution
 
-**Valdrix transforms raw cost data into actionable value intelligence.**
+**Valdrics transforms raw cost data into actionable value intelligence.**
 
 It connects to your cloud, uncovers waste, explains spend behavior, and gives you *exactly* what to do—with receipts.
 
@@ -68,7 +68,7 @@ It connects to your cloud, uncovers waste, explains spend behavior, and gives yo
 4. **Act** → Get Slack alerts, approve remediations, and watch your bill shrink.
 
 > [!TIP]
-> **Zero API Costs for Your AWS Account**: Valdrix uses [AWS CUR](https://docs.aws.amazon.com/cur/latest/userguide/what-is-cur.html) and [Resource Explorer 2](https://docs.aws.amazon.com/resource-explorer/latest/userguide/welcome.html) instead of expensive APIs like Cost Explorer ($0.01/request). Your AWS bill from Valdrix scans is **~$0.00/month**.
+> **Zero API Costs for Your AWS Account**: Valdrics uses [AWS CUR](https://docs.aws.amazon.com/cur/latest/userguide/what-is-cur.html) and [Resource Explorer 2](https://docs.aws.amazon.com/resource-explorer/latest/userguide/welcome.html) instead of expensive APIs like Cost Explorer ($0.01/request). Your AWS bill from Valdrics scans is **~$0.00/month**.
 
 
 ```
@@ -77,7 +77,7 @@ It connects to your cloud, uncovers waste, explains spend behavior, and gives yo
               └────────┬─────────┘
                        ▼
               ┌──────────────────┐
-              │  🔌 Valdrix Core │
+              │  🔌 Valdrics Core │
               │    (FastAPI)     │
               └────────┬─────────┘
                        ▼
@@ -121,7 +121,7 @@ Not just "idle EC2." We find *everything*:
 
 Other tools use static rules: *"CPU < 10% for 7 days = zombie."*
 
-Valdrix asks: *"Why did RDS costs spike 47% on Tuesday?"*  
+Valdrics asks: *"Why did RDS costs spike 47% on Tuesday?"*  
 And answers: *"Because Staging-DB-04 was left running after the load test. Estimated waste: $312/month."*
 
 **Powered by your choice of:**
@@ -136,7 +136,7 @@ And answers: *"Because Staging-DB-04 was left running after the load test. Estim
 
 ### 🌿 **GreenOps Native**
 
-Every wasted dollar has a carbon cost. Valdrix calculates it.
+Every wasted dollar has a carbon cost. Valdrics calculates it.
 
 ```
 Total CO₂ this month:      42.7 kg
@@ -151,7 +151,7 @@ Carbon efficiency:         89 gCO₂e per $1 spent
 
 ### 🔔 **Slack-First Alerts**
 
-Your engineering team lives in Slack. So does Valdrix.
+Your engineering team lives in Slack. So does Valdrics.
 
 - **Anomaly alerts** when costs spike unexpectedly
 - **Daily digests** with top savings opportunities
@@ -192,7 +192,7 @@ We're paranoid, so you don't have to be:
 - An AWS account with:
   - AWS CUR configured to deliver Parquet reports to S3
   - Resource Explorer 2 enabled
-- Cost Explorer is optional (Valdrix ingestion path is CUR + Resource Explorer 2)
+- Cost Explorer is optional (Valdrics ingestion path is CUR + Resource Explorer 2)
 - An LLM API key (OpenAI, Anthropic, Google, or Groq)
 
 ### Runtime Dependency Policy (Prod/Staging)
@@ -252,7 +252,7 @@ The dashboard will guide you through deploying our read-only IAM role via CloudF
 
 ## 🏗️ Production Infrastructure
 
-Valdrix includes production-ready infrastructure components:
+Valdrics includes production-ready infrastructure components:
 
 ### Kubernetes Deployment
 ```bash
@@ -313,10 +313,10 @@ We're in **active development**. Here's where we are:
 
 ## 📜 License
 
-Valdrix is **source available** under the **Business Source License (BSL) 1.1**.
+Valdrics is **source available** under the **Business Source License (BSL) 1.1**.
 
 - ✅ **Free for internal use** — Run it on your own infrastructure.
-- ❌ **No resale** — Cannot offer Valdrix as a managed service.
+- ❌ **No resale** — Cannot offer Valdrics as a managed service.
 - 🗓️ **Freedom date:** Converts to **Apache 2.0** on **January 12, 2029**.
 
 See [LICENSE](LICENSE) for full terms.
@@ -342,7 +342,7 @@ We welcome contributions! Please read our [CONTRIBUTING.md](CONTRIBUTING.md) bef
 
 ## 💖 Support
 
-If Valdrix saved your team $1,000 this month, consider sponsoring the project:
+If Valdrics saved your team $1,000 this month, consider sponsoring the project:
 
 <p align="center">
   <a href="https://github.com/sponsors/AbdulGoniyyDare">

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -1,6 +1,6 @@
-# Valdrix Dashboard Frontend
+# Valdrics Dashboard Frontend
 
-SvelteKit frontend for Valdrix.
+SvelteKit frontend for Valdrics.
 
 ## Commands
 

--- a/docs/CAPACITY_PLAN.md
+++ b/docs/CAPACITY_PLAN.md
@@ -1,4 +1,4 @@
-# Valdrix Capacity Plan (2026)
+# Valdrics Capacity Plan (2026)
 
 This plan outlines the infrastructure targets for scaling the platform.
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,8 +1,8 @@
-# Valdrix Deployment Guide (Cloudflare Pages + Koyeb + Supabase)
+# Valdrics Deployment Guide (Cloudflare Pages + Koyeb + Supabase)
 
 Last verified: **2026-02-18**
 
-This guide defines the current production path for Valdrix:
+This guide defines the current production path for Valdrics:
 - Frontend: Cloudflare Pages (SvelteKit + Cloudflare adapter)
 - API: Koyeb (FastAPI)
 - Data/Auth: Supabase (PostgreSQL + Auth)

--- a/docs/DEPRECATION_POLICY.md
+++ b/docs/DEPRECATION_POLICY.md
@@ -1,6 +1,6 @@
-# Valdrix Deprecation & Versioning Policy
+# Valdrics Deprecation & Versioning Policy
 
-To ensure high reliability for enterprise customers, Valdrix follows strict version lifecycles.
+To ensure high reliability for enterprise customers, Valdrics follows strict version lifecycles.
 
 ## 1. API Versioning
 - **Structure**: `/api/v[N]/` (e.g., `/api/v1/`).

--- a/docs/ROLLBACK_PLAN.md
+++ b/docs/ROLLBACK_PLAN.md
@@ -1,4 +1,4 @@
-# Valdrix Rollback & Disaster Recovery Plan
+# Valdrics Rollback & Disaster Recovery Plan
 
 Procedures for reverting changes in case of deployment failure.
 

--- a/docs/SOC2_CONTROLS.md
+++ b/docs/SOC2_CONTROLS.md
@@ -2,10 +2,10 @@
 
 ## Overview
 
-This document maps Valdrix security controls to SOC 2 Trust Service Criteria.
+This document maps Valdrics security controls to SOC 2 Trust Service Criteria.
 Use this as the foundation for SOC 2 Type 1 audit preparation.
 
-**Organization:** Valdrix AI  
+**Organization:** Valdrics AI  
 **Audit Scope:** Cloud FinOps Platform  
 **Document Version:** 1.0  
 **Last Updated:** 2026-01-14
@@ -161,7 +161,7 @@ Use this as the foundation for SOC 2 Type 1 audit preparation.
 
 ## Compliance Statement
 
-Valdrix AI maintains a security-first approach to software development. 
+Valdrics AI maintains a security-first approach to software development. 
 Our controls are designed to protect customer data and ensure service reliability.
 We leverage SOC 2 certified infrastructure providers (Supabase, AWS, Koyeb) 
 and implement application-level controls as documented above.

--- a/docs/architecture/ADR-0001-tenancy-model.md
+++ b/docs/architecture/ADR-0001-tenancy-model.md
@@ -6,7 +6,7 @@
 
 ## Context
 
-Valdrix is SaaS-first and must support enterprise tenant isolation, predictable cost scaling, and compliance evidence. A tenancy decision made late is expensive to reverse.
+Valdrics is SaaS-first and must support enterprise tenant isolation, predictable cost scaling, and compliance evidence. A tenancy decision made late is expensive to reverse.
 
 ## Decision
 

--- a/docs/architecture/ADR-0002-dashboard-modernization-2026.md
+++ b/docs/architecture/ADR-0002-dashboard-modernization-2026.md
@@ -6,7 +6,7 @@
 
 ## Context
 
-The Valdrix dashboard is a core product surface and must meet modern expectations for:
+The Valdrics dashboard is a core product surface and must meet modern expectations for:
 
 - performance (fast navigations, predictable budgets, good Core Web Vitals)
 - security (strong headers/CSP, safe auth/session handling, dependency auditing)

--- a/docs/architecture/failover.md
+++ b/docs/architecture/failover.md
@@ -2,7 +2,7 @@
 # Multi-Region Failover Architecture
 
 ## 1. Strategy
-Valdrix uses an **Active-Passive** multi-region strategy for high availability.
+Valdrics uses an **Active-Passive** multi-region strategy for high availability.
 
 ## 2. Components
 - **Primary Region**: AWS `us-east-1`.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,9 +1,9 @@
-# Valdrix Enterprise Architecture
+# Valdrics Enterprise Architecture
 > **Elite SaaS Standard: Domain-Driven Modular Monolith**
 
 ## 🏛️ Architectural Philosophy
 
-Valdrix is engineered as a **Modular Monolith** following **Domain-Driven Design (DDD)** and **Hexagonal (Ports & Adapters)** principles. This ensures the platform remains scalable, testable, and maintainable as it evolves from a single-cloud utility to a multi-cloud enterprise platform.
+Valdrics is engineered as a **Modular Monolith** following **Domain-Driven Design (DDD)** and **Hexagonal (Ports & Adapters)** principles. This ensures the platform remains scalable, testable, and maintainable as it evolves from a single-cloud utility to a multi-cloud enterprise platform.
 
 ### Key Pillars
 1.  **Modular Isolation**: Every business capability (Governance, Optimization, Reporting) is isolated into its own module.
@@ -91,15 +91,15 @@ Aggregates raw statistics into actionable business intelligence.
 
 ## 🔐 Security & Multi-Tenancy
 
-- **Identity Isolation**: Valdrix utilizes **Supabase Auth** with strict **Row Level Security (RLS)** in the database.
-- **Cloud Security**: No persistent AWS keys stored. Valdrix uses **AWS STS (AssumeRole)** to generate ephemeral, single-use credentials for every scan operation.
+- **Identity Isolation**: Valdrics utilizes **Supabase Auth** with strict **Row Level Security (RLS)** in the database.
+- **Cloud Security**: No persistent AWS keys stored. Valdrics uses **AWS STS (AssumeRole)** to generate ephemeral, single-use credentials for every scan operation.
 - **Data Protection**: Sensitive cloud configuration data is encrypted at rest using **AES-256**.
 
 ---
 
 ## 💰 Low-Incremental-API-Cost Architecture
 
-Valdrix is designed to minimize incremental cloud API costs billed to the customer's account while preserving scan coverage.
+Valdrics is designed to minimize incremental cloud API costs billed to the customer's account while preserving scan coverage.
 
 ### Data Sources (Customer Cost Profile)
 
@@ -125,7 +125,7 @@ Valdrix is designed to minimize incremental cloud API costs billed to the custom
 
 ## ☸️ Kubernetes Deployment
 
-Valdrix is production-ready with Kubernetes manifests in `k8s/`:
+Valdrics is production-ready with Kubernetes manifests in `k8s/`:
 
 | Manifest | Purpose |
 |---|---|
@@ -150,7 +150,7 @@ kubectl apply -f k8s/
 
 ## 🧪 Load Testing
 
-Valdrix includes comprehensive load testing tools in `loadtest/`:
+Valdrics includes comprehensive load testing tools in `loadtest/`:
 
 | Tool | File | Use Case |
 |---|---|---|
@@ -178,7 +178,7 @@ locust -f loadtest/locustfile.py --host=http://localhost:8000
 
 ## 📋 Compliance & SBOM
 
-Valdrix generates Software Bill of Materials (SBOM) for supply chain security.
+Valdrics generates Software Bill of Materials (SBOM) for supply chain security.
 
 ### Automated Generation
 - **GitHub Action**: `.github/workflows/sbom.yml`
@@ -196,9 +196,9 @@ Generated SBOMs are stored in `sbom/` and include:
 - SOC 2 Type II audit logging
 - GDPR-ready data isolation (RLS)
 - Executive Order 14028 SBOM requirements
-# Valdrix Architecture
+# Valdrics Architecture
 
-This document provides a visual overview of the Valdrix system architecture.
+This document provides a visual overview of the Valdrics system architecture.
 
 ## System Overview
 
@@ -312,7 +312,7 @@ flowchart LR
         BRUTE[Brute-force regional polling]
     end
 
-    subgraph "Valdrix (Cost-Sensitive)"
+    subgraph "Valdrics (Cost-Sensitive)"
         CUR[AWS CUR Export<br/>Primary cost source]
         RE[Resource Explorer + Describe/List<br/>Discovery path]
         CWF[Selective CloudWatch fallback<br/>Only when needed]

--- a/docs/compliance/compliance_pack.md
+++ b/docs/compliance/compliance_pack.md
@@ -1,6 +1,6 @@
 # Compliance Pack (Procurement / Audit Bundle)
 
-Valdrix provides a tenant-scoped **compliance pack ZIP** that bundles:
+Valdrics provides a tenant-scoped **compliance pack ZIP** that bundles:
 
 - An audit log export
 - Redacted tenant configuration snapshots (no secrets)

--- a/docs/compliance/focus_export.md
+++ b/docs/compliance/focus_export.md
@@ -1,8 +1,8 @@
 # FOCUS Export (v1.3 Core CSV)
 
-Valdrix supports a **FOCUS v1.3-aligned core export** for cost records in the tenant ledger.
+Valdrics supports a **FOCUS v1.3-aligned core export** for cost records in the tenant ledger.
 
-This export is intentionally scoped to the FOCUS columns that Valdrix can derive deterministically
+This export is intentionally scoped to the FOCUS columns that Valdrics can derive deterministically
 from the normalized cost ledger today, without claiming SKU or unit-price conformance for fields
 we do not persist yet.
 
@@ -58,7 +58,7 @@ The export includes the following columns:
 
 ## Known Limitations (By Design for v1)
 
-- SKU/unit price columns are not included yet (Valdrix does not persist those fields in the ledger today).
+- SKU/unit price columns are not included yet (Valdrics does not persist those fields in the ledger today).
 - ServiceSubcategory is currently exported as `Other (ServiceCategory)` until per-provider subcategory
   normalization is added.
 

--- a/docs/guides/aws_scp_setup.md
+++ b/docs/guides/aws_scp_setup.md
@@ -1,12 +1,12 @@
 # AWS SCP Deployment Guide
 
 ## Overview
-Service Control Policies (SCPs) provide central control over the maximum available permissions for all accounts in an organization. This guide explains how to use SCPs to protect Valdrix integrations.
+Service Control Policies (SCPs) provide central control over the maximum available permissions for all accounts in an organization. This guide explains how to use SCPs to protect Valdrics integrations.
 
 ## Recommended SCPs
 
-### 1. Protect Valdrix IAM Role
-This SCP prevents any user (including the root user) from deleting or modifying the Valdrix cross-account role.
+### 1. Protect Valdrics IAM Role
+This SCP prevents any user (including the root user) from deleting or modifying the Valdrics cross-account role.
 
 ```json
 {
@@ -31,7 +31,7 @@ This SCP prevents any user (including the root user) from deleting or modifying 
 ```
 
 ### 2. Restrict Remediation Regions
-Limit the regions where Valdrix (or any entity) can perform destructive actions.
+Limit the regions where Valdrics (or any entity) can perform destructive actions.
 
 ## Deployment Steps
 1. Login to the AWS Organizations management account.

--- a/docs/incident_response_plan.md
+++ b/docs/incident_response_plan.md
@@ -4,7 +4,7 @@
 **Status:** Active  
 
 ## 1. Introduction
-This plan outlines the steps for identifying, responding to, and recovering from security incidents within the Valdrix platform.
+This plan outlines the steps for identifying, responding to, and recovering from security incidents within the Valdrics platform.
 
 ## 2. Severity Levels
 - **P0 (Critical)**: Data breach, full system outage, or compromise of cloud credentials.

--- a/docs/integrations/idp_reference_configs.md
+++ b/docs/integrations/idp_reference_configs.md
@@ -1,14 +1,14 @@
 # IdP Reference Configs (SCIM + SSO Enforcement)
 
-This doc provides **reference configuration values** for common IdPs when integrating with Valdrix.
+This doc provides **reference configuration values** for common IdPs when integrating with Valdrics.
 
-Goal: reduce “tribal knowledge” during enterprise onboarding by documenting the **exact fields** Valdrix expects.
+Goal: reduce “tribal knowledge” during enterprise onboarding by documenting the **exact fields** Valdrics expects.
 
 Note: IdP admin UIs change often. This guide focuses on stable inputs (URLs, auth, attribute mappings) rather than click-path screenshots.
 
 ## SCIM (Enterprise)
 
-### Valdrix SCIM Base URL
+### Valdrics SCIM Base URL
 
 Your SCIM base URL is:
 
@@ -25,7 +25,7 @@ Generate the tenant SCIM token:
 
 ### Required User Attributes (Minimum)
 
-Valdrix requires:
+Valdrics requires:
 
 - `userName` (email)
 
@@ -36,7 +36,7 @@ Recommended:
 
 ### Group Mappings (Recommended)
 
-In Valdrix:
+In Valdrics:
 
 - `Settings -> Identity -> SCIM group mappings`
 - Map IdP group name -> `role` (`admin|member`) and optional default `persona`
@@ -64,14 +64,14 @@ Attribute mapping guidance:
 
 If you use groups:
 
-- Ensure groups are pushed and names match the Valdrix SCIM group mappings (case-insensitive).
+- Ensure groups are pushed and names match the Valdrics SCIM group mappings (case-insensitive).
 
 ## Microsoft Entra ID (Azure AD) (SCIM)
 
 Reference values (Provisioning):
 
 - Tenant URL: `https://<your-valdrix-host>/scim/v2`
-- Secret token: `<SCIM_TOKEN>` (Valdrix tenant SCIM token)
+- Secret token: `<SCIM_TOKEN>` (Valdrics tenant SCIM token)
 
 Recommended provisioning scope:
 
@@ -93,24 +93,24 @@ Google-native admin tooling often does not expose a generic SCIM app-provisionin
 Recommended production pattern:
 
 - Keep Google Workspace/Cloud Identity as source directory.
-- Use an IdP/broker layer that supports generic SCIM push to Valdrix (for example Okta Workforce Identity, Entra ID, or a directory broker).
+- Use an IdP/broker layer that supports generic SCIM push to Valdrics (for example Okta Workforce Identity, Entra ID, or a directory broker).
 
 Reference values (via broker):
 
 - SCIM connector base URL: `https://<your-valdrix-host>/scim/v2`
 - Auth mode: `Authorization: Bearer <SCIM_TOKEN>`
 - Unique identifier: `userName` (email)
-- Group mapping: broker group names should match Valdrix SCIM group mappings.
+- Group mapping: broker group names should match Valdrics SCIM group mappings.
 
 Operational guidance:
 
 - Run `scripts/smoke_test_scim_idp.py` in staging before production cutover.
-- Enable group sync after role/persona mappings are configured in Valdrix.
+- Enable group sync after role/persona mappings are configured in Valdrics.
 - Rotate SCIM token after onboarding and store it in your secret manager.
 
 ## SSO Federation + Enforcement (Pro+)
 
-Valdrix supports:
+Valdrics supports:
 - federated login bootstrap (`domain` or `provider_id` mode via Supabase SSO),
 - plus email-domain allowlist enforcement.
 
@@ -120,7 +120,7 @@ Reference values:
 - Federation mode:
   - `domain` (recommended) when your IdP is configured in Supabase for domain discovery
   - `provider_id` when you need explicit provider routing
-- Guardrail: Valdrix prevents lockout by requiring current admin domain in allowlist when enabling enforcement.
+- Guardrail: Valdrics prevents lockout by requiring current admin domain in allowlist when enabling enforcement.
 
 See:
 

--- a/docs/integrations/microsoft_teams.md
+++ b/docs/integrations/microsoft_teams.md
@@ -1,6 +1,6 @@
 # Microsoft Teams Integration (Pro+)
 
-Valdrix supports tenant-scoped Microsoft Teams notifications using incoming webhook URLs.
+Valdrics supports tenant-scoped Microsoft Teams notifications using incoming webhook URLs.
 
 ## Availability
 - Tier: **Pro**, **Enterprise**
@@ -12,7 +12,7 @@ Valdrix supports tenant-scoped Microsoft Teams notifications using incoming webh
 - Stores webhook URL encrypted at rest in tenant notification settings.
 
 ## Configure
-1. In Valdrix, open **Settings -> Notifications**.
+1. In Valdrics, open **Settings -> Notifications**.
 2. Enable **Teams policy notifications**.
 3. Paste your Teams incoming webhook URL.
 4. Save settings.

--- a/docs/integrations/scim.md
+++ b/docs/integrations/scim.md
@@ -1,6 +1,6 @@
 # SCIM 2.0 Provisioning (Enterprise)
 
-Valdrix supports **tenant-scoped SCIM 2.0 provisioning** for **Users** and (optionally) **Groups** via a dedicated SCIM bearer token.
+Valdrics supports **tenant-scoped SCIM 2.0 provisioning** for **Users** and (optionally) **Groups** via a dedicated SCIM bearer token.
 
 ## Availability
 - Tier: **Enterprise**
@@ -16,7 +16,7 @@ Examples:
 - `GET /scim/v2/Users`
 
 ## How To Enable
-1. In Valdrix, go to **Settings** -> **Identity**.
+1. In Valdrics, go to **Settings** -> **Identity**.
 2. Toggle **SCIM provisioning** on.
 3. Click **Rotate SCIM token** (this returns a new token once).
 4. Store the token in your IdP as a secret.
@@ -37,7 +37,7 @@ This endpoint never returns the stored token. It only confirms whether the submi
 Set the following:
 - SCIM Base URL: `https://<your-valdrix-host>/scim/v2`
 - Authentication: Bearer Token
-- Token: the SCIM token you generated in Valdrix
+- Token: the SCIM token you generated in Valdrics
 
 ## Supported Operations
 - `GET /ServiceProviderConfig`
@@ -65,7 +65,7 @@ For stable “reference values” (URLs, auth mode, attribute mapping guidance) 
 - `docs/integrations/idp_reference_configs.md`
 
 ## SCIM Group Mappings (Recommended)
-Valdrix supports **tenant-configurable group mappings** that assign:
+Valdrics supports **tenant-configurable group mappings** that assign:
 - `role`: `admin` or `member`
 - `persona` (optional UX default): `engineering | finance | platform | leadership`
 
@@ -74,8 +74,8 @@ Configure:
 2. Add one or more mappings (group name is case-insensitive).
 
 Provisioning behavior:
-- If your IdP includes `groups` on `POST/PUT/PATCH /Users`, Valdrix applies mappings to set `role` and optional `persona`.
-- If your IdP provisions Group objects and manages membership via `POST/PUT/PATCH /Groups`, Valdrix stores group membership and recomputes entitlements for affected users based on your mappings.
+- If your IdP includes `groups` on `POST/PUT/PATCH /Users`, Valdrics applies mappings to set `role` and optional `persona`.
+- If your IdP provisions Group objects and manages membership via `POST/PUT/PATCH /Groups`, Valdrics stores group membership and recomputes entitlements for affected users based on your mappings.
 - If `groups` is **omitted** on `PUT`, entitlements are treated as **no change**.
 - If `groups` is **present** (even an empty list) on `PUT`, it is treated as **authoritative** for `role`:
   - No matching mapping => `member`

--- a/docs/integrations/scim_compatibility.md
+++ b/docs/integrations/scim_compatibility.md
@@ -1,7 +1,7 @@
-# SCIM Compatibility Matrix (Valdrix)
+# SCIM Compatibility Matrix (Valdrics)
 
 This document is an internal, source-controlled checklist for SCIM IdP interoperability.
-It describes what Valdrix **supports today** (endpoints + payload variants), so we can
+It describes what Valdrics **supports today** (endpoints + payload variants), so we can
 validate compatibility without relying on tribal knowledge.
 
 It does **not** claim vendor certification unless explicitly stated elsewhere.

--- a/docs/integrations/sso.md
+++ b/docs/integrations/sso.md
@@ -1,6 +1,6 @@
 # SSO (Federation + Enforcement) (Pro+)
 
-Valdrix supports two complementary layers:
+Valdrics supports two complementary layers:
 
 1. **Federated login bootstrap** (OIDC/SAML through Supabase SSO)
 2. **Tenant-scoped domain allowlisting enforcement**
@@ -9,7 +9,7 @@ Valdrix supports two complementary layers:
 - Implemented:
   - Domain allowlist enforcement after authentication.
   - Federated login initiation from login page (`Continue with SSO`) using tenant-scoped discovery.
-- Not managed by Valdrix (still configured in Supabase):
+- Not managed by Valdrics (still configured in Supabase):
   - IdP/provider creation, certificates, and metadata lifecycle (SAML/OIDC provider setup remains in Supabase).
 
 ## Availability
@@ -18,13 +18,13 @@ Valdrix supports two complementary layers:
 ## How It Works
 When configured:
 - login page calls `POST /api/v1/public/sso/discovery` with user email.
-- Valdrix resolves tenant federation mode from domain allowlist + tenant identity settings.
+- Valdrics resolves tenant federation mode from domain allowlist + tenant identity settings.
 - browser starts Supabase SSO flow (`domain` or `provider_id` mode).
 - callback completes session at `/auth/callback`.
 - API still enforces allowlist after authentication as a second-layer policy.
 
 ## Configure
-1. In Valdrix, go to **Settings** -> **Identity**.
+1. In Valdrics, go to **Settings** -> **Identity**.
 2. Enable **SSO enforcement**.
 3. Add one or more allowed domains (example: `example.com`).
 4. Enable **Federated SSO login**.
@@ -47,16 +47,16 @@ Key signals:
 - `federation_ready` should be true when federated login is enabled.
 
 ## Self-Lockout Guardrail
-Valdrix prevents accidental lockout:
+Valdrics prevents accidental lockout:
 - when enabling enforcement, the API requires your current admin email domain to be included in the allowlist.
 
 ## Notes
 - Keep allowlisting enabled even when federation is enabled; federation handles login, allowlisting enforces tenant boundary.
 
 ## IdP-Initiated Flow (Optional)
-Valdrix’s supported flow is **SP-initiated** (user clicks `Continue with SSO` on the Valdrix login page).
+Valdrics' supported flow is **SP-initiated** (user clicks `Continue with SSO` on the Valdrics login page).
 
 If your IdP strongly prefers IdP-initiated patterns, keep the federation flow **anchored in Supabase SSO** and
-still rely on Valdrix allowlist enforcement to bind users to the correct tenant. IdP-initiated flows are easy to
+still rely on Valdrics allowlist enforcement to bind users to the correct tenant. IdP-initiated flows are easy to
 misconfigure (and can bypass tenant discovery if you’re not careful), so treat them as an enterprise-only operator
 option and validate with `/api/v1/settings/identity/sso/validation` before rollout.

--- a/docs/integrations/workflow_automation.md
+++ b/docs/integrations/workflow_automation.md
@@ -1,6 +1,6 @@
 # Workflow Automation Integrations
 
-Valdrix can trigger external automation workflows on remediation policy and execution events.
+Valdrics can trigger external automation workflows on remediation policy and execution events.
 
 ## Supported targets
 
@@ -10,7 +10,7 @@ Valdrix can trigger external automation workflows on remediation policy and exec
 
 ## Event model
 
-Valdrix emits deterministic events:
+Valdrics emits deterministic events:
 
 - `policy.block`
 - `policy.escalate`

--- a/docs/licensing.md
+++ b/docs/licensing.md
@@ -6,8 +6,8 @@ This project is released under the Business Source License 1.1 (BSL 1.1). The le
 
 ## Plain-English Summary
 
-- You can run Valdrix internally in your own organization.
-- You cannot offer Valdrix itself as a competing hosted/managed service to third parties.
+- You can run Valdrics internally in your own organization.
+- You cannot offer Valdrics itself as a competing hosted/managed service to third parties.
 - On the change date, the code converts to Apache 2.0.
 
 ## Change Terms
@@ -22,31 +22,31 @@ This project is released under the Business Source License 1.1 (BSL 1.1). The le
 | Internal self-hosting for your own company | Yes | Includes production internal usage. |
 | Internal use by subsidiaries under same corporate control | Yes | Treated as internal use. |
 | Consulting/professional services deploying a customer-owned instance | Yes | Customer controls the instance and data plane. |
-| Reselling Valdrix as your own hosted SaaS | No | Prohibited competitive hosted offering. |
-| Multi-tenant MSP offering Valdrix capabilities as a service | No | Prohibited if customers consume Valdrix as the service. |
+| Reselling Valdrics as your own hosted SaaS | No | Prohibited competitive hosted offering. |
+| Multi-tenant MSP offering Valdrics capabilities as a service | No | Prohibited if customers consume Valdrics as the service. |
 | Research, evaluation, and test environments | Yes | Non-production and production internal use allowed. |
 
 ## Definitions Used in This Project
 
 - Production use: any environment used to serve real internal business workloads.
 - Hosted service: software operated by one party for use by unrelated third parties over a network.
-- Competitive offering: hosted use where Valdrix functionality is sold or bundled as a service.
+- Competitive offering: hosted use where Valdrics functionality is sold or bundled as a service.
 
 ## Licensing FAQ
 
-### Can I self-host Valdrix?
+### Can I self-host Valdrics?
 
 Yes, for your own internal operations.
 
 ### Can Valdrix-AI offer an official hosted SaaS?
 
-Yes. The BSL restriction targets third parties offering competing hosted services. It does not block the project owner from operating the official Valdrix SaaS.
+Yes. The BSL restriction targets third parties offering competing hosted services. It does not block the project owner from operating the official Valdrics SaaS.
 
 ### Can I run it for my clients?
 
-You can deploy/support a client-owned instance. You cannot operate a shared hosted Valdrix service for third-party consumption.
+You can deploy/support a client-owned instance. You cannot operate a shared hosted Valdrics service for third-party consumption.
 
-### Can I buy rights to run Valdrix as a managed service?
+### Can I buy rights to run Valdrics as a managed service?
 
 Yes. We provide commercial exceptions for qualified partners and OEM use cases. See `COMMERCIAL_LICENSE.md`.
 

--- a/docs/open_core_boundary.md
+++ b/docs/open_core_boundary.md
@@ -2,7 +2,7 @@
 
 Last updated: February 12, 2026
 
-This document defines licensing boundaries for Valdrix components.
+This document defines licensing boundaries for Valdrics components.
 
 ## Current State
 

--- a/docs/ops/acceptance_evidence_capture.md
+++ b/docs/ops/acceptance_evidence_capture.md
@@ -98,7 +98,7 @@ This evidence is bundled in the compliance pack as `job_slo_evidence.json`.
 
 ## Automated Daily Acceptance Suite Capture (Recommended)
 
-Valdrix also runs a daily, tenant-scoped acceptance capture sweep via the scheduler:
+Valdrics also runs a daily, tenant-scoped acceptance capture sweep via the scheduler:
 
 - Enqueues background jobs: `acceptance_suite_capture`
 - Schedule: **daily 05:00 UTC** (see `SchedulerOrchestrator.start()`).

--- a/docs/ops/audit_remediation_2026-02-20.md
+++ b/docs/ops/audit_remediation_2026-02-20.md
@@ -207,9 +207,9 @@ Source audit: `/home/daretechie/.gemini/antigravity/brain/c6c55133-7d83-4352-ab2
 
 - `VAL-ADAPT-002+` remains open as maintainability refactor scope (full class-size/vendor-strategy split), not an immediate correctness or security hotfix blocker.
 
-## Consolidated remediation status (Valdrix follow-up, 2026-02-28)
+## Consolidated remediation status (Valdrics follow-up, 2026-02-28)
 
-This section consolidates what is now remediated from the Valdrix audit stream so reviewers do not need to reconstruct status across multiple execution updates.
+This section consolidates what is now remediated from the Valdrics audit stream so reviewers do not need to reconstruct status across multiple execution updates.
 
 ### Fully remediated (code + regression evidence captured)
 
@@ -239,7 +239,7 @@ This section consolidates what is now remediated from the Valdrix audit stream s
 - Remaining `VAL-ADAPT-002+` class-size/vendor-strategy decomposition scope.
 - No unresolved release-critical correctness/security defect was confirmed in this subset after remediation and regression reruns.
 
-## Additional remediation batch (Valdrix continuation, 2026-02-28N)
+## Additional remediation batch (Valdrics continuation, 2026-02-28N)
 
 - `VAL-SEC-002` remediated with machine-checkable API auth coverage:
   - Added `scripts/verify_api_auth_coverage.py` to recursively inspect route dependency trees.
@@ -267,7 +267,7 @@ This section consolidates what is now remediated from the Valdrix audit stream s
 - `TESTING=true DEBUG=false uv run python3 scripts/verify_api_auth_coverage.py` -> `Auth coverage check passed.`
 - `DEBUG=false uv run pytest -q --no-cov tests/unit/services/billing/test_entitlement_policy.py tests/unit/services/billing/test_dunning_service.py tests/unit/services/billing/test_paystack_billing_branches.py tests/unit/ops/test_verify_api_auth_coverage.py tests/unit/shared/adapters/test_aws_pagination.py tests/unit/supply_chain/test_enterprise_tdd_gate_runner.py tests/unit/governance/test_jobs_api.py tests/unit/governance/settings/test_llm_settings.py` -> `98 passed`.
 
-## Additional remediation batch (Valdrix continuation, 2026-02-28O)
+## Additional remediation batch (Valdrics continuation, 2026-02-28O)
 
 - `VAL-ADAPT-002+` decomposition advanced further in `app/shared/adapters/license.py`:
   - moved manual-feed transformation/validation/activity logic to `app/shared/adapters/license_feed_ops.py`,
@@ -283,7 +283,7 @@ This section consolidates what is now remediated from the Valdrix audit stream s
 - `uv run mypy app/shared/adapters/license.py app/shared/adapters/license_feed_ops.py app/shared/adapters/license_vendor_registry.py --hide-error-context --no-error-summary` -> passed.
 - `DEBUG=false uv run pytest -q --no-cov tests/unit/shared/adapters/test_license_feed_ops.py tests/unit/shared/adapters/test_license_vendor_registry.py tests/unit/services/adapters/test_adapter_helper_branches.py tests/unit/services/adapters/test_license_activity_and_revoke.py tests/unit/services/adapters/test_license_verification_stream_branches.py tests/unit/services/adapters/test_cloud_plus_adapters.py tests/unit/shared/adapters/test_google_workspace.py` -> `123 passed`.
 
-## Additional remediation batch (Valdrix continuation, 2026-02-28P)
+## Additional remediation batch (Valdrics continuation, 2026-02-28P)
 
 - `VAL-ADAPT-002+` decomposition advanced from helper extraction to vendor-module split:
   - `app/shared/adapters/license_vendor_verify.py`
@@ -312,7 +312,7 @@ This section consolidates what is now remediated from the Valdrix audit stream s
 - Snapshot/export stability: stream/revoke/activity wrapper signatures and returned record shapes are unchanged at call sites.
 - Failure modes and misconfiguration: unsupported vendor paths remain fail-closed with explicit error messages.
 
-## Additional remediation batch (Valdrix continuation, 2026-02-28Q)
+## Additional remediation batch (Valdrics continuation, 2026-02-28Q)
 
 - `VAL-ADAPT-002+` advanced by removing stub-grade behavior from the license adapter resource surfaces:
   - added `app/shared/adapters/license_resource_ops.py` for deterministic, typed resource/usage shaping from license activity rows,
@@ -337,7 +337,7 @@ This section consolidates what is now remediated from the Valdrix audit stream s
 - Snapshot stability/export integrity: usage row schema is explicit and stable (`provider/service/usage_type/resource_id/usage_amount/cost/currency/timestamp/tags`).
 - Failure modes/misconfiguration: unsupported resource/service requests return empty results; negative default seat prices are clamped to `0.0`; malformed timestamps fall back safely.
 
-## Additional remediation batch (Valdrix continuation, 2026-02-28R)
+## Additional remediation batch (Valdrics continuation, 2026-02-28R)
 
 - `VAL-CORE-002` remediated in `app/shared/core/pricing.py`:
   - removed legacy hardcoded `paystack_amount_kobo` tier constants from runtime pricing config,
@@ -376,7 +376,7 @@ This section consolidates what is now remediated from the Valdrix audit stream s
 - Snapshot stability/export integrity: billing metadata keys (`plan_code`, `pricing_mode`) are additive and backward-safe.
 - Failure modes/misconfiguration: router registry now fails closed at startup on missing/duplicate/unexpected prefixes.
 
-## Valdrix remaining finding dispositions (post-remediation review)
+## Valdrics remaining finding dispositions (post-remediation review)
 
 - Disposition evidence is now machine-checkable and release-gated via:
   - register artifact: `docs/ops/evidence/valdrix_disposition_register_2026-02-28.json`
@@ -391,7 +391,7 @@ This section consolidates what is now remediated from the Valdrix audit stream s
 - `VAL-API-004`: static Swagger asset serving remains read-only from packaged static directory; no runtime write path is exposed by app routes.
 - `VAL-ADAPT-002+`: still open as class-size/vendor-strategy maintainability decomposition backlog, not a correctness/security release blocker after current remediation packs.
 
-## Additional remediation batch (Valdrix continuation, 2026-02-28S)
+## Additional remediation batch (Valdrics continuation, 2026-02-28S)
 
 - `VAL-ADAPT-002+` decomposition advanced by extracting native vendor dispatch orchestration out of `LicenseAdapter`:
   - added `app/shared/adapters/license_native_dispatch.py` with typed, table-driven dispatch for verify, stream, revoke, and activity paths,
@@ -415,7 +415,7 @@ This section consolidates what is now remediated from the Valdrix audit stream s
 - Snapshot stability/export integrity: public adapter method signatures and emitted row shapes are unchanged.
 - Failure modes/misconfiguration: unknown native vendors stay fail-closed (`ExternalAPIError`/`UnsupportedVendorError`) with explicit operator-facing messages.
 
-## Additional remediation batch (Valdrix continuation, 2026-02-28T)
+## Additional remediation batch (Valdrics continuation, 2026-02-28T)
 
 - `VAL-ADAPT-001` hardening pass implemented for cloud-core adapters (AWS/Azure/GCP/CUR):
   - added sanitized adapter error helpers to `app/shared/adapters/base.py`:
@@ -447,7 +447,7 @@ This section consolidates what is now remediated from the Valdrix audit stream s
 - Snapshot stability/export integrity: no request/response schema changes; only failure-message selection semantics improved.
 - Failure modes/misconfiguration: unsupported-region and credential failures remain fail-closed with explicit operator-facing diagnostics.
 
-## Additional remediation batch (Valdrix continuation, 2026-02-28U)
+## Additional remediation batch (Valdrics continuation, 2026-02-28U)
 
 - Remediated all five explicit `get_resource_usage()` stubs that previously returned unconditional empty lists:
   - `app/shared/adapters/azure.py`
@@ -484,7 +484,7 @@ This section consolidates what is now remediated from the Valdrix audit stream s
 - Snapshot stability/export integrity: usage payloads are now consistently shaped with explicit defaults (`currency`, `region`, `source_adapter`) and no placeholder TODO paths.
 - Failure modes/misconfiguration: lookups fail closed (`[]`) on upstream errors; bounded lookback prevents unbounded scans; resource/service filters are explicit and case-normalized.
 
-## Additional remediation batch (Valdrix continuation, 2026-02-28V)
+## Additional remediation batch (Valdrics continuation, 2026-02-28V)
 
 - Remediated remaining AWS adapter `get_resource_usage()` placeholders:
   - `app/shared/adapters/aws_cur.py`
@@ -518,7 +518,7 @@ This section consolidates what is now remediated from the Valdrix audit stream s
 - Snapshot stability/export integrity: emitted usage schema remains consistent with all other adapter resource-usage surfaces.
 - Failure modes/misconfiguration: blank service requests and empty discovery/ingestion paths fail closed (`[]`) without raising unstable runtime errors.
 
-## Additional remediation batch (Valdrix continuation, 2026-02-28W)
+## Additional remediation batch (Valdrics continuation, 2026-02-28W)
 
 - `VAL-DB-001` hardening finalized for explicit tenant-context teardown:
   - added `clear_session_tenant_context()` in `app/shared/db/session.py` to enforce fail-closed state (`tenant_id=None`, `rls_context_set=False`, `rls_system_context=False`) on both session and connection.
@@ -552,7 +552,7 @@ This section consolidates what is now remediated from the Valdrix audit stream s
 - Snapshot stability/export integrity: no API payload schema changes; remediation is internal session-control behavior only.
 - Failure modes/misconfiguration: unresolved backend detection remains fail-closed and now applies symmetric system-context resets during both set and clear flows.
 
-## Additional remediation batch (Valdrix continuation, 2026-02-28X)
+## Additional remediation batch (Valdrics continuation, 2026-02-28X)
 
 - `VAL-ADAPT-002+` decomposition advanced by extracting native-vendor compatibility wrappers out of `LicenseAdapter`:
   - added `app/shared/adapters/license_native_compat.py` with a dedicated `LicenseNativeCompatMixin`.
@@ -584,7 +584,7 @@ This section consolidates what is now remediated from the Valdrix audit stream s
 - Snapshot stability/export integrity: adapter public/native private seams remain stable, protecting existing regression snapshots and downstream exports.
 - Failure modes/misconfiguration: unsupported vendor handling remains fail-closed through dispatch/runtime contracts; native auth guardrails are unchanged.
 
-## Additional remediation batch (Valdrix continuation, 2026-03-01A)
+## Additional remediation batch (Valdrics continuation, 2026-03-01A)
 
 - `VAL-ADAPT-002+` breaking cleanup completed (legacy private wrapper seam removed):
   - removed `app/shared/adapters/license_native_compat.py` and dropped `LicenseNativeCompatMixin` inheritance from `LicenseAdapter`.
@@ -618,7 +618,7 @@ This section consolidates what is now remediated from the Valdrix audit stream s
 - Snapshot stability/export integrity: public adapter outputs and exported usage/cost row schemas are unchanged; only internal invocation topology changed.
 - Failure modes/misconfiguration: unsupported vendor and unsupported revoke paths remain fail-closed with explicit `ExternalAPIError` / `UnsupportedVendorError` semantics.
 
-## Additional remediation batch (Valdrix continuation, 2026-03-01B)
+## Additional remediation batch (Valdrics continuation, 2026-03-01B)
 
 - Cloud+ adapter architecture hardening completed for remaining native-vendor branch chains:
   - `app/shared/adapters/saas.py`
@@ -655,7 +655,7 @@ This section consolidates what is now remediated from the Valdrix audit stream s
 - Snapshot stability/export integrity: discovery payload shape is deterministic and sorted by resource identity/region; no existing cost row schema contracts changed.
 - Failure modes/misconfiguration: unsupported vendor and invalid auth mode checks remain explicit fail-closed guards.
 
-## Additional remediation batch (Valdrix continuation, 2026-03-01C)
+## Additional remediation batch (Valdrics continuation, 2026-03-01C)
 
 - Completed no-compat cleanup for `VAL-ADAPT-002+` runtime dispatch:
   - removed `app/shared/adapters/license_vendor_ops.py` compatibility facade from production code,
@@ -689,7 +689,7 @@ This section consolidates what is now remediated from the Valdrix audit stream s
 - Failure modes: unsupported vendors still fail closed (`ExternalAPIError` / `UnsupportedVendorError`) and discovery errors return empty lists with explicit warning logs.
 - Operational misconfiguration risk: auth-mode/vendor guards and connector-config validation branches remain enforced with explicit error strings.
 
-## Additional remediation batch (Valdrix continuation, 2026-03-01D)
+## Additional remediation batch (Valdrics continuation, 2026-03-01D)
 
 - Adapter consistency hardening completed across cloud and Cloud+ discovery/usage surfaces:
   - `app/shared/adapters/aws_multitenant.py`
@@ -725,7 +725,7 @@ This section consolidates what is now remediated from the Valdrix audit stream s
 - Failure modes: fail-closed branches now carry explicit operator context instead of silent empty returns.
 - Operational misconfiguration: unsupported-region/plugin-mapping branches in AWS multitenant now surface explicit actionable error messages.
 
-## Additional remediation batch (Valdrix continuation, 2026-03-01E)
+## Additional remediation batch (Valdrics continuation, 2026-03-01E)
 
 - Completed remaining private stream-wrapper seam cleanup on adapters:
   - removed `_stream_cost_and_usage_impl` methods from:
@@ -762,7 +762,7 @@ This section consolidates what is now remediated from the Valdrix audit stream s
 - Failure modes: invalid `lastmod` env values are ignored (fail-safe omission instead of malformed XML).
 - Operational misconfiguration: explicit env-driven `lastmod` control makes deployment behavior auditable and intentional.
 
-## Additional remediation batch (Valdrix continuation, 2026-03-01F)
+## Additional remediation batch (Valdrics continuation, 2026-03-01F)
 
 - Closed remaining silent fallback path for unsupported native license auth vendors:
   - `app/shared/adapters/license.py`
@@ -791,7 +791,7 @@ This section consolidates what is now remediated from the Valdrix audit stream s
 - Failure modes: unsupported vendor + native auth can no longer silently degrade into manual-feed execution.
 - Operational misconfiguration: Playwright backend startup is now resilient to inherited non-boolean `DEBUG` values.
 
-## Additional remediation batch (Valdrix continuation, 2026-03-01G)
+## Additional remediation batch (Valdrics continuation, 2026-03-01G)
 
 - `VAL-CORE-003` hardening completed with process-level tenant-tier cache:
   - `app/shared/core/pricing.py`
@@ -831,7 +831,7 @@ This section consolidates what is now remediated from the Valdrix audit stream s
 - Failure modes: stale tier reads are bounded by TTL and explicit invalidation on plan sync; DB session dependency paths remain fail-closed where enforced.
 - Operational misconfiguration: cache behavior remains safe under missing `db.info`; direct dependency seams reduce override drift and hidden aliasing risk.
 
-## Additional remediation batch (Valdrix continuation, 2026-03-01H)
+## Additional remediation batch (Valdrics continuation, 2026-03-01H)
 
 - `VAL-SEC-003` hardening completed for webhook client IP attribution:
   - `app/modules/billing/api/v1/billing.py`
@@ -873,7 +873,7 @@ This section consolidates what is now remediated from the Valdrix audit stream s
 - Failure modes: proxy trust misconfiguration now fails closed for XFF usage; invalid CIDRs fail at config validation.
 - Operational misconfiguration: staging/production now requires explicit trusted proxy CIDR allowlist when proxy headers are enabled.
 
-## Additional remediation batch (Valdrix continuation, 2026-03-01I)
+## Additional remediation batch (Valdrics continuation, 2026-03-01I)
 
 - `VAL-CORE-004` compatibility cleanup finalized in tier resolution:
   - `app/shared/core/pricing.py`
@@ -909,7 +909,7 @@ This section consolidates what is now remediated from the Valdrix audit stream s
 - Failure modes: invalid pricing result shapes and malformed paystack webhook allowlist values fail closed.
 - Operational misconfiguration: webhook source-IP policy is now explicit, validated configuration rather than embedded constants.
 
-## Additional remediation batch (Valdrix continuation, 2026-03-01J)
+## Additional remediation batch (Valdrics continuation, 2026-03-01J)
 
 - Canonical disposition sync for adapter decomposition track:
   - `VAL-ADAPT-002`: `CLOSED`.
@@ -938,3 +938,58 @@ This section consolidates what is now remediated from the Valdrix audit stream s
 - Export integrity: documentation-only + frontend regression validation pass; export contracts unchanged.
 - Failure modes: overflow/sr-only/header/toggle regressions are explicit test failures.
 - Operational misconfiguration: no new runtime config surface introduced.
+
+## Additional remediation batch (Valdrics continuation, 2026-03-01K)
+
+- Billing webhook idempotency and replay hardening:
+  - `app/modules/billing/domain/billing/webhook_retry.py`
+  - replaced time-based webhook reference fallback with deterministic payload reference resolution (`reference`, `data.reference`, `data.id`, `id`, `event_id`, stable payload hash fallback),
+  - added `mark_inline_processed(...)` to complete queued webhook jobs when inline handling succeeds, preventing duplicate worker re-processing.
+  - `app/modules/billing/api/v1/billing_ops.py`
+  - immediate webhook path now marks queued retry jobs completed after successful inline processing.
+- Dunning duplicate-webhook control:
+  - `app/modules/billing/domain/billing/dunning_service.py`
+  - added `DUNNING_WEBHOOK_DEBOUNCE_SECONDS` (5 minutes),
+  - duplicate rapid `invoice.payment_failed` webhooks now return `duplicate_ignored` without incrementing attempt counters.
+- Billing precision hardening:
+  - `app/modules/billing/domain/billing/paystack_webhook_impl.py`
+  - converted charge subunit and FX parsing to decimal-safe normalization,
+  - invalid/negative payload values now fail closed with structured warnings.
+  - `app/modules/billing/domain/billing/paystack_service_impl.py`
+  - introduced decimal-first USD normalization and cent conversion to remove float-rounding drift in checkout/renewal USD paths.
+- Executive reporting security signal integration:
+  - `app/modules/reporting/domain/leadership_kpis.py`
+  - added deterministic enforcement-derived KPI counters:
+    - `security_high_risk_decisions`
+    - `security_approval_required_decisions`
+    - `security_anomaly_signal_decisions`
+  - extended leadership CSV summary with these security posture metrics.
+- Public edge and mobile layout hardening:
+  - `dashboard/src/routes/+layout.svelte`
+  - Supabase auth listener now initializes only for authenticated sessions, eliminating public landing client resolution noise.
+  - `dashboard/src/app.css`
+  - `.main-content` sidebar offset now applies only from tablet+ breakpoints (`min-width: 768px`), preventing mobile layout breakage.
+- Operational safety hardening for destructive/admin scripts:
+  - `scripts/force_wipe_app.py`
+  - `scripts/database_wipe.py`
+  - `scripts/emergency_token.py`
+  - all now enforce explicit force flags, confirmation phrases, and protected environment controls for break-glass flows.
+- Naming consistency:
+  - `app/shared/core/config.py`
+  - default `APP_NAME` updated to `Valdrics`.
+
+### Validation evidence (this batch)
+
+- `DEBUG=false .venv/bin/pytest -q -o addopts='' tests/unit/modules/reporting/test_webhook_retry.py tests/unit/services/billing/test_dunning_service.py tests/unit/api/v1/test_billing.py tests/unit/modules/reporting/test_leadership_kpis_domain.py tests/unit/services/billing/test_paystack_billing.py tests/unit/services/billing/test_paystack_billing_branches.py tests/unit/core/test_config_audit.py` -> `122 passed`.
+- `cd dashboard && npm run test:e2e -- e2e/landing-layout-audit.spec.ts` -> `2 passed`.
+- `.venv/bin/python -m py_compile app/modules/billing/api/v1/billing_ops.py app/modules/billing/domain/billing/dunning_service.py app/modules/billing/domain/billing/paystack_service_impl.py app/modules/billing/domain/billing/paystack_webhook_impl.py app/modules/billing/domain/billing/webhook_retry.py app/modules/reporting/domain/leadership_kpis.py scripts/force_wipe_app.py scripts/database_wipe.py scripts/emergency_token.py` -> passed.
+
+### Post-closure sanity check (release-critical)
+
+- Concurrency: inline webhook completion plus worker retries now share deterministic idempotency references; duplicate webhook storms are debounced before state mutation.
+- Observability: duplicate webhook suppression, inline completion failures, invalid payload values, and script guard denials emit explicit structured logs.
+- Deterministic replay: webhook idempotency keys are now derived from stable payload identity (no time entropy).
+- Snapshot stability: landing layout checks remain deterministic across mobile breakpoints and SR-only clipping assertions.
+- Export integrity: leadership KPI CSV now includes explicit security posture columns without changing provider/service sort determinism.
+- Failure modes: webhook inline-processing success no longer leaves pending jobs that can replay side effects; invalid FX/amount payloads are safely rejected.
+- Operational misconfiguration: destructive scripts and emergency-token generation now fail closed unless explicit break-glass controls are supplied.

--- a/docs/ops/enforcement_control_plane_gap_register_2026-02-23.md
+++ b/docs/ops/enforcement_control_plane_gap_register_2026-02-23.md
@@ -124,7 +124,7 @@ Execution update (2026-02-28H): immediate PKG/FIN evidence hardening controls co
    - supports bounded timestamp skew to avoid same-day false positives.
    - Evidence: `tests/unit/ops/test_verify_monthly_finance_evidence_refresh.py`, `tests/unit/supply_chain/test_enterprise_tdd_gate_runner.py`.
 
-Execution update (2026-02-28I): Valdrix codebase audit validation + remediation batch
+Execution update (2026-02-28I): Valdrics codebase audit validation + remediation batch
 1. Validated and remediated confirmed security/runtime defects from `VALDRX_CODEBASE_AUDIT_2026-02-28.md.resolved`:
    - `VAL-DB-001`: hardened RLS session posture by introducing explicit `rls_system_context` marker and fail-closed behavior for ambiguous (unset/non-system) DB query context in non-testing runtime.
      - Code: `app/shared/db/session.py`
@@ -171,7 +171,7 @@ Execution update (2026-02-28J): adapter retry abstraction remediation
 5. Remaining adapter backlog scope:
    - class-size and vendor-strategy decomposition (`VAL-ADAPT-002+`) remains a maintainability refactor backlog item (non-hotfix severity).
 
-Execution update (2026-02-28K): Valdrix audit follow-up (targeted closures + decomposition pass)
+Execution update (2026-02-28K): Valdrics audit follow-up (targeted closures + decomposition pass)
 1. Closed `VAL-CORE-001` (implicit maturity mapping risk):
    - `app/shared/core/pricing.py` now defines explicit preview maturity membership and enforces exact/complete feature-maturity coverage invariants.
    - Startup fails closed if any `FeatureFlag` is missing from maturity classification.
@@ -188,7 +188,7 @@ Execution update (2026-02-28K): Valdrix audit follow-up (targeted closures + dec
    - `VAL-ADAPT-002+` still has additional class-size/vendor-strategy extraction scope; this is maintainability backlog, not a release-blocking runtime defect.
 
 Execution update (2026-02-28L): consolidated remediation state sync
-1. Consolidated remediated Valdrix items now reflected in code + docs:
+1. Consolidated remediated Valdrics items now reflected in code + docs:
    - `VAL-DB-001`, `VAL-BILL-005`, `VAL-SEC-001`, `VAL-SEC-003`, `VAL-CORE-003/004`,
    - `VAL-CORE-001`, `VAL-BILL-001`, `VAL-ADAPT-003`, `VAL-ADAPT-004`.
 2. `VAL-ADAPT-002` status:
@@ -209,7 +209,7 @@ Execution update (2026-02-28M): license stream-cost decomposition follow-up
    - `uv run mypy app/shared/adapters/license.py app/shared/adapters/license_vendor_ops.py --hide-error-context --no-error-summary` -> passed.
    - `DEBUG=false uv run pytest -q --no-cov tests/unit/services/adapters/test_license_verification_stream_branches.py tests/unit/services/adapters/test_license_activity_and_revoke.py tests/unit/services/adapters/test_cloud_plus_adapters.py tests/unit/shared/adapters/test_google_workspace.py` -> `91 passed`.
 
-Execution update (2026-02-28N): Valdrix continuation (auth coverage + paginator + billing entitlement sync)
+Execution update (2026-02-28N): Valdrics continuation (auth coverage + paginator + billing entitlement sync)
 1. Closed `VAL-SEC-002` with machine-checkable route-auth verification:
    - added `scripts/verify_api_auth_coverage.py` (recursive dependency scan + explicit public allowlist),
    - wired as a mandatory enterprise gate command in `scripts/run_enterprise_tdd_gate.py`,
@@ -1484,7 +1484,7 @@ Later wave (`Optional/Later`):
 ## Operator review of new pricing feedback (2026-02-24)
 
 This section evaluates the newly provided pricing feedback with two evidence types only:
-1. Codebase facts (current Valdrix implementation).
+1. Codebase facts (current Valdrics implementation).
 2. Public pricing evidence from primary vendor pages / AWS Marketplace.
 
 ### Codebase facts verified
@@ -1632,7 +1632,7 @@ This addendum evaluates the latest tier-by-tier pricing feedback against reposit
 
 ## B-first launch recalibration addendum (2026-02-24, latest feedback)
 
-This section evaluates the claim that pricing/positioning must shift immediately if Valdrix launches as an economic control plane.
+This section evaluates the claim that pricing/positioning must shift immediately if Valdrics launches as an economic control plane.
 
 ### Codebase facts that constrain launch positioning
 
@@ -2509,7 +2509,7 @@ This section evaluates the latest BSL feedback against repository license terms 
 
 ### Repository facts (legal/commercial posture)
 
-1. Valdrix is licensed under BSL 1.1 with source availability, not OSI open-source licensing today.
+1. Valdrics is licensed under BSL 1.1 with source availability, not OSI open-source licensing today.
    - Evidence: `LICENSE`, `README.md`, `docs/licensing.md`.
 2. Change terms are explicit:
    - Change Date: `2029-01-12`.
@@ -2540,7 +2540,7 @@ Conclusion:
 1. The strategic comparison is useful directionally.
 2. Licensing analogs must be treated as category-adjacent, not all "BSL peers."
 
-### Commercial implication for Valdrix (strict)
+### Commercial implication for Valdrics (strict)
 
 1. Under BSL + public repo, monetization strength comes from operated service value:
    - reliability/SLOs,

--- a/docs/ops/evidence/README.md
+++ b/docs/ops/evidence/README.md
@@ -11,7 +11,7 @@ This directory stores staged enforcement evidence artifacts used by release gate
 5. PKG/FIN policy decision artifact: `pkg_fin_policy_decisions_YYYY-MM-DD.json`
 6. Finance telemetry snapshot artifact: `finance_telemetry_snapshot_YYYY-MM-DD.json`
 7. Finance committee assumptions artifact: `finance_committee_packet_assumptions_YYYY-MM-DD.json`
-8. Valdrix disposition register artifact: `valdrix_disposition_register_YYYY-MM-DD.json`
+8. Valdrics disposition register artifact: `valdrix_disposition_register_YYYY-MM-DD.json`
 
 ## Template Seeds
 
@@ -85,7 +85,7 @@ Finance committee assumptions should be captured to:
 docs/ops/evidence/finance_committee_packet_assumptions_YYYY-MM-DD.json
 ```
 
-Valdrix disposition register should be captured to:
+Valdrics disposition register should be captured to:
 
 ```text
 docs/ops/evidence/valdrix_disposition_register_YYYY-MM-DD.json
@@ -185,7 +185,7 @@ uv run python3 scripts/verify_monthly_finance_evidence_refresh.py \
   --max-capture-spread-days 14
 ```
 
-Valdrix disposition freshness verifier (risk-review reminder gate):
+Valdrics disposition freshness verifier (risk-review reminder gate):
 
 ```bash
 uv run python3 scripts/verify_valdrix_disposition_freshness.py \

--- a/docs/ops/incident_response_runbook.md
+++ b/docs/ops/incident_response_runbook.md
@@ -2,7 +2,7 @@
 
 **Version:** 1.0 (Audit Remediation)
 **Status:** Operational
-**Scope:** Valdrix CloudSentinel-AI Platform
+**Scope:** Valdrics CloudSentinel-AI Platform
 
 ## 1. Detection and Analysis
 
@@ -27,7 +27,7 @@ If an AWS connection is compromised or performing unauthorized deletions:
 ```bash
 python3 scripts/emergency_disconnect.py --tenant-id <UUID> --provider aws
 ```
-*This attaches an inline 'Deny All' policy to the Valdrix IAM role.*
+*This attaches an inline 'Deny All' policy to the Valdrics IAM role.*
 
 ### Global Kill Switch
 To stop all remediation actions globally (if a systemic bug is suspected):

--- a/docs/ops/pricing_competitiveness_fact_check_2026-02-17.md
+++ b/docs/ops/pricing_competitiveness_fact_check_2026-02-17.md
@@ -228,7 +228,7 @@ Not validated for external claims:
 - A blanket "zero API cost across all platforms" statement.
 
 Safe external wording:
-- "Valdrix is CUR-first on AWS and avoids Cost Explorer by default."
+- "Valdrics is CUR-first on AWS and avoids Cost Explorer by default."
 - "The platform is engineered for low incremental API costs; actual customer-side cost varies with scan profile, CloudWatch fallback usage, and BigQuery bytes scanned."
 - "Published dollar figures are based on measured tenant workloads and date-stamped provider pricing."
 

--- a/docs/policies/data_retention.md
+++ b/docs/policies/data_retention.md
@@ -1,6 +1,6 @@
 # Data Retention & Purge Policy
 
-**Scope:** All Valdrix Tenant Data
+**Scope:** All Valdrics Tenant Data
 
 ## 1. Purpose
 To ensure compliance with GDPR and other data protection regulations by defining how long data is stored and how it is purged.

--- a/docs/product/personas.md
+++ b/docs/product/personas.md
@@ -1,6 +1,6 @@
 # Personas (Product Defaults)
 
-Valdrix is used by different roles with different success metrics. Persona is a **UX default** that controls:
+Valdrics is used by different roles with different success metrics. Persona is a **UX default** that controls:
 
 - which navigation items are emphasized
 - which home widgets load first

--- a/docs/runbooks/disaster_recovery.md
+++ b/docs/runbooks/disaster_recovery.md
@@ -1,7 +1,7 @@
 # Disaster Recovery Runbook
 
 ## Overview
-This runbook documents recovery procedures for Valdrix infrastructure.
+This runbook documents recovery procedures for Valdrics infrastructure.
 
 **RTO (Recovery Time Objective):** 4 hours  
 **RPO (Recovery Point Objective):** 24 hours (Supabase daily backups)

--- a/docs/runbooks/emergency_disconnect.md
+++ b/docs/runbooks/emergency_disconnect.md
@@ -2,39 +2,39 @@
 
 **Version:** 1.0  
 **Status:** Active  
-**Author:** Valdrix Platform Team
+**Author:** Valdrics Platform Team
 
 ## Overview
-This runbook provides instructions for immediate disconnection of a cloud provider account from Valdrix in case of a security incident or at the customer's request.
+This runbook provides instructions for immediate disconnection of a cloud provider account from Valdrics in case of a security incident or at the customer's request.
 
 ## Target Audience
-- Valdrix Security Engineers
+- Valdrics Security Engineers
 - Customer Cloud Administrators
 
 ## Procedure
 
 ### 1. In-App Disconnect
-1. Login to Valdrix Admin/Dashboard.
+1. Login to Valdrics Admin/Dashboard.
 2. Navigate to **Connections**.
 3. Locate the connection to be removed.
 4. Click **Delete/Disconnect**.
 5. Confirm deletion. This will:
-   - Mark the connection as `deleted` in the Valdrix DB.
+   - Mark the connection as `deleted` in the Valdrics DB.
    - Stop all ongoing scans and health checks.
    - Revoke access to the connection in the application layer.
 
 ### 2. AWS Side Revocation (Manual)
-If the Valdrix app is unavailable or the situation is urgent:
+If the Valdrics app is unavailable or the situation is urgent:
 1. Login to the **AWS Management Console** of the connected account.
 2. Navigate to **IAM > Roles**.
-3. Search for the role assumed by Valdrix (e.g., `Valdrix-AI-Role` or `Valdrix-Role`).
+3. Search for the role assumed by Valdrics (e.g., `Valdrix-AI-Role` or `Valdrix-Role`).
 4. **Delete the role** OR **Remove the Trust Relationship** of the role.
-   - Removing the trust relationship is less destructive and prevents Valdrix from assuming the role without deleting the role itself.
+   - Removing the trust relationship is less destructive and prevents Valdrics from assuming the role without deleting the role itself.
 5. Search for the **IAM Policy** associated with the role and delete it.
 
 ### 3. Verification
-1. Attempt to run a scan in the Valdrix dashboard; it should fail with an `AccessDenied` or `ResourceNotFound` error.
-2. Check the Audit Log in AWS for `AssumeRole` failures from the Valdrix Principal ARN.
+1. Attempt to run a scan in the Valdrics dashboard; it should fail with an `AccessDenied` or `ResourceNotFound` error.
+2. Check the Audit Log in AWS for `AssumeRole` failures from the Valdrics Principal ARN.
 
 ---
 

--- a/docs/runbooks/incident_response.md
+++ b/docs/runbooks/incident_response.md
@@ -1,4 +1,4 @@
-# Valdrix Operational Runbooks
+# Valdrics Operational Runbooks
 
 This document provides step-by-step procedures for handling common operational scenarios and incidents.
 

--- a/docs/runbooks/month_end_close.md
+++ b/docs/runbooks/month_end_close.md
@@ -1,6 +1,6 @@
 # Month-End Close (Operator Runbook)
 
-Valdrix “month-end close” is a deterministic reconciliation package meant for finance/procurement sign-off:
+Valdrics “month-end close” is a deterministic reconciliation package meant for finance/procurement sign-off:
 
 - Close status (ready / not-ready reasons)
 - Lifecycle counts (preliminary vs final)

--- a/docs/runbooks/partition_maintenance.md
+++ b/docs/runbooks/partition_maintenance.md
@@ -1,6 +1,6 @@
 # Partition Maintenance (Postgres)
 
-Valdrix uses monthly range partitioning for high-volume tables to keep query latency stable as data grows.
+Valdrics uses monthly range partitioning for high-volume tables to keep query latency stable as data grows.
 
 Tables:
 - `cost_records` (partitioned by `recorded_at` DATE)

--- a/docs/runbooks/production_env_checklist.md
+++ b/docs/runbooks/production_env_checklist.md
@@ -4,7 +4,7 @@ Use this checklist before every production rollout.
 
 ## 1. Ownership model (who sets what)
 
-- Platform operator (you/Valdrix team) sets infrastructure env vars and deploys backend/frontend.
+- Platform operator (you/Valdrics team) sets infrastructure env vars and deploys backend/frontend.
 - Tenant users configure integrations in product UI under `/settings/notifications`.
 - Tenant users do **not** set backend process env vars.
 

--- a/docs/security/PQC_ROADMAP.md
+++ b/docs/security/PQC_ROADMAP.md
@@ -1,7 +1,7 @@
 # Post-Quantum Cryptography (PQC) Roadmap
 
 ## Strategic Vision
-Valdrix is committed to future-proofing tenant data against the "Harvest Now, Decrypt Later" threat. This roadmap outlines the transition from classical asymmetric cryptography (RSA, ECC) to NIST-standardized quantum-resistant algorithms.
+Valdrics is committed to future-proofing tenant data against the "Harvest Now, Decrypt Later" threat. This roadmap outlines the transition from classical asymmetric cryptography (RSA, ECC) to NIST-standardized quantum-resistant algorithms.
 
 ## 1. Cryptographic Inventory (Current State)
 - **Symmetric**: AES-256-CBC (Fernet) - *Quantum-Safe (requires 256-bit keys)*.

--- a/loadtest/README.md
+++ b/loadtest/README.md
@@ -1,4 +1,4 @@
-# Load Testing for Valdrix
+# Load Testing for Valdrics
 
 ## k6 (Recommended for CI/CD)
 

--- a/roadmap.md
+++ b/roadmap.md
@@ -1,4 +1,4 @@
-# Valdrix Roadmap (Internal)
+# Valdrics Roadmap (Internal)
 
 Last updated: **February 20, 2026**
 


### PR DESCRIPTION
## Summary
- rename user-facing documentation branding from Valdrix to Valdrics
- keep technical identifiers unchanged (for example `VALDRIX_*` env vars, alert names, and legacy audit artifact keys)
- docs/readme scope only; no application code changes

## Files
- README and deployment/roadmap docs
- dashboard/loadtest readmes
- docs/* references where branding text is user-facing