### PR TITLE
docs: sync Valdrics org links and add categorized workstream register

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -13,7 +13,7 @@
 
 ```bash
 # Clone and setup
-git clone https://github.com/Valdrix-AI/valdrix.git
+git clone https://github.com/Valdrics/valdrics.git
 cd valdrix
 
 # Install dependencies (using uv)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/Valdrix-AI/valdrix/actions/workflows/ci.yml"><img src="https://github.com/Valdrix-AI/valdrix/actions/workflows/ci.yml/badge.svg" alt="CI/CD Status" /></a>
+  <a href="https://github.com/Valdrics/valdrics/actions/workflows/ci.yml"><img src="https://github.com/Valdrics/valdrics/actions/workflows/ci.yml/badge.svg" alt="CI/CD Status" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-BSL%201.1-blue.svg" alt="License: BSL 1.1" /></a>
   <a href="https://python.org"><img src="https://img.shields.io/badge/Python-3.12-3776AB.svg?logo=python&logoColor=white" alt="Python 3.12" /></a>
   <a href="https://svelte.dev"><img src="https://img.shields.io/badge/Svelte-5-FF3E00.svg?logo=svelte&logoColor=white" alt="Svelte 5" /></a>
@@ -207,7 +207,7 @@ We're paranoid, so you don't have to be:
 ### 1. Clone & Configure
 
 ```bash
-git clone https://github.com/Valdrix-AI/valdrix.git
+git clone https://github.com/Valdrics/valdrics.git
 cd valdrix
 cp .env.example .env
 ```

--- a/docs/SOC2_CONTROLS.md
+++ b/docs/SOC2_CONTROLS.md
@@ -130,7 +130,7 @@ Use this as the foundation for SOC 2 Type 1 audit preparation.
 
 | Evidence Type | Location |
 |---------------|----------|
-| Code repository | github.com/Valdrix-AI/valdrix |
+| Code repository | github.com/Valdrics/valdrics |
 | CI/CD history | GitHub Actions logs |
 | Security scans | CI artifacts |
 | Access logs | Supabase dashboard |

--- a/docs/ops/workstream_categorization_2026-03-01.md
+++ b/docs/ops/workstream_categorization_2026-03-01.md
@@ -1,0 +1,28 @@
+# Workstream Categorization (2026-03-01)
+
+This register splits the current mixed local delta into merge-safe tracks.
+
+## Track A: Frontend landing decomposition and auth flow
+- Issue: https://github.com/Valdrics/valdrics/issues/199
+- Scope: landing component decomposition, public auth intent routing, onboarding/login/layout regressions, and landing e2e alignment.
+
+## Track B: Billing dunning and Paystack resilience
+- Issue: https://github.com/Valdrics/valdrics/issues/200
+- Scope: billing operations, dunning behavior, Paystack webhook/retry hardening, and coverage for failure/idempotency branches.
+
+## Track C: Governance cloud IAM auditing (Azure/GCP unified)
+- Issue: https://github.com/Valdrics/valdrics/issues/201
+- Scope: Azure RBAC + GCP IAM auditors, unified domain finding models, and audit payload stability.
+
+## Track D: Ops safety guardrails and infra policy checks
+- Issue: https://github.com/Valdrics/valdrics/issues/202
+- Scope: destructive-script safeguards, verification scripts, deployment channel checks, and Terraform/IAM policy updates.
+
+## Track E: Enforcement/scheduler/runtime resilience
+- Issue: https://github.com/Valdrics/valdrics/issues/203
+- Scope: enforcement service reliability branches, scheduler handling, hybrid scheduler behavior, circuit-breaker resilience, and safety bounds.
+
+## Merge strategy
+- Keep each track in a dedicated branch and PR.
+- Require track-local tests plus relevant contract checks before merge.
+- Avoid bundling multiple tracks into a single high-risk PR.


### PR DESCRIPTION
## Summary
- update remaining docs links from `Valdrix-AI/valdrix` to `Valdrics/valdrics`
- add a dated workstream categorization register for the current mixed delta
- map each categorized track to a dedicated GitHub issue (#199-#203)

## Issues
- #199 Frontend landing/auth track
- #200 Billing/Paystack track
- #201 Governance cloud IAM auditing track
- #202 Ops guardrails + infra checks track
- #203 Enforcement/scheduler/runtime resilience track

## Scope
Docs-only changes.