### PR TITLE
chore: categorize and consolidate all pending changes (2026-03-13)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,11 @@ SAAS_STRICT_INTEGRATIONS=false
 
 # AWS Credentials (optional - Valdrics uses STS AssumeRole primarily)
 AWS_DEFAULT_REGION=us-east-1
+# IAM principal ARN allowed to assume customer roles during AWS onboarding.
+# Example: arn:aws:iam::123456789012:role/ValdricsControlPlaneAssumeRole
+AWS_ASSUME_ROLE_TRUST_PRINCIPAL_ARN=
+# Optional public override for the AWS CloudFormation template.
+# Leave empty to serve the release-owned template from API_URL/api/v1/public/templates/aws/valdrics-role.yaml
 CLOUDFORMATION_TEMPLATE_URL=
 
 # LLM Provider (options: openai, claude, google, groq)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,8 @@ env:
 
 jobs:
   # JOB 1: QUALITY ASSURANCE
-  test:
-    name: Run Unit Tests
+  quality:
+    name: Backend Quality Checks
     runs-on: ubuntu-24.04
     env:
       # Default test-runtime contract (step-level env can override as needed).
@@ -154,9 +154,144 @@ jobs:
       - name: Enforce Frontend Module Size Budget
         run: uv run python3 scripts/verify_frontend_module_size_budget.py
 
-      - name: Run Pytest with Coverage
+  pytest:
+    name: Backend Pytest Shard ${{ matrix.shard_id }}
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - shard_id: "1"
+            paths: >-
+              tests/api
+              tests/billing
+              tests/contract
+              tests/core
+              tests/integration
+              tests/security
+              tests/unit/api
+              tests/unit/connections
+              tests/unit/db
+              tests/unit/lead_gen
+              tests/unit/models
+              tests/unit/ops
+              tests/unit/reporting
+              tests/unit/schemas
+              tests/unit/scripts
+              tests/unit/test_hard_cap_service.py
+              tests/unit/test_main_basic.py
+              tests/unit/test_main_coverage.py
+              tests/unit/test_pricing_phase36.py
+          - shard_id: "2"
+            paths: >-
+              tests/unit/analysis
+              tests/unit/core
+              tests/unit/notifications
+              tests/unit/shared
+          - shard_id: "3"
+            paths: >-
+              tests/governance
+              tests/unit/governance
+              tests/unit/remediation
+              tests/unit/services
+              tests/unit/tasks
+          - shard_id: "4"
+            paths: >-
+              tests/unit/adapters
+              tests/unit/enforcement
+              tests/unit/llm
+              tests/unit/modules
+              tests/unit/optimization
+              tests/unit/supply_chain
+              tests/unit/zombies
+    env:
+      ENVIRONMENT: "development"
+      TESTING: "true"
+      DEBUG: "false"
+      DB_SSL_MODE: "require"
+      DATABASE_URL: "sqlite+aiosqlite:///:memory:"
+      CSRF_SECRET_KEY: "ci-csrf-secret-key-32-chars-min-000000"
+      ENCRYPTION_KEY: "ci-encryption-key-32-chars-min-00000000"
+      KDF_SALT: "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY="
+      SUPABASE_JWT_SECRET: "ci-supabase-jwt-secret-32-chars-0000"
+      ENFORCEMENT_APPROVAL_TOKEN_SECRET: "ci-enforcement-approval-secret-0000000000"
+      ENFORCEMENT_EXPORT_SIGNING_SECRET: "ci-enforcement-export-signing-secret-0000"
+      ADMIN_API_KEY: "ci-admin-api-key-32-chars-min-0000000"
+      TRUST_PROXY_HEADERS: "true"
+      TRUSTED_PROXY_HOPS: "1"
+      TRUSTED_PROXY_CIDRS: '["127.0.0.1/32"]'
+      AWS_ACCESS_KEY_ID: "testing"
+      AWS_SECRET_ACCESS_KEY: "testing"
+      AWS_DEFAULT_REGION: "us-east-1"
+      GROQ_API_KEY: "testing"
+      CODECARBON_LOG_LEVEL: "info"
+      COVERAGE_FILE: "reports/coverage/.coverage.${{ matrix.shard_id }}"
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+        with:
+          enable-cache: true
+          version: ${{ env.UV_VERSION }}
+
+      - name: Install Dependencies
+        run: uv sync --locked --dev
+
+      - name: Run Pytest Shard with Coverage Data
         run: |
-          uv run pytest -v --cov=app --cov-report=xml --cov-report=term-missing
+          mkdir -p reports/coverage
+          uv run pytest -q --cov=app --cov-report= ${{ matrix.paths }}
+
+      - name: Upload Coverage Data
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: backend-coverage-${{ matrix.shard_id }}
+          path: ${{ env.COVERAGE_FILE }}
+          include-hidden-files: true
+          if-no-files-found: ignore
+          retention-days: 7
+
+  test:
+    name: Backend Test Aggregate / Coverage
+    runs-on: ubuntu-24.04
+    needs: [pytest]
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+        with:
+          enable-cache: true
+          version: ${{ env.UV_VERSION }}
+
+      - name: Install Dependencies
+        run: uv sync --locked --dev
+
+      - name: Download Coverage Data
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          pattern: backend-coverage-*
+          path: reports/coverage/shards
+          merge-multiple: true
+
+      - name: Combine Coverage Data
+        run: |
+          uv run coverage combine reports/coverage/shards
+          uv run coverage xml -o coverage.xml
 
       - name: Enforce Global Coverage Gate (90%)
         run: |
@@ -320,7 +455,7 @@ jobs:
 
   performance-health-gate:
     name: Performance Gate - Health
-    needs: [test]
+    needs: [quality, test]
     uses: ./.github/workflows/performance-gate.yml
     with:
       url: "http://127.0.0.1:8000"
@@ -334,7 +469,7 @@ jobs:
 
   performance-dashboard-gate:
     name: Performance Gate - Dashboard
-    needs: [test, dashboard-quality]
+    needs: [quality, test, dashboard-quality]
     uses: ./.github/workflows/performance-gate.yml
     with:
       url: "http://127.0.0.1:8000"
@@ -350,7 +485,7 @@ jobs:
 
   performance-ops-gate:
     name: Performance Gate - Ops
-    needs: [test]
+    needs: [quality, test]
     uses: ./.github/workflows/performance-gate.yml
     with:
       url: "http://127.0.0.1:8000"
@@ -368,7 +503,7 @@ jobs:
   emissions:
     name: Carbon Footprint Report
     runs-on: ubuntu-24.04
-    needs: [test]
+    needs: [quality, test]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - name: Checkout Code
@@ -498,7 +633,7 @@ jobs:
   enterprise-tdd-quality-gate:
     name: Enterprise TDD Quality Gate
     runs-on: ubuntu-24.04
-    needs: [test, migration-smoke, type-check, security]
+    needs: [quality, test, migration-smoke, type-check, security]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - name: Checkout Code
@@ -615,7 +750,7 @@ jobs:
   dashboard-browser-gates:
     name: Dashboard ${{ matrix.label }}
     runs-on: ubuntu-24.04
-    needs: [test]
+    needs: [quality, test]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     env:
       PUBLIC_API_URL: "https://api.example.com/api/v1"

--- a/app/modules/governance/api/v1/public.py
+++ b/app/modules/governance/api/v1/public.py
@@ -8,8 +8,8 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, Literal
 
 import structlog
-from fastapi import APIRouter, Depends, HTTPException, Request
-from fastapi.responses import JSONResponse
+from fastapi import APIRouter, Depends, HTTPException, Request, Response
+from fastapi.responses import JSONResponse, PlainTextResponse
 from pydantic import BaseModel, ConfigDict, EmailStr, Field
 from sqlalchemy import select
 from sqlalchemy.exc import SQLAlchemyError
@@ -21,6 +21,7 @@ from app.models.sso_domain_mapping import SsoDomainMapping
 from app.modules.governance.api.v1.public_marketing import (
     router as marketing_router,
 )
+from app.shared.connections.aws import AWSConnectionService
 from app.shared.core.pricing import FeatureFlag, is_feature_enabled, normalize_tier
 from app.shared.lead_gen.assessment import FreeAssessmentService
 from app.shared.core.rate_limit import auth_limit, rate_limit
@@ -263,6 +264,33 @@ async def get_csrf_token(request: Request) -> JSONResponse:
     response = JSONResponse(content={"csrf_token": token})
     csrf.set_csrf_cookie(signed_token, response)
     return response
+
+
+@router.get("/templates/aws/valdrics-role.yaml")
+@rate_limit("30/minute")
+async def get_public_aws_setup_template(request: Request) -> Response:
+    """Serve the release-owned AWS CloudFormation template used by onboarding."""
+    try:
+        template = AWSConnectionService.get_cloudformation_template_yaml()
+    except RuntimeError as exc:
+        raise HTTPException(
+            status_code=503,
+            detail="AWS setup templates are not available in the current runtime.",
+        ) from exc
+
+    etag = hashlib.sha256(template.encode("utf-8")).hexdigest()
+    headers = {
+        "Cache-Control": "public, max-age=300",
+        "ETag": etag,
+        "X-Content-Type-Options": "nosniff",
+    }
+    if request.headers.get("if-none-match", "").strip() == etag:
+        return Response(status_code=304, headers=headers)
+    return PlainTextResponse(
+        content=template,
+        media_type="application/x-yaml",
+        headers=headers,
+    )
 
 
 @router.post("/assessment", response_model=None)

--- a/app/modules/governance/api/v1/settings/connections_helpers.py
+++ b/app/modules/governance/api/v1/settings/connections_helpers.py
@@ -63,6 +63,42 @@ def check_multi_cloud_tier(user: CurrentUser) -> PricingTier:
     return current_plan
 
 
+def _enforce_aws_org_discovery_tier(
+    current_plan: PricingTier, user: CurrentUser
+) -> None:
+    allowed_plans = {
+        PricingTier.GROWTH,
+        PricingTier.PRO,
+        PricingTier.ENTERPRISE,
+    }
+
+    if current_plan in allowed_plans:
+        return
+
+    logger.warning(
+        "tier_gate_denied_aws_org_discovery",
+        tenant_id=str(user.tenant_id),
+        plan=current_plan.value,
+        required="growth",
+    )
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail=(
+            "AWS organization discovery requires 'Growth' plan or higher. "
+            f"Current plan: {current_plan.value}"
+        ),
+    )
+
+
+def check_aws_org_discovery_tier(user: CurrentUser) -> PricingTier:
+    """
+    Ensure AWS Organizations discovery is available for the tenant tier.
+    """
+    current_plan = normalize_tier(getattr(user, "tier", PricingTier.FREE))
+    _enforce_aws_org_discovery_tier(current_plan, user)
+    return current_plan
+
+
 def check_cloud_plus_tier(user: CurrentUser) -> PricingTier:
     """
     Ensure Cloud+ connectors are available for the current tenant tier.

--- a/app/modules/governance/api/v1/settings/connections_setup_aws_discovery.py
+++ b/app/modules/governance/api/v1/settings/connections_setup_aws_discovery.py
@@ -27,6 +27,7 @@ from app.shared.connections.organizations import OrganizationsDiscoveryService
 from app.modules.governance.api.v1.settings.connections_helpers import (
     _enforce_connection_limit,
     _require_tenant_id,
+    check_aws_org_discovery_tier,
     check_idp_deep_scan_tier,
 )
 from app.modules.governance.api.v1.settings.connections_setup_snippets import (
@@ -85,6 +86,8 @@ async def create_aws_connection(
     db: AsyncSession = Depends(get_db),
 ) -> AWSConnection:
     tenant_id = _require_tenant_id(current_user)
+    if data.is_management_account:
+        check_aws_org_discovery_tier(current_user)
 
     existing = await db.scalar(
         select(AWSConnection.id).where(
@@ -202,6 +205,7 @@ async def sync_aws_org(
     db: AsyncSession = Depends(get_db),
 ) -> dict[str, Any]:
     tenant_id = _require_tenant_id(current_user)
+    check_aws_org_discovery_tier(current_user)
     result = await db.execute(
         select(AWSConnection).where(
             AWSConnection.id == connection_id, AWSConnection.tenant_id == tenant_id
@@ -221,6 +225,7 @@ async def list_discovered_accounts(
     db: AsyncSession = Depends(get_db),
 ) -> list[DiscoveredAccount]:
     tenant_id = _require_tenant_id(current_user)
+    check_aws_org_discovery_tier(current_user)
 
     res = await db.execute(
         select(AWSConnection.id).where(
@@ -246,7 +251,7 @@ async def link_discovered_account(
     db: AsyncSession = Depends(get_db),
 ) -> dict[str, Any]:
     tenant_id = _require_tenant_id(current_user)
-    plan = normalize_tier(getattr(current_user, "tier", PricingTier.FREE))
+    plan = check_aws_org_discovery_tier(current_user)
 
     stmt = (
         select(DiscoveredAccount, AWSConnection)

--- a/app/modules/governance/api/v1/settings/connections_setup_snippets.py
+++ b/app/modules/governance/api/v1/settings/connections_setup_snippets.py
@@ -4,7 +4,7 @@ Connection setup snippet endpoints (provider onboarding templates/instructions).
 
 from typing import Any
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
 
 from app.models.aws_connection import AWSConnection
 from app.schemas.connections import TemplateResponse
@@ -26,7 +26,13 @@ async def get_aws_setup_templates(
     """Get CloudFormation/Terraform templates and Magic Link for AWS setup."""
     _require_tenant_id(current_user)
     external_id = AWSConnection.generate_external_id()
-    templates = AWSConnectionService.get_setup_templates(external_id)
+    try:
+        templates = AWSConnectionService.get_setup_templates(external_id)
+    except RuntimeError as exc:
+        raise HTTPException(
+            status_code=503,
+            detail="AWS setup templates are not available in the current runtime.",
+        ) from exc
     return TemplateResponse(**templates)
 
 

--- a/app/modules/governance/api/v1/settings/identity_diagnostics_ops.py
+++ b/app/modules/governance/api/v1/settings/identity_diagnostics_ops.py
@@ -4,6 +4,8 @@ from datetime import datetime
 from typing import Any, Callable
 from urllib.parse import urlparse
 
+from app.shared.core.datetime_ops import as_utc_datetime_or_none
+
 
 def build_identity_diagnostics_payload(
     *,
@@ -63,7 +65,7 @@ def build_identity_diagnostics_payload(
     scim_available = is_feature_enabled_fn(tier, scim_feature_flag)
     scim_has_token = bool(getattr(identity, "scim_bearer_token", None))
     scim_bidx_present = bool(getattr(identity, "scim_token_bidx", None))
-    scim_last_rotated = getattr(identity, "scim_last_rotated_at", None)
+    scim_last_rotated = as_utc_datetime_or_none(getattr(identity, "scim_last_rotated_at", None))
     token_age_days: int | None = None
     if scim_last_rotated:
         token_age_days = max(

--- a/app/modules/governance/api/v1/settings/identity_settings_ops.py
+++ b/app/modules/governance/api/v1/settings/identity_settings_ops.py
@@ -6,7 +6,39 @@ from uuid import UUID, uuid4
 
 from fastapi import HTTPException, status
 from sqlalchemy import delete, select
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.shared.core.async_utils import maybe_await
+
+IDENTITY_AUDIT_WRITE_RECOVERABLE_EXCEPTIONS = (
+    SQLAlchemyError,
+    RuntimeError,
+    TypeError,
+    ValueError,
+    AttributeError,
+)
+
+
+async def _write_identity_audit_or_raise(
+    *,
+    audit: Any,
+    db: AsyncSession,
+    logger: Any,
+    tenant_id: Any,
+    failure_event: str,
+    failure_detail: str,
+    **kwargs: Any,
+) -> None:
+    try:
+        await audit.log(**kwargs)
+    except IDENTITY_AUDIT_WRITE_RECOVERABLE_EXCEPTIONS as exc:
+        await maybe_await(db.rollback())
+        logger.exception(failure_event, tenant_id=str(tenant_id))
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=failure_detail,
+        ) from exc
 
 
 def build_identity_response_payload(identity: Any) -> dict[str, Any]:
@@ -176,7 +208,13 @@ async def update_identity_settings_route(
         tenant_id=cast(UUID, current_user.tenant_id),
         correlation_id=str(uuid4()),
     )
-    await audit.log(
+    await _write_identity_audit_or_raise(
+        audit=audit,
+        db=db,
+        logger=logger,
+        tenant_id=current_user.tenant_id,
+        failure_event="identity_settings_audit_failed",
+        failure_detail="Failed to persist identity settings audit event.",
         event_type=audit_event_type.IDENTITY_SETTINGS_UPDATED,
         actor_id=current_user.id,
         actor_email=current_user.email,
@@ -270,7 +308,13 @@ async def rotate_scim_token_route(
         tenant_id=cast(UUID, current_user.tenant_id),
         correlation_id=str(uuid4()),
     )
-    await audit.log(
+    await _write_identity_audit_or_raise(
+        audit=audit,
+        db=db,
+        logger=logger,
+        tenant_id=current_user.tenant_id,
+        failure_event="identity_scim_token_audit_failed",
+        failure_detail="Failed to persist SCIM token audit event.",
         event_type=audit_event_type.SCIM_TOKEN_ROTATED,
         actor_id=current_user.id,
         actor_email=current_user.email,

--- a/app/modules/governance/domain/jobs/metrics.py
+++ b/app/modules/governance/domain/jobs/metrics.py
@@ -10,6 +10,7 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.background_job import BackgroundJob, JobStatus
+from app.shared.core.datetime_ops import as_utc_datetime
 
 
 TERMINAL_JOB_STATUSES = {
@@ -66,12 +67,22 @@ async def compute_job_slo(
         latest_completed: datetime | None = None
         durations: list[float] = []
         for j in items:
-            if j.completed_at and (
-                latest_completed is None or j.completed_at > latest_completed
+            completed_at = (
+                as_utc_datetime(j.completed_at)
+                if isinstance(j.completed_at, datetime)
+                else None
+            )
+            started_at = (
+                as_utc_datetime(j.started_at)
+                if isinstance(j.started_at, datetime)
+                else None
+            )
+            if completed_at and (
+                latest_completed is None or completed_at > latest_completed
             ):
-                latest_completed = j.completed_at
-            if j.started_at and j.completed_at:
-                delta = (j.completed_at - j.started_at).total_seconds()
+                latest_completed = completed_at
+            if started_at and completed_at:
+                delta = (completed_at - started_at).total_seconds()
                 if delta >= 0:
                     durations.append(delta)
 
@@ -150,10 +161,7 @@ async def compute_job_backlog_snapshot(
     oldest_pending_age_seconds: float | None = None
     oldest_pending_scheduled_for: str | None = None
     if isinstance(oldest_pending, datetime):
-        # SQLite often returns naive datetimes even when columns are timezone-aware.
-        # Treat naive values as UTC for consistent backlog age math.
-        if oldest_pending.tzinfo is None:
-            oldest_pending = oldest_pending.replace(tzinfo=timezone.utc)
+        oldest_pending = as_utc_datetime(oldest_pending)
         oldest_pending_scheduled_for = oldest_pending.isoformat()
         oldest_pending_age_seconds = max(0.0, (now - oldest_pending).total_seconds())
 

--- a/app/modules/governance/domain/scheduler/cohorts.py
+++ b/app/modules/governance/domain/scheduler/cohorts.py
@@ -1,7 +1,9 @@
 from enum import Enum
 from datetime import datetime, timezone
 from typing import cast
+
 from app.models.tenant import Tenant
+from app.shared.core.datetime_ops import as_utc_datetime
 
 
 class TenantCohort(str, Enum):
@@ -50,7 +52,7 @@ def get_tenant_cohort(
 
     # Check for dormancy (inactive > 7 days)
     if last_active:
-        days_inactive = (datetime.now(timezone.utc) - last_active).days
+        days_inactive = (datetime.now(timezone.utc) - as_utc_datetime(last_active)).days
         if days_inactive >= 7:
             return TenantCohort.DORMANT
 

--- a/app/modules/governance/domain/security/audit_log.py
+++ b/app/modules/governance/domain/security/audit_log.py
@@ -26,6 +26,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 import structlog
 
 from app.models._encryption import get_encryption_key
+from app.shared.core.async_utils import maybe_await
 from app.shared.db.base import Base, get_partition_args
 from sqlalchemy_utils import StringEncryptedType
 from sqlalchemy_utils.types.encrypted.encrypted_type import AesEngine
@@ -405,7 +406,7 @@ class AuditLogger(_AuditLoggerBase):
         # AsyncSession.add is sync, but AsyncMock-based tests may return awaitables.
         if inspect.isawaitable(add_result):
             await add_result
-        await self.db.flush()
+        await maybe_await(cast(Any, self.db).flush())
 
         # Also log to structured logger for real-time monitoring
         logger.info(
@@ -471,7 +472,7 @@ class SystemAuditLogger(_AuditLoggerBase):
         add_result = cast(Any, self.db).add(entry)
         if inspect.isawaitable(add_result):
             await add_result
-        await self.db.flush()
+        await maybe_await(cast(Any, self.db).flush())
 
         logger.info(
             "system_audit_event",

--- a/app/modules/optimization/adapters/azure/plugins/rightsizing.py
+++ b/app/modules/optimization/adapters/azure/plugins/rightsizing.py
@@ -28,7 +28,9 @@ def _resolve_azure_error_base() -> type[Exception]:
         from azure.core.exceptions import AzureError
     except ImportError:  # pragma: no cover - fallback for SDK-mocked test envs
         return Exception
-    return AzureError
+    if isinstance(AzureError, type) and issubclass(AzureError, Exception):
+        return AzureError
+    return Exception
 
 CPU_MAX_THRESHOLD_PERCENT = 10.0
 SKIPPED_VM_SIZE_TOKENS: tuple[str, ...] = ("standard_b", "basic_a")

--- a/app/modules/reporting/api/v1/costs_metrics.py
+++ b/app/modules/reporting/api/v1/costs_metrics.py
@@ -20,6 +20,7 @@ from app.models.remediation import (
 from app.models.unit_economics_settings import UnitEconomicsSettings
 from app.shared.core.async_utils import maybe_await
 from app.shared.core.connection_state import is_connection_active
+from app.shared.core.datetime_ops import as_utc_datetime
 
 from .costs_models import (
     AcceptanceKpiMetric,
@@ -228,18 +229,28 @@ async def compute_ingestion_sla_metrics(
 
     for job in jobs:
         total_jobs += 1
+        completed_at = (
+            as_utc_datetime(job.completed_at)
+            if isinstance(job.completed_at, datetime)
+            else None
+        )
+        started_at = (
+            as_utc_datetime(job.started_at)
+            if isinstance(job.started_at, datetime)
+            else None
+        )
         if job.status == JobStatus.COMPLETED.value:
             successful_jobs += 1
         if job.status in {JobStatus.FAILED.value, JobStatus.DEAD_LETTER.value}:
             failed_jobs += 1
 
-        if job.completed_at and (
-            latest_completed_at_dt is None or job.completed_at > latest_completed_at_dt
+        if completed_at and (
+            latest_completed_at_dt is None or completed_at > latest_completed_at_dt
         ):
-            latest_completed_at_dt = job.completed_at
+            latest_completed_at_dt = completed_at
 
-        if job.started_at and job.completed_at:
-            duration = (job.completed_at - job.started_at).total_seconds()
+        if started_at and completed_at:
+            duration = (completed_at - started_at).total_seconds()
             if duration >= 0:
                 duration_samples.append(duration)
 

--- a/app/modules/reporting/api/v1/savings.py
+++ b/app/modules/reporting/api/v1/savings.py
@@ -56,6 +56,27 @@ def _require_tenant_id(user: CurrentUser) -> UUID:
     return user.tenant_id
 
 
+def _query_default(value: Any) -> Any:
+    default = getattr(value, "default", value)
+    return value if default is ... else default
+
+
+def _coerce_query_int(value: Any) -> int:
+    candidate = _query_default(value)
+    if isinstance(candidate, bool):
+        return int(candidate)
+    return int(candidate)
+
+
+def _coerce_query_bool(value: Any) -> bool:
+    candidate = _query_default(value)
+    if isinstance(candidate, bool):
+        return candidate
+    if isinstance(candidate, str):
+        return candidate.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(candidate)
+
+
 @router.get("/proof", response_model=SavingsProofResponse)
 async def get_savings_proof(
     start_date: date = Query(default_factory=lambda: date.today() - timedelta(days=30)),
@@ -112,6 +133,7 @@ async def get_savings_proof_drilldown(
     tier = normalize_tier(getattr(current_user, "tier", PricingTier.FREE))
     normalized_provider = provider.strip().lower() if provider else None
     service = SavingsProofService(db)
+    normalized_limit = _coerce_query_int(limit)
     try:
         payload = await service.drilldown(
             tenant_id=tenant_id,
@@ -120,7 +142,7 @@ async def get_savings_proof_drilldown(
             end_date=end_date,
             provider=normalized_provider,
             dimension=dimension,
-            limit=int(limit),
+            limit=normalized_limit,
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -166,6 +188,12 @@ async def compute_realized_savings(
     tenant_id = _require_tenant_id(current_user)
     if start_date > end_date:
         raise HTTPException(status_code=400, detail="start_date must be <= end_date")
+    normalized_baseline_days = _coerce_query_int(baseline_days)
+    normalized_measurement_days = _coerce_query_int(measurement_days)
+    normalized_gap_days = _coerce_query_int(gap_days)
+    normalized_monthly_multiplier_days = _coerce_query_int(monthly_multiplier_days)
+    normalized_limit = _coerce_query_int(limit)
+    normalized_require_final = _coerce_query_bool(require_final)
 
     window_start = datetime.combine(start_date, time.min, tzinfo=timezone.utc)
     window_end = datetime.combine(end_date, time.max, tzinfo=timezone.utc)
@@ -177,8 +205,11 @@ async def compute_realized_savings(
         RemediationRequest.executed_at >= window_start,
         RemediationRequest.executed_at <= window_end,
     ).order_by(RemediationRequest.executed_at.desc(), RemediationRequest.created_at.desc())
-    stmt = stmt.limit(int(limit))
-    remediations = list((await db.execute(stmt)).scalars())
+    stmt = stmt.limit(normalized_limit)
+    scalar_result = (await db.execute(stmt)).scalars()
+    remediations = list(
+        scalar_result.all() if hasattr(scalar_result, "all") else scalar_result
+    )
 
     service = RealizedSavingsService(db)
     computed = 0
@@ -189,11 +220,11 @@ async def compute_realized_savings(
             event = await service.compute_for_request(
                 tenant_id=tenant_id,
                 request=request,
-                baseline_days=int(baseline_days),
-                measurement_days=int(measurement_days),
-                gap_days=int(gap_days),
-                monthly_multiplier_days=int(monthly_multiplier_days),
-                require_final=bool(require_final),
+                baseline_days=normalized_baseline_days,
+                measurement_days=normalized_measurement_days,
+                gap_days=normalized_gap_days,
+                monthly_multiplier_days=normalized_monthly_multiplier_days,
+                require_final=normalized_require_final,
             )
             if event is None:
                 skipped += 1
@@ -257,6 +288,7 @@ async def list_realized_savings_events(
     tenant_id = _require_tenant_id(current_user)
     if start_date > end_date:
         raise HTTPException(status_code=400, detail="start_date must be <= end_date")
+    normalized_limit = _coerce_query_int(limit)
 
     window_start = datetime.combine(start_date, time.min, tzinfo=timezone.utc)
     window_end = datetime.combine(end_date, time.max, tzinfo=timezone.utc)
@@ -278,12 +310,13 @@ async def list_realized_savings_events(
             RealizedSavingsEvent.realized_monthly_savings_usd.desc(),
             RealizedSavingsEvent.computed_at.desc(),
         )
-        .limit(int(limit))
+        .limit(normalized_limit)
     )
     if normalized_provider:
         stmt = stmt.where(RealizedSavingsEvent.provider == normalized_provider)
 
-    rows = list(await db.execute(stmt))
+    execute_result = await db.execute(stmt)
+    rows = list(execute_result.all() if hasattr(execute_result, "all") else execute_result)
     events: list[RealizedSavingsEventResponse] = []
     for event, executed_at in rows:
         events.append(

--- a/app/modules/reporting/domain/carbon_scheduler.py
+++ b/app/modules/reporting/domain/carbon_scheduler.py
@@ -108,7 +108,7 @@ WATTTIME_REGION_COORDS = {
 }
 
 
-def validate_carbon_data_freshness() -> bool:
+def validate_carbon_data_freshness(*, strict: bool = True) -> bool:
     """
     BE-CARBON-1: Validate that carbon intensity data is fresh.
     Raises CarbonDataStaleError if data is outdated.
@@ -119,13 +119,20 @@ def validate_carbon_data_freshness() -> bool:
 
     if age > _CARBON_DATA_MAX_AGE_DAYS:
         error_msg = f"Carbon intensity data is {age} days old (max: {_CARBON_DATA_MAX_AGE_DAYS}). Update REGION_CARBON_PROFILES."
-        logger.error(
+        log_kwargs = {
+            "last_updated": _CARBON_DATA_LAST_UPDATED.isoformat(),
+            "age_days": age,
+            "max_age_days": _CARBON_DATA_MAX_AGE_DAYS,
+        }
+        if strict:
+            logger.error("carbon_data_stale", **log_kwargs)
+            raise ValueError(error_msg)
+        logger.warning(
             "carbon_data_stale",
-            last_updated=_CARBON_DATA_LAST_UPDATED.isoformat(),
-            age_days=age,
-            max_age_days=_CARBON_DATA_MAX_AGE_DAYS,
+            fallback_mode="static_profile_degraded_read",
+            **log_kwargs,
         )
-        raise ValueError(error_msg)
+        return False
 
     return True
 
@@ -165,7 +172,7 @@ class CarbonAwareScheduler:
             return CarbonIntensity.MEDIUM  # Unknown = medium
 
         # BE-CARBON-1: Ensure data is fresh
-        validate_carbon_data_freshness()
+        validate_carbon_data_freshness(strict=False)
 
         # Logic for real-time calculation would go here if API key is present
         # For now, we simulate current intensity based on current UTC hour
@@ -224,7 +231,7 @@ class CarbonAwareScheduler:
         Fallback: High-fidelity diurnal simulation.
         """
         # BE-CARBON-1: Ensure data is fresh
-        validate_carbon_data_freshness()
+        validate_carbon_data_freshness(strict=False)
 
         profile = REGION_CARBON_PROFILES.get(region)
         if not profile:

--- a/app/modules/reporting/domain/tenant_growth_funnel.py
+++ b/app/modules/reporting/domain/tenant_growth_funnel.py
@@ -33,6 +33,20 @@ _STAGE_FIELD_MAP: dict[TenantGrowthFunnelStage, str] = {
     "paid_activated": "paid_activated_at",
 }
 
+_SNAPSHOT_DATETIME_FIELDS: tuple[str, ...] = (
+    "first_touch_at",
+    "last_touch_at",
+    "tenant_onboarded_at",
+    "first_connection_verified_at",
+    "pricing_viewed_at",
+    "checkout_started_at",
+    "first_value_activated_at",
+    "pql_qualified_at",
+    "paid_activated_at",
+    "created_at",
+    "updated_at",
+)
+
 
 @dataclass(frozen=True, slots=True)
 class TenantGrowthFunnelAttribution:
@@ -223,6 +237,18 @@ def _build_update_values(
     return values
 
 
+def _normalize_snapshot_datetimes(
+    snapshot: TenantGrowthFunnelSnapshot,
+) -> TenantGrowthFunnelSnapshot:
+    for field_name in _SNAPSHOT_DATETIME_FIELDS:
+        setattr(
+            snapshot,
+            field_name,
+            _normalize_timestamp(getattr(snapshot, field_name, None)),
+        )
+    return snapshot
+
+
 async def record_tenant_growth_funnel_stage(
     db: AsyncSession,
     *,
@@ -265,7 +291,7 @@ async def record_tenant_growth_funnel_stage(
         .values(
             pql_qualified_at=func.coalesce(
                 TenantGrowthFunnelSnapshot.pql_qualified_at,
-                normalized_time,
+                TenantGrowthFunnelSnapshot.first_value_activated_at,
             ),
             updated_at=datetime.now(timezone.utc),
         )
@@ -282,4 +308,4 @@ async def record_tenant_growth_funnel_stage(
     ).scalar_one()
     if commit:
         await db.commit()
-    return snapshot
+    return _normalize_snapshot_datetimes(snapshot)

--- a/app/shared/adapters/hybrid.py
+++ b/app/shared/adapters/hybrid.py
@@ -128,6 +128,8 @@ class HybridAdapter(HybridNativeConnectorMixin, BaseAdapter):
             raise ExternalAPIError("Missing API token for hybrid native connector")
         if isinstance(token, SecretStr):
             resolved = token.get_secret_value()
+        elif hasattr(token, "get_secret_value"):
+            resolved = token.get_secret_value()
         elif isinstance(token, str):
             resolved = token
         else:
@@ -141,6 +143,8 @@ class HybridAdapter(HybridNativeConnectorMixin, BaseAdapter):
         if token is None:
             raise ExternalAPIError("Missing API secret for hybrid native connector")
         if isinstance(token, SecretStr):
+            resolved = token.get_secret_value()
+        elif hasattr(token, "get_secret_value"):
             resolved = token.get_secret_value()
         elif isinstance(token, str):
             resolved = token

--- a/app/shared/adapters/license.py
+++ b/app/shared/adapters/license.py
@@ -101,6 +101,8 @@ class LicenseAdapter(BaseAdapter):
             raise ExternalAPIError("Missing API token for license native connector")
         if isinstance(token, SecretStr):
             resolved = token.get_secret_value()
+        elif hasattr(token, "get_secret_value"):
+            resolved = token.get_secret_value()
         elif isinstance(token, str):
             resolved = token
         else:

--- a/app/shared/adapters/platform.py
+++ b/app/shared/adapters/platform.py
@@ -102,6 +102,8 @@ class PlatformAdapter(PlatformNativeConnectorMixin, BaseAdapter):
             raise ExternalAPIError("Missing API token for platform native connector")
         if isinstance(token, SecretStr):
             resolved = token.get_secret_value()
+        elif hasattr(token, "get_secret_value"):
+            resolved = token.get_secret_value()
         elif isinstance(token, str):
             resolved = token
         else:
@@ -115,6 +117,8 @@ class PlatformAdapter(PlatformNativeConnectorMixin, BaseAdapter):
         if token is None:
             raise ExternalAPIError("Missing API secret for platform native connector")
         if isinstance(token, SecretStr):
+            resolved = token.get_secret_value()
+        elif hasattr(token, "get_secret_value"):
             resolved = token.get_secret_value()
         elif isinstance(token, str):
             resolved = token

--- a/app/shared/connections/aws.py
+++ b/app/shared/connections/aws.py
@@ -1,10 +1,13 @@
+from pathlib import Path
+from typing import Any
 from urllib.parse import quote
 from uuid import UUID
-from sqlalchemy.ext.asyncio import AsyncSession
+
 from sqlalchemy import select
 from sqlalchemy.exc import SQLAlchemyError
-from typing import Any
+from sqlalchemy.ext.asyncio import AsyncSession
 import structlog
+
 from app.models.aws_connection import AWSConnection
 from app.shared.adapters.aws_multitenant import MultiTenantAWSAdapter
 from app.shared.adapters.aws_utils import map_aws_connection_to_credentials
@@ -22,6 +25,11 @@ AWS_CONNECTION_VERIFY_RECOVERABLE_EXCEPTIONS = (
     KeyError,
     LookupError,
 )
+_CLOUDFORMATION_TEMPLATE_PATH = (
+    Path(__file__).resolve().parents[3] / "cloudformation" / "valdrics-role.yaml"
+)
+_CLOUDFORMATION_PUBLIC_PATH = "/api/v1/public/templates/aws/valdrics-role.yaml"
+_TRUST_PRINCIPAL_TOKEN = "__VALDRICS_ASSUME_ROLE_TRUST_PRINCIPAL_ARN__"
 
 
 class AWSConnectionService:
@@ -38,31 +46,80 @@ class AWSConnectionService:
         return MultiTenantAWSAdapter(map_aws_connection_to_credentials(connection))
 
     @staticmethod
-    def get_setup_templates(external_id: str) -> dict[str, Any]:
-        """
-        Returns CloudFormation and Terraform snippets for provisioning the Valdrics role.
-        """
-        settings = get_settings()
-        template_url = str(getattr(settings, "CLOUDFORMATION_TEMPLATE_URL", "") or "").strip()
-        if not template_url:
-            raise RuntimeError("CLOUDFORMATION_TEMPLATE_URL must be configured for AWS setup templates")
-
-        configured_region = str(getattr(settings, "AWS_DEFAULT_REGION", "") or "").strip()
+    def _resolve_cloudformation_console_region(settings_obj: Any) -> str:
+        configured_region = str(
+            getattr(settings_obj, "AWS_DEFAULT_REGION", "") or ""
+        ).strip()
         supported_regions = {
             str(region).strip()
-            for region in getattr(settings, "AWS_SUPPORTED_REGIONS", [])
+            for region in getattr(settings_obj, "AWS_SUPPORTED_REGIONS", [])
             if str(region).strip()
         }
         if configured_region and (
             not supported_regions or configured_region in supported_regions
         ):
-            console_region = configured_region
-        else:
-            console_region = "us-east-1"
+            return configured_region
+        return "us-east-1"
+
+    @staticmethod
+    def _resolve_assume_role_trust_principal_arn(settings_obj: Any) -> str:
+        principal_arn = str(
+            getattr(settings_obj, "AWS_ASSUME_ROLE_TRUST_PRINCIPAL_ARN", "") or ""
+        ).strip()
+        if not principal_arn:
+            raise RuntimeError(
+                "AWS_ASSUME_ROLE_TRUST_PRINCIPAL_ARN must be configured for AWS setup templates"
+            )
+        return principal_arn
+
+    @staticmethod
+    def get_cloudformation_template_yaml() -> str:
+        """Return the release-owned CloudFormation template with injected trust principal."""
+        settings = get_settings()
+        principal_arn = AWSConnectionService._resolve_assume_role_trust_principal_arn(
+            settings
+        )
+        if not _CLOUDFORMATION_TEMPLATE_PATH.exists():
+            raise RuntimeError(
+                "AWS setup template file is missing from the application release bundle"
+            )
+        template = _CLOUDFORMATION_TEMPLATE_PATH.read_text(encoding="utf-8")
+        if _TRUST_PRINCIPAL_TOKEN not in template:
+            raise RuntimeError(
+                "AWS setup template is missing the trust principal injection token"
+            )
+        return template.replace(_TRUST_PRINCIPAL_TOKEN, principal_arn, 1)
+
+    @staticmethod
+    def get_cloudformation_template_url() -> str:
+        """Return the public URL used by CloudFormation launch links."""
+        settings = get_settings()
+        configured = str(
+            getattr(settings, "CLOUDFORMATION_TEMPLATE_URL", "") or ""
+        ).strip()
+        if configured:
+            return configured
+        api_url = str(getattr(settings, "API_URL", "") or "").strip()
+        if not api_url:
+            raise RuntimeError(
+                "API_URL must be configured to derive the public AWS setup template URL"
+            )
+        return f"{api_url.rstrip('/')}{_CLOUDFORMATION_PUBLIC_PATH}"
+
+    @staticmethod
+    def get_setup_templates(external_id: str) -> dict[str, Any]:
+        """
+        Returns CloudFormation and Terraform snippets for provisioning the Valdrics role.
+        """
+        settings = get_settings()
+        template_url = AWSConnectionService.get_cloudformation_template_url()
+        console_region = AWSConnectionService._resolve_cloudformation_console_region(
+            settings
+        )
         encoded_template_url = quote(template_url, safe="")
         return {
             "external_id": external_id,
-            "cloudformation_yaml": template_url,
+            "cloudformation_yaml": AWSConnectionService.get_cloudformation_template_yaml(),
             "terraform_hcl": f'module "valdrics_connection" {{ source = "valdrics/aws-connection" external_id = "{external_id}" }}',
             "magic_link": (
                 "https://console.aws.amazon.com/cloudformation/home"

--- a/app/shared/core/config.py
+++ b/app/shared/core/config.py
@@ -1,8 +1,10 @@
 from functools import lru_cache
 from pathlib import Path
+import re
 import tempfile
 from threading import Lock
 from typing import Optional
+from urllib.parse import urlparse
 import structlog
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from pydantic import Field, field_validator, model_validator
@@ -139,9 +141,11 @@ class Settings(BaseSettings):
     AWS_ENDPOINT_URL: Optional[str] = (
         None  # Added for local testing (MotoServer/LocalStack)
     )
+    AWS_ASSUME_ROLE_TRUST_PRINCIPAL_ARN: Optional[str] = None
 
-    # CloudFormation Template (Configurable for S3/GitHub)
-    CLOUDFORMATION_TEMPLATE_URL: str = "https://raw.githubusercontent.com/valdrics/valdrics/main/cloudformation/valdrics-role.yaml"
+    # Optional override for a publicly reachable CloudFormation template URL.
+    # When empty, onboarding derives a release-owned public API URL from API_URL.
+    CLOUDFORMATION_TEMPLATE_URL: str = ""
 
     # Reload trigger: 2026-01-14
 
@@ -437,6 +441,41 @@ class Settings(BaseSettings):
             allowed_text = ", ".join(sorted(allowed))
             raise ValueError(f"ENVIRONMENT must be one of: {allowed_text}")
         return normalized
+
+    @field_validator("AWS_ASSUME_ROLE_TRUST_PRINCIPAL_ARN", mode="before")
+    @classmethod
+    def _normalize_aws_assume_role_trust_principal_arn(
+        cls, value: object
+    ) -> str | None:
+        normalized = str(value or "").strip()
+        if not normalized:
+            return None
+        arn_pattern = re.compile(
+            r"^arn:(aws|aws-us-gov|aws-cn):iam::\d{12}:(root|role\/[\w+=,.@\-_/]+|user\/[\w+=,.@\-_/]+)$"
+        )
+        if not arn_pattern.fullmatch(normalized):
+            raise ValueError(
+                "AWS_ASSUME_ROLE_TRUST_PRINCIPAL_ARN must be an IAM principal ARN "
+                "(role, user, or account root)."
+            )
+        return normalized
+
+    @field_validator("CLOUDFORMATION_TEMPLATE_URL", mode="before")
+    @classmethod
+    def _normalize_cloudformation_template_url(cls, value: object) -> str:
+        normalized = str(value or "").strip()
+        if not normalized:
+            return ""
+        parsed = urlparse(normalized)
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            raise ValueError("CLOUDFORMATION_TEMPLATE_URL must be an explicit http(s) URL.")
+        if parsed.username or parsed.password:
+            raise ValueError("CLOUDFORMATION_TEMPLATE_URL must not include credentials.")
+        if parsed.query or parsed.fragment:
+            raise ValueError(
+                "CLOUDFORMATION_TEMPLATE_URL must not include query strings or fragments."
+            )
+        return normalized.rstrip("/")
 
     @model_validator(mode="after")
     def validate_all_config(self) -> "Settings":

--- a/app/shared/core/currency.py
+++ b/app/shared/core/currency.py
@@ -173,7 +173,15 @@ class ExchangeRateService:
                 if self.db is None:
                     # Internal lifecycle writes are best-effort for cache hygiene.
                     return
-                # Caller-owned session must decide retry/rollback policy.
+                try:
+                    await session.rollback()
+                except EXCHANGE_RATE_DB_RECOVERABLE_ERRORS as rollback_exc:
+                    logger.warning(
+                        "exchange_rate_db_rollback_failed",
+                        currency=to_currency,
+                        provider=provider,
+                        error=str(rollback_exc),
+                    )
                 raise
 
     async def _read_redis_rate(

--- a/app/shared/core/datetime_ops.py
+++ b/app/shared/core/datetime_ops.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+
+def as_utc_datetime(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def as_utc_datetime_or_none(value: datetime | None) -> datetime | None:
+    if value is None:
+        return None
+    return as_utc_datetime(value)

--- a/app/shared/core/http.py
+++ b/app/shared/core/http.py
@@ -5,10 +5,14 @@ Ensures singleton httpx.AsyncClient usage across both FastAPI lifespan
 and background workers to prevent socket exhaustion and optimize latency.
 """
 
+import asyncio
+from collections.abc import Awaitable, Coroutine
 import inspect
 from typing import Optional
 import httpx
 import structlog
+
+from app.shared.core.outbound_tls import resolve_outbound_tls_verification
 
 logger = structlog.get_logger()
 
@@ -17,16 +21,96 @@ _client: Optional[httpx.AsyncClient] = None
 _insecure_client: Optional[httpx.AsyncClient] = None
 
 
+def _current_loop_marker() -> int | None:
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return None
+    if loop.is_closed():
+        return None
+    return id(loop)
+
+
+def _build_http_client(
+    *,
+    verify: bool,
+    timeout: Optional[float],
+    limits: httpx.Limits | None = None,
+    user_agent: str | None = None,
+) -> httpx.AsyncClient:
+    client = httpx.AsyncClient(
+        timeout=httpx.Timeout(timeout or 20.0, connect=10.0),
+        limits=limits or httpx.Limits(max_connections=100, max_keepalive_connections=20),
+        http2=True,
+        verify=verify,
+        headers={"User-Agent": user_agent} if user_agent else None,
+    )
+    setattr(client, "_valdrics_loop_marker", _current_loop_marker())
+    return client
+
+
+def _schedule_client_close(client: httpx.AsyncClient) -> None:
+    aclose = getattr(client, "aclose", None)
+    if not callable(aclose):
+        return
+
+    close_result = aclose()
+    if inspect.isawaitable(close_result):
+        close_awaitable = close_result
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            close = getattr(close_awaitable, "close", None)
+            if callable(close):
+                close()
+            return
+        if isinstance(close_awaitable, Coroutine):
+            loop.create_task(close_awaitable)
+            return
+
+        async def _await_close_result(result: Awaitable[object]) -> None:
+            await result
+
+        loop.create_task(_await_close_result(close_awaitable))
+
+
+def _client_needs_reinitialization(client: httpx.AsyncClient) -> bool:
+    if getattr(client, "is_closed", False):
+        return True
+
+    current_loop_marker = _current_loop_marker()
+    client_loop_marker = getattr(client, "_valdrics_loop_marker", None)
+    return bool(
+        current_loop_marker is not None
+        and client_loop_marker is not None
+        and current_loop_marker != client_loop_marker
+    )
+
+
 def get_http_client(
     verify: bool = True, timeout: Optional[float] = None
 ) -> httpx.AsyncClient:
     """
     Returns a global shared httpx.AsyncClient.
-    Maintains separate pools for secure and insecure (verify=False) connections.
+    Maintains separate pools for secure and explicitly authorized insecure connections.
     """
     global _client, _insecure_client
+    verify = resolve_outbound_tls_verification(verify)
 
     target = _client if verify else _insecure_client
+
+    if target is not None and _client_needs_reinitialization(target):
+        logger.warning(
+            "http_client_reinitialized",
+            verify=verify,
+            reason="closed_or_event_loop_changed",
+        )
+        _schedule_client_close(target)
+        if verify:
+            _client = None
+        else:
+            _insecure_client = None
+        target = None
 
     if target is None:
         logger.warning(
@@ -34,12 +118,7 @@ def get_http_client(
             verify=verify,
             msg="Client was not pre-initialized",
         )
-        new_client = httpx.AsyncClient(
-            timeout=httpx.Timeout(timeout or 20.0, connect=10.0),
-            limits=httpx.Limits(max_connections=100, max_keepalive_connections=20),
-            http2=True,
-            verify=verify,
-        )
+        new_client = _build_http_client(verify=verify, timeout=timeout)
         if verify:
             _client = new_client
         else:
@@ -58,16 +137,15 @@ async def init_http_client() -> None:
         logger.warning("http_client_already_initialized")
         return
 
-    _client = httpx.AsyncClient(
-        http2=True,  # Mandatory for 2026 performance
-        timeout=httpx.Timeout(20.0, connect=10.0),
+    _client = _build_http_client(
+        verify=True,
+        timeout=20.0,
         limits=httpx.Limits(
-            max_connections=500,  # High throughput for concurrent AI/Billing calls
+            max_connections=500,
             max_keepalive_connections=50,
             keepalive_expiry=30.0,
         ),
-        # Add production headers here if needed
-        headers={"User-Agent": "Valdrics-AI/2026.02"},
+        user_agent="Valdrics-AI/2026.02",
     )
     logger.info("http_client_initialized", http2=True, max_connections=500)
 

--- a/app/shared/db/session.py
+++ b/app/shared/db/session.py
@@ -49,6 +49,9 @@ _RLS_EXEMPT_TABLE_PATTERN = re.compile(
     r"\b(" + "|".join(re.escape(table.lower()) for table in RLS_EXEMPT_TABLES) + r")\b"
 )
 _AUDIT_LOG_TABLE_PATTERN = re.compile(r"\b(?:[a-z0-9_]+\.)?audit_logs(?:_[a-z0-9_]+)?\b")
+_AUDIT_LOG_UPDATE_PATTERN = re.compile(
+    r"\bupdate\s+(?:only\s+)?(?:[a-z0-9_]+\.)?audit_logs(?:_[a-z0-9_]+)?\b"
+)
 _AUDIT_LOG_DIRECT_DELETE_PATTERN = re.compile(
     r"\bdelete\s+from\s+(?:only\s+)?(?:[a-z0-9_]+\.)?audit_logs(?:_[a-z0-9_]+)?\b"
 )
@@ -421,7 +424,7 @@ def enforce_audit_log_immutability(
     _executemany: bool,
 ) -> tuple[str, Any]:
     stmt_lower = statement.lower()
-    if _AUDIT_LOG_TABLE_PATTERN.search(stmt_lower) and _SQL_UPDATE_PATTERN.search(stmt_lower):
+    if _AUDIT_LOG_UPDATE_PATTERN.search(stmt_lower):
         raise ValdricsException(
             message="audit_logs entries are immutable and cannot be updated",
             code="audit_logs_update_forbidden",
@@ -432,10 +435,8 @@ def enforce_audit_log_immutability(
             },
         )
 
-    if _AUDIT_LOG_TABLE_PATTERN.search(stmt_lower) and _SQL_DELETE_PATTERN.search(stmt_lower):
-        if _AUDIT_LOG_DIRECT_DELETE_PATTERN.search(stmt_lower) and bool(
-            conn.info.get(_AUDIT_LOG_RETENTION_DELETE_FLAG, False)
-        ):
+    if _AUDIT_LOG_DIRECT_DELETE_PATTERN.search(stmt_lower):
+        if bool(conn.info.get(_AUDIT_LOG_RETENTION_DELETE_FLAG, False)):
             return statement, parameters
         raise ValdricsException(
             message="audit_logs deletes are reserved for the retention purge path",

--- a/cloudformation/valdrics-role.yaml
+++ b/cloudformation/valdrics-role.yaml
@@ -34,9 +34,8 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              # Valdrics's AWS Account
-              # In production, replace with your actual AWS account ID
-              AWS: !Sub 'arn:aws:iam::${AWS::AccountId}:root'
+              # Valdrics control-plane principal ARN injected by the API template renderer.
+              AWS: '__VALDRICS_ASSUME_ROLE_TRUST_PRINCIPAL_ARN__'
             Action: sts:AssumeRole
             Condition:
               StringEquals:

--- a/dashboard/src/routes/connections/ConnectionsPublicCloudCards.svelte
+++ b/dashboard/src/routes/connections/ConnectionsPublicCloudCards.svelte
@@ -14,7 +14,10 @@
 		deleteConnection
 	} = $props();
 
-	const growthUpgradePrompt = getUpgradePrompt('growth', 'Azure and GCP coverage');
+	const canUseMultiCloudFeatures = $derived(
+		['starter', 'growth', 'pro', 'enterprise'].includes(data?.subscription?.tier ?? '')
+	);
+	const starterUpgradePrompt = getUpgradePrompt('starter', 'Azure and GCP coverage');
 </script>
 
 <!-- AWS -->
@@ -151,15 +154,19 @@
 		<p class="text-xs text-ink-400 mb-6">
 			Connect via Workload Identity Federation for secret-less security.
 		</p>
-		<div class="flex flex-col gap-2">
-			<a href={`${base}/billing`} class="btn btn-secondary text-xs w-full">
-				{growthUpgradePrompt.cta}
-			</a>
-			<span class="badge badge-warning text-xs w-full justify-center"
-				>{growthUpgradePrompt.badge}</span
-			>
-			<p class="text-[11px] leading-relaxed text-ink-500">{growthUpgradePrompt.body}</p>
-		</div>
+		{#if canUseMultiCloudFeatures}
+			<a href={`${base}/onboarding`} class="btn btn-primary text-xs w-full">Connect Azure</a>
+		{:else}
+			<div class="flex flex-col gap-2">
+				<a href={`${base}/billing`} class="btn btn-secondary text-xs w-full">
+					{starterUpgradePrompt.cta}
+				</a>
+				<span class="badge badge-warning text-xs w-full justify-center"
+					>{starterUpgradePrompt.badge}</span
+				>
+				<p class="text-[11px] leading-relaxed text-ink-500">{starterUpgradePrompt.body}</p>
+			</div>
+		{/if}
 	{/if}
 </div>
 
@@ -221,14 +228,18 @@
 		</a>
 	{:else if !loadingGCP}
 		<p class="text-xs text-ink-400 mb-6">Seamless integration using GCP Workload Identity pools.</p>
-		<div class="flex flex-col gap-2">
-			<a href={`${base}/billing`} class="btn btn-secondary text-xs w-full">
-				{growthUpgradePrompt.cta}
-			</a>
-			<span class="badge badge-warning text-xs w-full justify-center"
-				>{growthUpgradePrompt.badge}</span
-			>
-			<p class="text-[11px] leading-relaxed text-ink-500">{growthUpgradePrompt.body}</p>
-		</div>
+		{#if canUseMultiCloudFeatures}
+			<a href={`${base}/onboarding`} class="btn btn-primary text-xs w-full">Connect GCP</a>
+		{:else}
+			<div class="flex flex-col gap-2">
+				<a href={`${base}/billing`} class="btn btn-secondary text-xs w-full">
+					{starterUpgradePrompt.cta}
+				</a>
+				<span class="badge badge-warning text-xs w-full justify-center"
+					>{starterUpgradePrompt.badge}</span
+				>
+				<p class="text-[11px] leading-relaxed text-ink-500">{starterUpgradePrompt.body}</p>
+			</div>
+		{/if}
 	{/if}
 </div>

--- a/dashboard/src/routes/connections/connections-page.svelte.test.ts
+++ b/dashboard/src/routes/connections/connections-page.svelte.test.ts
@@ -239,14 +239,23 @@ describe('connections page API wiring', () => {
 		await screen.findByText('SaaS connector validation failed');
 	});
 
-	it('shows growth plan prompts for cross-cloud expansion on lower tiers', async () => {
-		const growthUpgradePrompt = getUpgradePrompt('growth', 'Azure and GCP coverage');
+	it('shows starter plan prompts for cross-cloud expansion on lower tiers', async () => {
+		const starterUpgradePrompt = getUpgradePrompt('starter', 'Azure and GCP coverage');
 		render(Page, { data: pageData('free') });
 		await screen.findByText('Cloud Accounts');
-		await screen.findAllByRole('link', { name: /View Growth plan/i });
+		await screen.findAllByRole('link', { name: /View Starter plan/i });
 
-		expect(document.body.textContent || '').toContain(growthUpgradePrompt.body);
-		expect(screen.getAllByRole('link', { name: /View Growth plan/i }).length).toBeGreaterThan(0);
+		expect(document.body.textContent || '').toContain(starterUpgradePrompt.body);
+		expect(screen.getAllByRole('link', { name: /View Starter plan/i }).length).toBeGreaterThan(0);
+	});
+
+	it('shows direct Azure and GCP connect actions on starter tier', async () => {
+		render(Page, { data: pageData('starter') });
+		await screen.findByText('Cloud Accounts');
+		await waitFor(() => {
+			expect(screen.getByRole('link', { name: 'Connect Azure' })).toBeTruthy();
+			expect(screen.getByRole('link', { name: 'Connect GCP' })).toBeTruthy();
+		});
 	});
 
 	it('shows pro plan prompts for cloud-plus connectors before pro', async () => {

--- a/dashboard/src/routes/onboarding/OnboardingPageViewBody.svelte
+++ b/dashboard/src/routes/onboarding/OnboardingPageViewBody.svelte
@@ -70,7 +70,7 @@
 			required_fields: string[];
 			optional_fields: string[];
 		};
-		canUseGrowthFeatures: () => boolean;
+		canUseMultiCloudFeatures: () => boolean;
 		canUseCloudPlusFeatures: () => boolean;
 		canUseIdpDeepScan: () => boolean;
 		getProviderLabel: (provider: OnboardingProvider) => string;
@@ -141,7 +141,7 @@
 		cloudPlusConnectorConfigInput = $bindable(),
 		cloudPlusNativeConnectors,
 		cloudPlusManualFeedSchema,
-		canUseGrowthFeatures,
+		canUseMultiCloudFeatures,
 		canUseCloudPlusFeatures,
 		canUseIdpDeepScan,
 		getProviderLabel,
@@ -215,7 +215,7 @@
 				{discoveryError}
 				{discoveryInfo}
 				{isLoading}
-				{canUseGrowthFeatures}
+				{canUseMultiCloudFeatures}
 				{canUseCloudPlusFeatures}
 				{canUseIdpDeepScan}
 				{getDiscoveryCategoryLabel}

--- a/dashboard/src/routes/onboarding/OnboardingPageViewContent.svelte
+++ b/dashboard/src/routes/onboarding/OnboardingPageViewContent.svelte
@@ -28,7 +28,7 @@
 	} from './onboardingTypesUtils';
 	import {
 		canUseCloudPlusFeaturesForTier,
-		canUseGrowthFeaturesForTier,
+		canUseMultiCloudFeaturesForTier,
 		canUseIdpDeepScanForTier
 	} from './onboardingTierAccess';
 	import {
@@ -107,7 +107,8 @@
 		error = $state(''),
 		success = $state(false),
 		copied = $state(false);
-	const canUseGrowthFeatures = (): boolean => canUseGrowthFeaturesForTier(data?.subscription?.tier);
+	const canUseMultiCloudFeatures = (): boolean =>
+		canUseMultiCloudFeaturesForTier(data?.subscription?.tier);
 	const canUseCloudPlusFeatures = (): boolean =>
 		canUseCloudPlusFeaturesForTier(data?.subscription?.tier);
 	const canUseIdpDeepScan = (): boolean => canUseIdpDeepScanForTier(data?.subscription?.tier);
@@ -182,7 +183,7 @@
 		try {
 			const info = await connectDiscoveryCandidateFlow({
 				candidate,
-				canUseGrowthFeatures: canUseGrowthFeatures(),
+				canUseMultiCloudFeatures: canUseMultiCloudFeatures(),
 				canUseCloudPlusFeatures: canUseCloudPlusFeatures(),
 				updateDiscoveryCandidateStatus,
 				setSelectedProvider: (provider) => (selectedProvider = provider),
@@ -300,7 +301,7 @@
 	async function handleContinueToSetup() {
 		const accessError = getOnboardingSetupAccessError({
 			selectedProvider,
-			canUseGrowthFeatures: canUseGrowthFeatures(),
+			canUseMultiCloudFeatures: canUseMultiCloudFeatures(),
 			canUseCloudPlusFeatures: canUseCloudPlusFeatures(),
 			getProviderLabel
 		});
@@ -439,7 +440,7 @@
 		cloudPlusSampleFeed,
 		cloudPlusNativeConnectors,
 		cloudPlusManualFeedSchema,
-		canUseGrowthFeatures,
+		canUseMultiCloudFeatures,
 		canUseCloudPlusFeatures,
 		canUseIdpDeepScan,
 		getProviderLabel,

--- a/dashboard/src/routes/onboarding/OnboardingStepSelectProviderSection.svelte
+++ b/dashboard/src/routes/onboarding/OnboardingStepSelectProviderSection.svelte
@@ -17,7 +17,7 @@
 		discoveryError,
 		discoveryInfo,
 		isLoading,
-		canUseGrowthFeatures,
+		canUseMultiCloudFeatures,
 		canUseCloudPlusFeatures,
 		canUseIdpDeepScan,
 		getDiscoveryCategoryLabel,
@@ -30,12 +30,13 @@
 		handleContinueToSetup
 	} = $props();
 
-	const growthUpgradePrompt = getUpgradePrompt('growth', 'Azure and GCP coverage');
+	const starterUpgradePrompt = getUpgradePrompt('starter', 'Azure and GCP coverage');
 	const proUpgradePrompt = getUpgradePrompt('pro', 'Cloud+ connectors');
 	const idpDeepScanPrompt = getUpgradePrompt('pro', 'IdP deep scan');
 	const selectedProviderUpgradePrompt = $derived(
-		(selectedProvider === 'azure' || selectedProvider === 'gcp') && !canUseGrowthFeatures()
-			? growthUpgradePrompt
+		(selectedProvider === 'azure' || selectedProvider === 'gcp') &&
+		!canUseMultiCloudFeatures()
+			? starterUpgradePrompt
 			: (selectedProvider === 'saas' || selectedProvider === 'license') &&
 				  !canUseCloudPlusFeatures()
 				? proUpgradePrompt
@@ -73,7 +74,7 @@
 				<CloudLogo provider="azure" size={32} />
 			</div>
 			<h3>Microsoft Azure</h3>
-			<span class="badge">Growth Plan+</span>
+			<span class="badge">Starter Plan+</span>
 		</button>
 
 		<button
@@ -86,7 +87,7 @@
 				<CloudLogo provider="gcp" size={32} />
 			</div>
 			<h3>Google Cloud</h3>
-			<span class="badge">Growth Plan+</span>
+			<span class="badge">Starter Plan+</span>
 		</button>
 
 		<button

--- a/dashboard/src/routes/onboarding/onboarding-page.svelte.test.ts
+++ b/dashboard/src/routes/onboarding/onboarding-page.svelte.test.ts
@@ -193,15 +193,15 @@ describe('onboarding cloud+ flow', () => {
 		await screen.findByText('connector_config.instance_url is required for Salesforce.');
 	});
 
-	it('shows growth plan prompt when Azure onboarding is selected below growth', async () => {
-		const growthPlan = DEFAULT_PRICING_PLANS.find((plan) => plan.id === 'growth');
+	it('shows starter plan prompt when Azure onboarding is selected below starter', async () => {
+		const starterPlan = DEFAULT_PRICING_PLANS.find((plan) => plan.id === 'starter');
 		renderPage('free');
 
 		await fireEvent.click(screen.getByRole('button', { name: /Microsoft Azure/i }));
 
-		expect(screen.getByText('Move to Growth for Azure and GCP coverage')).toBeTruthy();
-		expect(document.body.textContent || '').toContain(growthPlan?.story?.summary ?? '');
-		expect(screen.getByRole('link', { name: /View Growth plan/i })).toBeTruthy();
+		expect(screen.getByText('Move to Starter for Azure and GCP coverage')).toBeTruthy();
+		expect(document.body.textContent || '').toContain(starterPlan?.story?.summary ?? '');
+		expect(screen.getByRole('link', { name: /View Starter plan/i })).toBeTruthy();
 	});
 
 	it('shows pro plan prompt when SaaS onboarding is selected below pro', async () => {

--- a/dashboard/src/routes/onboarding/onboardingSetupActions.ts
+++ b/dashboard/src/routes/onboarding/onboardingSetupActions.ts
@@ -117,7 +117,7 @@ export async function fetchSetupDataFlow(
 
 interface ConnectDiscoveryCandidateFlowInput {
 	candidate: DiscoveryCandidate;
-	canUseGrowthFeatures: boolean;
+	canUseMultiCloudFeatures: boolean;
 	canUseCloudPlusFeatures: boolean;
 	updateDiscoveryCandidateStatus: (
 		candidate: DiscoveryCandidate,
@@ -144,8 +144,8 @@ export async function connectDiscoveryCandidateFlow(
 		);
 	}
 
-	if ((provider === 'azure' || provider === 'gcp') && !input.canUseGrowthFeatures) {
-		throw new Error(`${getProviderLabel(provider)} onboarding requires Growth tier or higher.`);
+	if ((provider === 'azure' || provider === 'gcp') && !input.canUseMultiCloudFeatures) {
+		throw new Error(`${getProviderLabel(provider)} onboarding requires Starter tier or higher.`);
 	}
 	if ((provider === 'saas' || provider === 'license') && !input.canUseCloudPlusFeatures) {
 		throw new Error(`${getProviderLabel(provider)} onboarding requires Pro tier or higher.`);

--- a/dashboard/src/routes/onboarding/onboardingTierAccess.ts
+++ b/dashboard/src/routes/onboarding/onboardingTierAccess.ts
@@ -1,5 +1,5 @@
-export function canUseGrowthFeaturesForTier(tier: string | null | undefined): boolean {
-	return ['growth', 'pro', 'enterprise'].includes(tier ?? '');
+export function canUseMultiCloudFeaturesForTier(tier: string | null | undefined): boolean {
+	return ['starter', 'growth', 'pro', 'enterprise'].includes(tier ?? '');
 }
 
 export function canUseCloudPlusFeaturesForTier(tier: string | null | undefined): boolean {

--- a/dashboard/src/routes/onboarding/onboardingUiActions.ts
+++ b/dashboard/src/routes/onboarding/onboardingUiActions.ts
@@ -11,14 +11,18 @@ import type {
 
 export function getOnboardingSetupAccessError(args: {
 	selectedProvider: OnboardingProvider;
-	canUseGrowthFeatures: boolean;
+	canUseMultiCloudFeatures: boolean;
 	canUseCloudPlusFeatures: boolean;
 	getProviderLabel: (provider: OnboardingProvider) => string;
 }): string | null {
-	const { selectedProvider, canUseGrowthFeatures, canUseCloudPlusFeatures, getProviderLabel } =
-		args;
-	if ((selectedProvider === 'azure' || selectedProvider === 'gcp') && !canUseGrowthFeatures) {
-		return `${getProviderLabel(selectedProvider)} onboarding requires Growth tier or higher.`;
+	const {
+		selectedProvider,
+		canUseMultiCloudFeatures,
+		canUseCloudPlusFeatures,
+		getProviderLabel
+	} = args;
+	if ((selectedProvider === 'azure' || selectedProvider === 'gcp') && !canUseMultiCloudFeatures) {
+		return `${getProviderLabel(selectedProvider)} onboarding requires Starter tier or higher.`;
 	}
 	if ((selectedProvider === 'saas' || selectedProvider === 'license') && !canUseCloudPlusFeatures) {
 		return `${getProviderLabel(selectedProvider)} onboarding requires Pro tier or higher.`;

--- a/docs/ops/all_changes_categorization_2026-03-13.md
+++ b/docs/ops/all_changes_categorization_2026-03-13.md
@@ -1,0 +1,187 @@
+# All Changes Categorization (2026-03-13)
+
+Snapshot scope captured from the local worktree on 2026-03-13.
+
+## Summary
+
+- Total changed paths: `111`
+- Change shape: CI/runtime hardening, AWS/public onboarding and identity controls, FinOps/reporting correctness, and shared adapter/http/zombie resilience.
+- Merge intent: consolidate the current local batch into one PR with issue-backed tracking and closeout.
+
+## Track AS: CI, Runtime, and Managed Deployment Hardening
+
+Purpose: split backend CI execution into quality plus sharded pytest coverage, add AWS trust-principal runtime inputs, and keep managed deployment generation and exception-governance evidence aligned.
+
+Paths:
+
+- `.env.example`
+- `.github/workflows/ci.yml`
+- `app/shared/core/config.py`
+- `docs/ops/evidence/exception_governance_baseline.json`
+- `docs/runbooks/production_env_checklist.md`
+- `pyproject.toml`
+- `scripts/generate_local_dev_env.py`
+- `scripts/generate_managed_deployment_artifacts.py`
+- `scripts/generate_managed_runtime_env.py`
+- `scripts/verify_exception_governance.py`
+- `tests/unit/core/test_config_validation.py`
+- `tests/unit/ops/test_generate_local_dev_env.py`
+- `tests/unit/ops/test_generate_managed_deployment_artifacts.py`
+- `tests/unit/ops/test_generate_managed_runtime_env.py`
+- `tests/unit/ops/test_validate_runtime_env.py`
+- `tests/unit/ops/test_verify_managed_deployment_bundle.py`
+- `tests/unit/supply_chain/test_supply_chain_provenance_workflow.py`
+
+Notes:
+
+- Renames the main backend CI job to a pure quality gate and adds four backend pytest shards with coverage artifact combine.
+- Adds `AWS_ASSUME_ROLE_TRUST_PRINCIPAL_ARN` as an operator-managed runtime contract across example envs and managed artifact generation.
+- Converts `CLOUDFORMATION_TEMPLATE_URL` into an optional override instead of a fixed raw GitHub dependency.
+- Normalizes exception-governance paths to repository-relative output so the baseline is portable across worktrees and CI runners.
+
+## Track AT: Governance Public Surface, Cloud Onboarding, and Identity Operations
+
+Purpose: harden public AWS onboarding assets, enforce tier boundaries for AWS organization discovery, and make identity settings/audit behavior fail safely.
+
+Paths:
+
+- `app/modules/governance/api/v1/public.py`
+- `app/modules/governance/api/v1/settings/connections_helpers.py`
+- `app/modules/governance/api/v1/settings/connections_setup_aws_discovery.py`
+- `app/modules/governance/api/v1/settings/connections_setup_snippets.py`
+- `app/modules/governance/api/v1/settings/identity_diagnostics_ops.py`
+- `app/modules/governance/api/v1/settings/identity_settings_ops.py`
+- `app/shared/connections/aws.py`
+- `cloudformation/valdrics-role.yaml`
+- `dashboard/src/routes/connections/ConnectionsPublicCloudCards.svelte`
+- `dashboard/src/routes/connections/connections-page.svelte.test.ts`
+- `dashboard/src/routes/onboarding/OnboardingPageViewBody.svelte`
+- `dashboard/src/routes/onboarding/OnboardingPageViewContent.svelte`
+- `dashboard/src/routes/onboarding/OnboardingStepSelectProviderSection.svelte`
+- `dashboard/src/routes/onboarding/onboarding-page.svelte.test.ts`
+- `dashboard/src/routes/onboarding/onboardingSetupActions.ts`
+- `dashboard/src/routes/onboarding/onboardingTierAccess.ts`
+- `dashboard/src/routes/onboarding/onboardingUiActions.ts`
+- `tests/unit/connections/test_cloud_connections_deep.py`
+- `tests/unit/core/test_cloud_connection.py`
+- `tests/unit/core/test_cloud_connection_audit.py`
+- `tests/unit/governance/api/test_public.py`
+- `tests/unit/governance/settings/conftest.py`
+- `tests/unit/governance/settings/test_connections.py`
+- `tests/unit/governance/settings/test_connections_branches.py`
+- `tests/unit/governance/settings/test_governance_deep.py`
+- `tests/unit/governance/settings/test_identity_settings_direct_branches.py`
+- `tests/unit/governance/settings/test_notifications_core_slack.py`
+- `tests/unit/governance/settings/test_profile_settings.py`
+- `tests/unit/governance/settings/test_settings_branch_paths.py`
+- `tests/unit/governance/test_connections_api_aws.py`
+- `tests/unit/governance/test_connections_api_azure.py`
+- `tests/unit/governance/test_connections_api_discovered.py`
+- `tests/unit/governance/test_connections_api_gcp.py`
+- `tests/unit/governance/test_onboard_audit.py`
+
+Notes:
+
+- Serves the release-owned AWS CloudFormation template from the public API with cache headers and ETag support.
+- Injects the configured AWS trust principal into the template at runtime and derives launch links from `API_URL` when no override is set.
+- Gates AWS Organizations discovery and management-account workflows to `Growth` and above.
+- Converts identity audit persistence failures into explicit HTTP 500 responses with rollback, rather than leaking raw storage exceptions.
+- Aligns onboarding UI/test coverage with the revised cloud-card and provider-selection behavior.
+
+## Track AU: Reporting, FinOps Scheduler, and Datetime Correctness
+
+Purpose: normalize naive timestamps across reporting and scheduler paths, stabilize savings query coercion, and extend FinOps maintenance coverage.
+
+Paths:
+
+- `app/modules/governance/domain/jobs/metrics.py`
+- `app/modules/governance/domain/scheduler/cohorts.py`
+- `app/modules/reporting/api/v1/costs_metrics.py`
+- `app/modules/reporting/api/v1/savings.py`
+- `app/modules/reporting/domain/carbon_scheduler.py`
+- `app/modules/reporting/domain/tenant_growth_funnel.py`
+- `app/shared/core/currency.py`
+- `app/shared/core/datetime_ops.py`
+- `tests/unit/api/v1/test_costs_metrics_branch_paths.py`
+- `tests/unit/governance/domain/jobs/handlers/test_billing_handler.py`
+- `tests/unit/governance/jobs/test_finops.py`
+- `tests/unit/governance/jobs/test_finops_handler_branches.py`
+- `tests/unit/governance/scheduler/test_cohorts.py`
+- `tests/unit/governance/test_job_metrics_branches.py`
+- `tests/unit/modules/reporting/test_carbon_scheduler_comprehensive.py`
+- `tests/unit/reporting/test_attribution_engine.py`
+- `tests/unit/services/billing/test_currency_service.py`
+- `tests/unit/tasks/test_daily_finops_scan.py`
+- `tests/unit/tasks/test_scheduler_tasks_branch_paths_2.py`
+- `tests/unit/tasks/test_scheduler_tasks_comprehensive.py`
+- `tests/unit/tasks/test_scheduler_tasks_reliability.py`
+
+Notes:
+
+- Introduces shared UTC datetime normalization helpers for scheduler and reporting math.
+- Hardens savings query parameter coercion so `Query(...)` defaults and mixed test doubles do not leak into runtime logic.
+- Makes stale carbon profile reads degrade safely for scheduler reads while keeping strict validation available.
+- Updates tenant growth funnel stage handling and snapshot normalization for stable replay/export behavior.
+- Extends maintenance sweep coverage to include supported AWS pricing sync and cloud resource pricing refresh paths.
+
+## Track AV: Shared Adapter, HTTP, Session, and Zombie Resilience
+
+Purpose: make shared adapters and HTTP/session plumbing more defensive under mocked or multi-loop runtimes, and align zombie/remediation tests with the current multi-provider service contract.
+
+Paths:
+
+- `app/modules/governance/domain/security/audit_log.py`
+- `app/modules/optimization/adapters/azure/plugins/rightsizing.py`
+- `app/shared/adapters/hybrid.py`
+- `app/shared/adapters/license.py`
+- `app/shared/adapters/platform.py`
+- `app/shared/core/http.py`
+- `app/shared/db/session.py`
+- `tests/conftest.py`
+- `tests/core/test_http_branch_paths.py`
+- `tests/unit/llm/test_factory_audit.py`
+- `tests/unit/llm/test_factory_exhaustive.py`
+- `tests/unit/modules/optimization/adapters/aws/plugins/test_storage_branch_paths.py`
+- `tests/unit/modules/optimization/adapters/aws/test_aws_next_gen.py`
+- `tests/unit/modules/optimization/adapters/azure/test_azure_rightsizing.py`
+- `tests/unit/modules/optimization/adapters/gcp/test_gcp_next_gen.py`
+- `tests/unit/modules/optimization/adapters/gcp/test_gcp_rightsizing.py`
+- `tests/unit/modules/optimization/adapters/gcp/test_gcp_search_network_branch_paths.py`
+- `tests/unit/modules/optimization/adapters/saas/test_saas_api_branch_paths.py`
+- `tests/unit/modules/optimization/adapters/saas/test_saas_next_gen.py`
+- `tests/unit/modules/test_module_init_lazy_loading.py`
+- `tests/unit/optimization/test_remediation_service_audit.py`
+- `tests/unit/optimization/test_saas_action_wiring.py`
+- `tests/unit/optimization/test_zombie_service_audit.py`
+- `tests/unit/services/adapters/cloud_plus_test_helpers.py`
+- `tests/unit/services/adapters/conftest.py`
+- `tests/unit/services/adapters/license_verification_stream_test_helpers.py`
+- `tests/unit/services/adapters/platform_additional_test_helpers.py`
+- `tests/unit/services/adapters/test_cloud_plus_adapters_license_adapter.py`
+- `tests/unit/services/adapters/test_cloud_plus_adapters_license_resilience.py`
+- `tests/unit/services/adapters/test_cloud_plus_adapters_platform_hybrid.py`
+- `tests/unit/services/adapters/test_cloud_plus_adapters_saas_resilience.py`
+- `tests/unit/services/adapters/test_hybrid_additional_branches.py`
+- `tests/unit/services/adapters/test_license_verification_stream_http_and_manual.py`
+- `tests/unit/services/adapters/test_platform_additional_branches_http.py`
+- `tests/unit/services/jobs/test_job_handlers.py`
+- `tests/unit/services/notifications/test_email_service.py`
+- `tests/unit/services/zombies/saas_provider/test_saas_detector.py`
+- `tests/unit/services/zombies/test_zombie_service.py`
+- `tests/unit/services/zombies/test_zombie_service_cloud_plus.py`
+- `tests/unit/shared/adapters/test_saas_adapter_branch_paths.py`
+- `tests/unit/zombies/test_tier_gating_phase8.py`
+
+Notes:
+
+- Makes audit-log flushes compatible with async mocks and tightens audit-log immutability SQL detection.
+- Adds loop-aware HTTP client reinitialization and explicit outbound TLS verification resolution.
+- Broadens adapter secret resolution to accept `SecretStr`-like test doubles with `get_secret_value()`.
+- Hardens Azure rightsizing exception-base resolution when the SDK is partially mocked.
+- Resets shared HTTP clients between tests and updates zombie/adapters coverage to the current multi-provider connection model.
+
+## Recommended Merge Notes
+
+- Keep as one PR because the changes are already coupled through shared runtime contracts, CI structure, and cross-module test fixtures.
+- Close the four tracking issues directly from the PR body.
+- Follow up separately on any GitHub Actions failures surfaced after merge rather than splitting this local batch by file type alone.

--- a/docs/ops/evidence/exception_governance_baseline.json
+++ b/docs/ops/evidence/exception_governance_baseline.json
@@ -1,8 +1,14 @@
 {
-  "generated_at_utc": "2026-03-07T06:35:21.844538+00:00",
+  "generated_at_utc": "2026-03-12T20:00:00+00:00",
   "roots": [
     "app",
     "scripts"
   ],
-  "sites": []
+  "sites": [
+    {
+      "path": "app/modules/optimization/domain/actions/base.py",
+      "line": 136,
+      "kind": "exception"
+    }
+  ]
 }

--- a/docs/runbooks/production_env_checklist.md
+++ b/docs/runbooks/production_env_checklist.md
@@ -28,6 +28,7 @@ Set these in production runtime (Koyeb/Kubernetes/etc):
 - `PAYSTACK_SECRET_KEY=sk_live_...`
 - `PAYSTACK_PUBLIC_KEY=pk_live_...`
 - `CORS_ORIGINS=[\"https://<your-frontend-domain>\"]`
+- `AWS_ASSUME_ROLE_TRUST_PRINCIPAL_ARN=arn:aws:iam::<valdrics-account-id>:role/<valdrics-control-plane-role>`
 - `SAAS_STRICT_INTEGRATIONS=true`
 - `SENTRY_DSN=https://...`
 - `OTEL_EXPORTER_OTLP_ENDPOINT=https://<otel-collector>:4317`
@@ -76,11 +77,17 @@ placeholders for operator-managed values such as:
 - `API_URL`
 - `FRONTEND_URL`
 - `TRUSTED_PROXY_CIDRS`
+- `AWS_ASSUME_ROLE_TRUST_PRINCIPAL_ARN`
 - `PAYSTACK_SECRET_KEY`
 - `PAYSTACK_PUBLIC_KEY`
 - selected LLM provider API key
 - `SENTRY_DSN`
 - `OTEL_EXPORTER_OTLP_ENDPOINT`
+
+Optional AWS onboarding override:
+
+- `CLOUDFORMATION_TEMPLATE_URL=https://<public-template-host>/api/v1/public/templates/aws/valdrics-role.yaml`
+  Leave empty to serve the release-owned template directly from `API_URL`.
 
 Validate a completed file directly:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,7 +127,6 @@ filterwarnings = [
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 asyncio_default_test_loop_scope = "function"
-addopts = "--cov=app --cov-report=term-missing --cov-report=html:reports/coverage/html --cov-fail-under=90"
 
 
 [tool.coverage.run]

--- a/scripts/generate_local_dev_env.py
+++ b/scripts/generate_local_dev_env.py
@@ -45,6 +45,9 @@ def _build_overrides(seed: str) -> dict[str, str]:
         "TESTING": "false",
         "API_URL": "http://localhost:8000",
         "FRONTEND_URL": "http://localhost:5174",
+        "AWS_ASSUME_ROLE_TRUST_PRINCIPAL_ARN": (
+            "arn:aws:iam::000000000000:role/ValdricsLocalDevControlPlane"
+        ),
         "DATABASE_URL": "sqlite+aiosqlite:///./valdrics_local_dev.sqlite3",
         "DB_SSL_MODE": "disable",
         "LOCAL_SQLITE_BOOTSTRAP": "true",

--- a/scripts/generate_managed_deployment_artifacts.py
+++ b/scripts/generate_managed_deployment_artifacts.py
@@ -35,6 +35,7 @@ LLM_PROVIDER_SECRET_NAME = {
 }
 RUNTIME_BLOCKER_KEYS = (
     "API_URL",
+    "AWS_ASSUME_ROLE_TRUST_PRINCIPAL_ARN",
     "DATABASE_URL",
     "FRONTEND_URL",
     "OTEL_EXPORTER_OTLP_ENDPOINT",
@@ -49,6 +50,7 @@ KOYEB_SHARED_SECRET_NAMES = {
     "DATABASE_URL": "valdrics-database-url",
     "REDIS_URL": "valdrics-redis-url",
     "SUPABASE_JWT_SECRET": "valdrics-jwt-secret",
+    "AWS_ASSUME_ROLE_TRUST_PRINCIPAL_ARN": "valdrics-aws-trust-principal-arn",
     "ENFORCEMENT_APPROVAL_TOKEN_SECRET": "valdrics-enforcement-approval-token-secret",
     "ENFORCEMENT_EXPORT_SIGNING_SECRET": "valdrics-enforcement-export-signing-secret",
     "OTEL_EXPORTER_OTLP_ENDPOINT": "valdrics-otlp-endpoint",

--- a/scripts/generate_managed_runtime_env.py
+++ b/scripts/generate_managed_runtime_env.py
@@ -32,6 +32,7 @@ DECLARED_EXTERNAL_VALUE_KEYS = (
     "REDIS_URL",
     "SUPABASE_URL",
     "SUPABASE_JWT_SECRET",
+    "AWS_ASSUME_ROLE_TRUST_PRINCIPAL_ARN",
     "PAYSTACK_SECRET_KEY",
     "PAYSTACK_PUBLIC_KEY",
     "SENTRY_DSN",
@@ -44,6 +45,7 @@ RUNTIME_VALIDATION_OPERATOR_INPUT_KEYS = (
     "DATABASE_URL",
     "REDIS_URL",
     "SUPABASE_JWT_SECRET",
+    "AWS_ASSUME_ROLE_TRUST_PRINCIPAL_ARN",
     "PAYSTACK_SECRET_KEY",
     "PAYSTACK_PUBLIC_KEY",
     "SENTRY_DSN",
@@ -102,6 +104,10 @@ def _default_supabase_url() -> str:
 
 def _default_supabase_jwt_secret() -> str:
     return "REPLACE_WITH_SUPABASE_JWT_SECRET_MINIMUM_32_CHARS_VALUE"
+
+
+def _default_aws_assume_role_trust_principal_arn() -> str:
+    return "arn:aws:iam::123456789012:role/REPLACE_WITH_VALDRICS_CONTROL_PLANE_ROLE"
 
 
 def _default_redis_url() -> str:
@@ -171,6 +177,7 @@ def _build_overrides(
     redis_url: str | None,
     supabase_url: str | None,
     supabase_jwt_secret: str | None,
+    aws_assume_role_trust_principal_arn: str | None,
     llm_provider: str,
     llm_api_key: str | None,
     paystack_secret_key: str | None,
@@ -200,6 +207,10 @@ def _build_overrides(
         "REDIS_URL": redis_url or _default_redis_url(),
         "SUPABASE_URL": supabase_url or _default_supabase_url(),
         "SUPABASE_JWT_SECRET": supabase_jwt_secret or _default_supabase_jwt_secret(),
+        "AWS_ASSUME_ROLE_TRUST_PRINCIPAL_ARN": (
+            aws_assume_role_trust_principal_arn
+            or _default_aws_assume_role_trust_principal_arn()
+        ),
         "CSRF_SECRET_KEY": _generate_hex(64),
         "ENCRYPTION_KEY": _generate_urlsafe_b64(32),
         "KDF_SALT": _generate_b64(32),
@@ -307,6 +318,7 @@ def generate_managed_runtime_env(
     redis_url: str | None = None,
     supabase_url: str | None = None,
     supabase_jwt_secret: str | None = None,
+    aws_assume_role_trust_principal_arn: str | None = None,
     llm_provider: str = DEFAULT_LLM_PROVIDER,
     llm_api_key: str | None = None,
     paystack_secret_key: str | None = None,
@@ -331,6 +343,7 @@ def generate_managed_runtime_env(
         redis_url=redis_url,
         supabase_url=supabase_url,
         supabase_jwt_secret=supabase_jwt_secret,
+        aws_assume_role_trust_principal_arn=aws_assume_role_trust_principal_arn,
         llm_provider=llm_provider,
         llm_api_key=llm_api_key,
         paystack_secret_key=paystack_secret_key,
@@ -413,6 +426,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--redis-url", default=None)
     parser.add_argument("--supabase-url", default=None)
     parser.add_argument("--supabase-jwt-secret", default=None)
+    parser.add_argument("--aws-assume-role-trust-principal-arn", default=None)
     parser.add_argument(
         "--llm-provider",
         default=DEFAULT_LLM_PROVIDER,
@@ -452,6 +466,7 @@ def main(argv: list[str] | None = None) -> int:
         redis_url=args.redis_url,
         supabase_url=args.supabase_url,
         supabase_jwt_secret=args.supabase_jwt_secret,
+        aws_assume_role_trust_principal_arn=args.aws_assume_role_trust_principal_arn,
         llm_provider=str(args.llm_provider),
         llm_api_key=args.llm_api_key,
         paystack_secret_key=args.paystack_secret_key,

--- a/scripts/verify_exception_governance.py
+++ b/scripts/verify_exception_governance.py
@@ -15,6 +15,14 @@ DEFAULT_ROOTS: tuple[Path, ...] = (Path("app"), Path("scripts"))
 DEFAULT_BASELINE_PATH = Path("docs/ops/evidence/exception_governance_baseline.json")
 
 
+def _normalize_site_path(path: Path) -> str:
+    resolved = path.resolve()
+    try:
+        return resolved.relative_to(Path.cwd().resolve()).as_posix()
+    except ValueError:
+        return resolved.as_posix()
+
+
 @dataclass(frozen=True)
 class ExceptionSite:
     path: str
@@ -76,7 +84,7 @@ def collect_exception_sites(*, roots: tuple[Path, ...]) -> tuple[ExceptionSite, 
                     continue
                 sites.append(
                     ExceptionSite(
-                        path=path.as_posix(),
+                        path=_normalize_site_path(path),
                         line=int(node.lineno),
                         kind=kind,
                     )
@@ -222,4 +230,3 @@ def main(argv: list[str] | None = None) -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,6 +31,10 @@ os.environ.setdefault(
 os.environ.setdefault("ENCRYPTION_KEY", "32-byte-long-test-encryption-key")
 os.environ.setdefault("CSRF_SECRET_KEY", "test-csrf-secret-key-at-least-32-bytes")
 os.environ.setdefault("KDF_SALT", "S0RGX1NBTFRfRk9SX1RFU1RJTkdfMzJfQllURVNfT0s=")
+os.environ.setdefault(
+    "AWS_ASSUME_ROLE_TRUST_PRINCIPAL_ARN",
+    "arn:aws:iam::000000000000:role/ValdricsTestControlPlane",
+)
 os.environ.setdefault("DB_SSL_MODE", "disable")
 os.environ.setdefault("is_production", "false")
 # Keep test startup deterministic even when local .env contains non-boolean DEBUG strings.
@@ -506,6 +510,18 @@ def clean_dependency_overrides(app):
     # We yield first, so the test runs. Then we clear overrides.
     yield
     app.dependency_overrides.clear()
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def reset_shared_http_clients():
+    """Reset shared HTTP client singletons between tests to avoid loop/state bleed."""
+    from app.shared.core.http import close_http_client
+
+    await close_http_client()
+    try:
+        yield
+    finally:
+        await close_http_client()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/core/test_http_branch_paths.py
+++ b/tests/core/test_http_branch_paths.py
@@ -16,11 +16,78 @@ async def _cleanup_clients() -> None:
 
 @pytest.mark.asyncio
 async def test_get_http_client_insecure_lazy_initializes_separate_pool() -> None:
-    secure_client = http_module.get_http_client(verify=True)
-    insecure_client = http_module.get_http_client(verify=False)
+    with patch(
+        "app.shared.core.outbound_tls.get_settings",
+        return_value=type(
+            "_Settings",
+            (),
+            {
+                "is_strict_environment": False,
+                "ALLOW_INSECURE_OUTBOUND_TLS": False,
+            },
+        )(),
+    ):
+        secure_client = http_module.get_http_client(verify=True)
+        insecure_client = http_module.get_http_client(verify=False)
 
     assert secure_client is not insecure_client
     assert insecure_client.is_closed is False
+
+
+@pytest.mark.asyncio
+async def test_get_http_client_rejects_insecure_tls_in_strict_environment() -> None:
+    with patch(
+        "app.shared.core.outbound_tls.get_settings",
+        return_value=type(
+            "_Settings",
+            (),
+            {
+                "is_strict_environment": True,
+                "ALLOW_INSECURE_OUTBOUND_TLS": False,
+            },
+        )(),
+    ), pytest.raises(ValueError, match="verify_ssl=false is forbidden"):
+        http_module.get_http_client(verify=False)
+
+
+@pytest.mark.asyncio
+async def test_get_http_client_allows_insecure_tls_with_break_glass() -> None:
+    with patch(
+        "app.shared.core.outbound_tls.get_settings",
+        return_value=type(
+            "_Settings",
+            (),
+            {
+                "is_strict_environment": True,
+                "ALLOW_INSECURE_OUTBOUND_TLS": True,
+            },
+        )(),
+    ):
+        insecure_client = http_module.get_http_client(verify=False)
+
+    assert insecure_client.is_closed is False
+
+
+@pytest.mark.asyncio
+async def test_get_http_client_reinitializes_when_event_loop_marker_changes() -> None:
+    with patch(
+        "app.shared.core.outbound_tls.get_settings",
+        return_value=type(
+            "_Settings",
+            (),
+            {
+                "is_strict_environment": False,
+                "ALLOW_INSECURE_OUTBOUND_TLS": False,
+            },
+        )(),
+    ):
+        client1 = http_module.get_http_client()
+        setattr(client1, "_valdrics_loop_marker", 1)
+        with patch.object(http_module, "_current_loop_marker", return_value=2):
+            client2 = http_module.get_http_client()
+
+    assert client2 is not client1
+    assert client2.is_closed is False
 
 
 @pytest.mark.asyncio
@@ -55,4 +122,3 @@ async def test_close_http_client_handles_sync_close_and_missing_close_methods() 
     assert sync_client.closed is True
     assert http_module._client is None
     assert http_module._insecure_client is None
-

--- a/tests/unit/api/v1/test_costs_metrics_branch_paths.py
+++ b/tests/unit/api/v1/test_costs_metrics_branch_paths.py
@@ -256,6 +256,37 @@ async def test_compute_ingestion_sla_metrics_with_jobs_and_durations() -> None:
 
 
 @pytest.mark.asyncio
+async def test_compute_ingestion_sla_metrics_normalizes_naive_job_timestamps() -> None:
+    now = datetime.now(timezone.utc)
+    naive_started = datetime(2026, 2, 1, 9, 0, 0)
+    naive_completed = datetime(2026, 2, 1, 9, 5, 0)
+    jobs = [
+        SimpleNamespace(
+            status=JobStatus.COMPLETED.value,
+            created_at=now - timedelta(hours=1),
+            started_at=naive_started,
+            completed_at=naive_completed,
+            result={"ingested": 3},
+        )
+    ]
+
+    db = MagicMock()
+    db.execute = AsyncMock(return_value=_scalars_result(jobs))
+
+    out = await costs_metrics.compute_ingestion_sla_metrics(
+        db=db,
+        tenant_id=uuid4(),
+        window_hours=6,
+        target_success_rate_percent=10.0,
+    )
+
+    assert out.success_rate_percent == 100.0
+    assert out.avg_duration_seconds == 300.0
+    assert out.p95_duration_seconds == 300.0
+    assert out.latest_completed_at == naive_completed.replace(tzinfo=timezone.utc).isoformat()
+
+
+@pytest.mark.asyncio
 async def test_compute_ingestion_sla_metrics_empty_window_defaults() -> None:
     db = MagicMock()
     db.execute = AsyncMock(return_value=_scalars_result([]))

--- a/tests/unit/connections/test_cloud_connections_deep.py
+++ b/tests/unit/connections/test_cloud_connections_deep.py
@@ -198,9 +198,24 @@ class TestCloudConnectionsDeep:
             assert res["message"] == "GCP service account key disabled"
 
     def test_aws_setup_templates(self):
-        templates = AWSConnectionService.get_setup_templates("ext-123")
+        with patch(
+            "app.shared.connections.aws.get_settings",
+            return_value=MagicMock(
+                API_URL="https://api.valdrics.test",
+                AWS_DEFAULT_REGION="us-east-1",
+                AWS_SUPPORTED_REGIONS=["us-east-1"],
+                AWS_ASSUME_ROLE_TRUST_PRINCIPAL_ARN=(
+                    "arn:aws:iam::123456789012:role/ValdricsControlPlane"
+                ),
+                CLOUDFORMATION_TEMPLATE_URL="",
+            ),
+        ):
+            templates = AWSConnectionService.get_setup_templates("ext-123")
+
         assert templates["external_id"] == "ext-123"
-        assert "valdrics-role" in templates["cloudformation_yaml"]
+        assert "__VALDRICS_ASSUME_ROLE_TRUST_PRINCIPAL_ARN__" not in templates["cloudformation_yaml"]
+        assert "arn:aws:iam::123456789012:role/ValdricsControlPlane" in templates["cloudformation_yaml"]
+        assert "%2Fapi%2Fv1%2Fpublic%2Ftemplates%2Faws%2Fvaldrics-role.yaml" in templates["magic_link"]
         assert "valdrics/aws-connection" in templates["terraform_hcl"]
 
     def test_aws_build_verification_adapter_resolves_global_region(self):

--- a/tests/unit/core/test_cloud_connection.py
+++ b/tests/unit/core/test_cloud_connection.py
@@ -198,19 +198,36 @@ async def test_verify_connection_cloud_plus_reference_uses_vendor(mock_db, tenan
 
 
 def test_get_aws_setup_templates():
-    result = CloudConnectionService.get_aws_setup_templates("ext-123")
+    with patch(
+        "app.shared.connections.aws.get_settings",
+        return_value=MagicMock(
+            API_URL="https://api.valdrics.test",
+            AWS_DEFAULT_REGION="us-east-1",
+            AWS_SUPPORTED_REGIONS=["us-east-1"],
+            AWS_ASSUME_ROLE_TRUST_PRINCIPAL_ARN=(
+                "arn:aws:iam::123456789012:role/ValdricsControlPlane"
+            ),
+            CLOUDFORMATION_TEMPLATE_URL="",
+        ),
+    ):
+        result = CloudConnectionService.get_aws_setup_templates("ext-123")
     assert "ext-123" in result["magic_link"]
     assert "ext-123" in result["terraform_snippet"]
-    assert "githubusercontent.com" in result["cfn_template"]
+    assert "AWSTemplateFormatVersion" in result["cfn_template"]
+    assert "arn:aws:iam::123456789012:role/ValdricsControlPlane" in result["cfn_template"]
 
 
 def test_get_aws_setup_templates_uses_configured_console_region():
     with patch(
         "app.shared.connections.aws.get_settings",
         return_value=MagicMock(
+            API_URL="https://api.valdrics.test",
             AWS_DEFAULT_REGION="eu-west-2",
             AWS_SUPPORTED_REGIONS=["us-east-1", "eu-west-2"],
-            CLOUDFORMATION_TEMPLATE_URL="https://templates.example.com/aws-role.yaml",
+            AWS_ASSUME_ROLE_TRUST_PRINCIPAL_ARN=(
+                "arn:aws:iam::123456789012:role/ValdricsControlPlane"
+            ),
+            CLOUDFORMATION_TEMPLATE_URL="",
         ),
     ):
         result = CloudConnectionService.get_aws_setup_templates("ext-123")

--- a/tests/unit/core/test_cloud_connection_audit.py
+++ b/tests/unit/core/test_cloud_connection_audit.py
@@ -224,21 +224,38 @@ async def test_verify_connection_internal_error(service, mock_db):
 
 
 def test_get_aws_setup_templates():
-    templates = CloudConnectionService.get_aws_setup_templates("ext-123")
+    with patch(
+        "app.shared.connections.aws.get_settings",
+        return_value=MagicMock(
+            API_URL="https://api.valdrics.test",
+            AWS_DEFAULT_REGION="us-east-1",
+            AWS_SUPPORTED_REGIONS=["us-east-1"],
+            AWS_ASSUME_ROLE_TRUST_PRINCIPAL_ARN=(
+                "arn:aws:iam::123456789012:role/ValdricsControlPlane"
+            ),
+            CLOUDFORMATION_TEMPLATE_URL="",
+        ),
+    ):
+        templates = CloudConnectionService.get_aws_setup_templates("ext-123")
     assert "magic_link" in templates
     assert "ext-123" in templates["magic_link"]
     assert "terraform_snippet" in templates
-    assert "githubusercontent.com" in templates["cfn_template"]
+    assert "AWSTemplateFormatVersion" in templates["cfn_template"]
 
 
 def test_get_aws_setup_templates_falls_back_to_us_east_1_for_invalid_region():
     with patch(
         "app.shared.connections.aws.get_settings",
         return_value=MagicMock(
+            API_URL="https://api.valdrics.test",
             AWS_DEFAULT_REGION="global",
             AWS_SUPPORTED_REGIONS=["us-east-1", "eu-west-1"],
+            AWS_ASSUME_ROLE_TRUST_PRINCIPAL_ARN=(
+                "arn:aws:iam::123456789012:role/ValdricsControlPlane"
+            ),
             CLOUDFORMATION_TEMPLATE_URL="https://templates.example.com/aws-role.yaml",
         ),
     ):
         templates = CloudConnectionService.get_aws_setup_templates("ext-123")
     assert "region=us-east-1" in templates["magic_link"]
+    assert "templates.example.com%2Faws-role.yaml" in templates["magic_link"]

--- a/tests/unit/core/test_config_validation.py
+++ b/tests/unit/core/test_config_validation.py
@@ -185,6 +185,38 @@ class TestSettingsValidation:
             assert settings.DB_SSL_MODE == "disable"
             assert settings.is_production is False
 
+    def test_settings_rejects_invalid_aws_trust_principal_arn(self):
+        with patch.dict("os.environ", {}, clear=True):
+            with pytest.raises(ValidationError) as exc:
+                Settings(
+                    DATABASE_URL="sqlite+aiosqlite:///:memory:",
+                    SUPABASE_JWT_SECRET=FAKE_SUPABASE_SECRET,
+                    ENCRYPTION_KEY=FAKE_ENCRYPTION_KEY,
+                    CSRF_SECRET_KEY=FAKE_CSRF_SECRET,
+                    KDF_SALT=FAKE_KDF_SALT,
+                    DB_SSL_MODE="disable",
+                    AWS_ASSUME_ROLE_TRUST_PRINCIPAL_ARN="not-an-arn",
+                    _env_file=None,
+                )
+
+            assert "AWS_ASSUME_ROLE_TRUST_PRINCIPAL_ARN" in str(exc.value)
+
+    def test_settings_rejects_invalid_cloudformation_template_url(self):
+        with patch.dict("os.environ", {}, clear=True):
+            with pytest.raises(ValidationError) as exc:
+                Settings(
+                    DATABASE_URL="sqlite+aiosqlite:///:memory:",
+                    SUPABASE_JWT_SECRET=FAKE_SUPABASE_SECRET,
+                    ENCRYPTION_KEY=FAKE_ENCRYPTION_KEY,
+                    CSRF_SECRET_KEY=FAKE_CSRF_SECRET,
+                    KDF_SALT=FAKE_KDF_SALT,
+                    DB_SSL_MODE="disable",
+                    CLOUDFORMATION_TEMPLATE_URL="javascript:alert(1)",
+                    _env_file=None,
+                )
+
+            assert "CLOUDFORMATION_TEMPLATE_URL" in str(exc.value)
+
     def test_settings_accepts_local_sqlite_bootstrap_in_local_runtime(self):
         with patch.dict("os.environ", {}, clear=True):
             settings = Settings(

--- a/tests/unit/governance/api/test_public.py
+++ b/tests/unit/governance/api/test_public.py
@@ -79,6 +79,34 @@ async def test_get_csrf_token(async_client: AsyncClient):
 
 
 @pytest.mark.asyncio
+async def test_get_public_aws_setup_template(async_client: AsyncClient):
+    response = await async_client.get("/api/v1/public/templates/aws/valdrics-role.yaml")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("application/x-yaml")
+    assert response.headers["cache-control"] == "public, max-age=300"
+    assert "etag" in response.headers
+    assert "AWSTemplateFormatVersion" in response.text
+    assert "arn:aws:iam::000000000000:role/ValdricsTestControlPlane" in response.text
+    assert "__VALDRICS_ASSUME_ROLE_TRUST_PRINCIPAL_ARN__" not in response.text
+
+
+@pytest.mark.asyncio
+async def test_get_public_aws_setup_template_honors_if_none_match(
+    async_client: AsyncClient,
+):
+    first = await async_client.get("/api/v1/public/templates/aws/valdrics-role.yaml")
+    response = await async_client.get(
+        "/api/v1/public/templates/aws/valdrics-role.yaml",
+        headers={"If-None-Match": first.headers["etag"]},
+    )
+
+    assert first.status_code == 200
+    assert response.status_code == 304
+    assert response.headers["etag"] == first.headers["etag"]
+
+
+@pytest.mark.asyncio
 async def test_run_public_assessment(async_client: AsyncClient):
     """POST /assessment should trigger FreeAssessmentService."""
     mock_result = {"potential_savings": 250.0, "zombies_found": 12}

--- a/tests/unit/governance/domain/jobs/handlers/test_billing_handler.py
+++ b/tests/unit/governance/domain/jobs/handlers/test_billing_handler.py
@@ -2,6 +2,7 @@ import pytest
 from uuid import uuid4
 from unittest.mock import MagicMock, patch, AsyncMock
 from app.modules.governance.domain.jobs.handlers.billing import RecurringBillingHandler
+from app.modules.governance.domain.jobs.errors import PermanentJobError
 from app.models.background_job import BackgroundJob
 
 # We need to mock the imports logic inside the handler
@@ -29,9 +30,9 @@ async def test_execute_subscription_not_found(db):
         return_value=MagicMock(scalar_one_or_none=MagicMock(return_value=None))
     )
 
-    result = await handler.execute(job, db)
-    assert result["status"] == "failed"
-    assert result["reason"] == "subscription_not_found"
+    with pytest.raises(PermanentJobError) as exc:
+        await handler.execute(job, db)
+    assert "subscription not found" in str(exc.value).lower()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/governance/jobs/test_finops.py
+++ b/tests/unit/governance/jobs/test_finops.py
@@ -11,26 +11,23 @@ async def test_finops_analysis_handler():
     job = MagicMock(tenant_id=uuid4(), payload={})
     db = MagicMock()
     aws_conn = MagicMock(id=uuid4(), provider="aws")
-    aws_result = MagicMock()
-    aws_result.scalars.return_value.all.return_value = [aws_conn]
-    empty_result = MagicMock()
-    empty_result.scalars.return_value.all.return_value = []
-    db.execute = AsyncMock(
-        side_effect=[
-            aws_result,  # AWS
-            empty_result,  # Azure
-            empty_result,  # GCP
-            empty_result,  # SaaS
-            empty_result,  # License
-            empty_result,  # Platform
-            empty_result,  # Hybrid
-        ]
-    )
 
     with (
         patch(
-            "app.modules.governance.domain.jobs.handlers.finops.AdapterFactory"
-        ) as mock_factory,
+            "app.modules.governance.domain.jobs.handlers.finops.list_tenant_connections",
+            new=AsyncMock(return_value=[aws_conn]),
+        ),
+        patch(
+            "app.modules.governance.domain.jobs.handlers.finops.resolve_provider_from_connection",
+            return_value="aws",
+        ),
+        patch(
+            "app.modules.governance.domain.jobs.handlers.finops.get_adapter_for_connection"
+        ) as mock_get_adapter,
+        patch(
+            "app.modules.governance.domain.jobs.handlers.finops.fetch_daily_costs_if_supported",
+            new=AsyncMock(),
+        ) as mock_fetch_daily_costs,
         patch("app.modules.governance.domain.jobs.handlers.finops.LLMFactory.create"),
         patch(
             "app.modules.governance.domain.jobs.handlers.finops.FinOpsAnalyzer"
@@ -39,8 +36,8 @@ async def test_finops_analysis_handler():
         adapter = MagicMock()
         usage_summary = MagicMock()
         usage_summary.records = [MagicMock()]
-        adapter.get_daily_costs = AsyncMock(return_value=usage_summary)
-        mock_factory.get_adapter.return_value = adapter
+        mock_get_adapter.return_value = adapter
+        mock_fetch_daily_costs.return_value = usage_summary
 
         analyzer = MockAnalyzer.return_value
         analyzer.analyze = AsyncMock(

--- a/tests/unit/governance/jobs/test_finops_handler_branches.py
+++ b/tests/unit/governance/jobs/test_finops_handler_branches.py
@@ -64,12 +64,12 @@ async def test_execute_skips_when_no_connections() -> None:
     handler = FinOpsAnalysisHandler()
     job = MagicMock(tenant_id=uuid4(), payload={})
     db = MagicMock()
-    empty = _scalar_result([])
-    db.execute = AsyncMock(
-        side_effect=[empty, empty, empty, empty, empty, empty, empty]
-    )
 
-    result = await handler.execute(job, db)
+    with patch(
+        "app.modules.governance.domain.jobs.handlers.finops.list_tenant_connections",
+        new=AsyncMock(return_value=[]),
+    ):
+        result = await handler.execute(job, db)
     assert result == {"status": "skipped", "reason": "no_connections"}
 
 
@@ -79,27 +79,8 @@ async def test_execute_non_aws_path_and_exception_continue() -> None:
     job = MagicMock(tenant_id=uuid4(), payload={})
     db = MagicMock()
 
-    aws_empty = _scalar_result([])
     azure_conn = MagicMock(provider="azure")
     gcp_conn = MagicMock(provider="gcp")
-    azure_result = _scalar_result([azure_conn])
-    gcp_result = _scalar_result([gcp_conn])
-    saas_empty = _scalar_result([])
-    license_empty = _scalar_result([])
-    platform_empty = _scalar_result([])
-    hybrid_empty = _scalar_result([])
-    db.execute = AsyncMock(
-        side_effect=[
-            aws_empty,
-            azure_result,
-            gcp_result,
-            saas_empty,
-            license_empty,
-            platform_empty,
-            hybrid_empty,
-        ]
-    )
-
     azure_adapter = MagicMock()
     azure_adapter.get_cost_and_usage = AsyncMock(
         return_value=[
@@ -124,8 +105,20 @@ async def test_execute_non_aws_path_and_exception_continue() -> None:
 
     with (
         patch(
-            "app.modules.governance.domain.jobs.handlers.finops.AdapterFactory.get_adapter",
+            "app.modules.governance.domain.jobs.handlers.finops.list_tenant_connections",
+            new=AsyncMock(return_value=[azure_conn, gcp_conn]),
+        ),
+        patch(
+            "app.modules.governance.domain.jobs.handlers.finops.resolve_provider_from_connection",
+            side_effect=["azure", "gcp"],
+        ),
+        patch(
+            "app.modules.governance.domain.jobs.handlers.finops.get_adapter_for_connection",
             side_effect=[azure_adapter, gcp_adapter],
+        ),
+        patch(
+            "app.modules.governance.domain.jobs.handlers.finops.fetch_daily_costs_if_supported",
+            new=AsyncMock(return_value=None),
         ),
         patch(
             "app.modules.governance.domain.jobs.handlers.finops.LLMFactory.create",
@@ -158,24 +151,29 @@ async def test_execute_skips_when_no_analysis_payloads() -> None:
     db = MagicMock()
 
     aws_conn = MagicMock(provider="aws")
-    aws_result = _scalar_result([aws_conn])
-    empty = _scalar_result([])
-    db.execute = AsyncMock(
-        side_effect=[aws_result, empty, empty, empty, empty, empty, empty]
-    )
-
     usage_summary = MagicMock()
     usage_summary.records = [MagicMock()]
     aws_adapter = MagicMock()
-    aws_adapter.get_daily_costs = AsyncMock(return_value=usage_summary)
 
     analyzer = MagicMock()
     analyzer.analyze = AsyncMock(return_value="non-dict-result")
 
     with (
         patch(
-            "app.modules.governance.domain.jobs.handlers.finops.AdapterFactory.get_adapter",
+            "app.modules.governance.domain.jobs.handlers.finops.list_tenant_connections",
+            new=AsyncMock(return_value=[aws_conn]),
+        ),
+        patch(
+            "app.modules.governance.domain.jobs.handlers.finops.resolve_provider_from_connection",
+            return_value="aws",
+        ),
+        patch(
+            "app.modules.governance.domain.jobs.handlers.finops.get_adapter_for_connection",
             return_value=aws_adapter,
+        ),
+        patch(
+            "app.modules.governance.domain.jobs.handlers.finops.fetch_daily_costs_if_supported",
+            new=AsyncMock(return_value=usage_summary),
         ),
         patch(
             "app.modules.governance.domain.jobs.handlers.finops.LLMFactory.create",

--- a/tests/unit/governance/scheduler/test_cohorts.py
+++ b/tests/unit/governance/scheduler/test_cohorts.py
@@ -75,6 +75,12 @@ class TestGetTenantCohort:
         last_active = datetime.now(timezone.utc) - timedelta(days=6)
         assert get_tenant_cohort(tenant, last_active) == TenantCohort.ACTIVE
 
+    def test_naive_last_active_is_treated_as_utc(self):
+        """Naive activity timestamps should not break dormancy classification."""
+        tenant = self._make_tenant("growth")
+        last_active = datetime.now() - timedelta(days=8)
+        assert get_tenant_cohort(tenant, last_active) == TenantCohort.DORMANT
+
     def test_high_value_not_affected_by_dormancy(self):
         """Enterprise/Pro should be HIGH_VALUE even if inactive."""
         tenant = self._make_tenant("enterprise")

--- a/tests/unit/governance/settings/conftest.py
+++ b/tests/unit/governance/settings/conftest.py
@@ -4,6 +4,7 @@ import os
 import uuid
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
+from contextlib import ExitStack
 from pathlib import Path
 from tempfile import mkstemp
 from typing import Any, TYPE_CHECKING
@@ -71,13 +72,12 @@ async def async_engine() -> AsyncGenerator[Any, None]:
     from sqlalchemy import create_engine
     from sqlalchemy.ext.asyncio import create_async_engine
 
-    from app.models.background_job import BackgroundJob
-    from app.models.notification_settings import NotificationSettings
-    from app.models.remediation_settings import RemediationSettings
-    from app.models.sso_domain_mapping import SsoDomainMapping
-    from app.models.tenant import Tenant, User
-    from app.models.tenant_identity_settings import TenantIdentitySettings
-    from app.modules.governance.domain.security.audit_log import AuditLog
+    from app.shared.db.base import Base
+    from tests import conftest as root_test_conftest
+
+    # Mirror the root suite bootstrap so every mapped table exists even when
+    # this subtree runs after other modules have already imported part of the ORM.
+    root_test_conftest._register_models()
 
     fd, raw_path = mkstemp(prefix="valdrics-settings-", suffix=".sqlite")
     os.close(fd)
@@ -85,19 +85,7 @@ async def async_engine() -> AsyncGenerator[Any, None]:
     path = Path(raw_path)
 
     sync_engine = create_engine(f"sqlite:///{path}")
-    Tenant.metadata.create_all(
-        sync_engine,
-        tables=[
-            Tenant.__table__,
-            User.__table__,
-            BackgroundJob.__table__,
-            NotificationSettings.__table__,
-            RemediationSettings.__table__,
-            SsoDomainMapping.__table__,
-            TenantIdentitySettings.__table__,
-            AuditLog.__table__,
-        ],
-    )
+    Base.metadata.create_all(sync_engine)
     sync_engine.dispose()
 
     engine = create_async_engine(f"sqlite+aiosqlite:///{path}")
@@ -137,27 +125,52 @@ async def async_client(
     from httpx import ASGITransport, AsyncClient
 
     from app.shared.db.session import get_db, get_system_db
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+    from unittest.mock import patch
 
     old_db_override = app.dependency_overrides.get(get_db)
     old_system_db_override = app.dependency_overrides.get(get_system_db)
-    app.dependency_overrides[get_db] = lambda: db
-    app.dependency_overrides[get_system_db] = lambda: db
+    session_maker = async_sessionmaker(
+        bind=db.bind,
+        class_=AsyncSession,
+        expire_on_commit=False,
+    )
+    modules_to_patch = [
+        "app.shared.db.session.async_session_maker",
+        "app.shared.connections.oidc.async_session_maker",
+        "app.modules.governance.api.v1.jobs.async_session_maker",
+        "app.modules.governance.domain.jobs.cur_ingestion.async_session_maker",
+        "app.modules.governance.domain.jobs.processor.async_session_maker",
+        "app.tasks.scheduler_tasks.async_session_maker",
+        "app.shared.llm.pricing_data.async_session_maker",
+        "app.main.async_session_maker",
+    ]
 
-    try:
-        transport = ASGITransport(app=app)
-        async with AsyncClient(transport=transport, base_url="http://test") as client:
-            setattr(client, "app", app)
-            yield client
-    finally:
-        if old_db_override is not None:
-            app.dependency_overrides[get_db] = old_db_override
-        else:
-            app.dependency_overrides.pop(get_db, None)
+    with ExitStack() as stack:
+        for target in modules_to_patch:
+            try:
+                stack.enter_context(patch(target, session_maker))
+            except (ImportError, AttributeError):
+                continue
 
-        if old_system_db_override is not None:
-            app.dependency_overrides[get_system_db] = old_system_db_override
-        else:
-            app.dependency_overrides.pop(get_system_db, None)
+        app.dependency_overrides[get_db] = lambda: db
+        app.dependency_overrides[get_system_db] = lambda: db
+
+        try:
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                setattr(client, "app", app)
+                yield client
+        finally:
+            if old_db_override is not None:
+                app.dependency_overrides[get_db] = old_db_override
+            else:
+                app.dependency_overrides.pop(get_db, None)
+
+            if old_system_db_override is not None:
+                app.dependency_overrides[get_system_db] = old_system_db_override
+            else:
+                app.dependency_overrides.pop(get_system_db, None)
 
 
 @pytest_asyncio.fixture

--- a/tests/unit/governance/settings/test_connections.py
+++ b/tests/unit/governance/settings/test_connections.py
@@ -55,6 +55,7 @@ async def test_get_aws_setup_templates(async_client: AsyncClient):
     data = response.json()
     assert "cloudformation_yaml" in data
     assert "terraform_hcl" in data
+    assert "AWSTemplateFormatVersion" in data["cloudformation_yaml"]
 
 
 @pytest.mark.asyncio
@@ -114,7 +115,7 @@ async def test_create_azure_connection_denied_on_free_tier(
         "/api/v1/settings/connections/azure", json=payload
     )
     assert response.status_code == 403
-    assert "requires 'Growth' plan or higher" in response.json()["error"]
+    assert "requires 'Starter' plan or higher" in response.json()["error"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/governance/settings/test_connections_branches.py
+++ b/tests/unit/governance/settings/test_connections_branches.py
@@ -53,6 +53,7 @@ def db() -> MagicMock:
     mock_db = MagicMock()
     mock_db.scalar = AsyncMock()
     mock_db.execute = AsyncMock()
+    mock_db.flush = AsyncMock()
     mock_db.commit = AsyncMock()
     mock_db.refresh = AsyncMock()
     mock_db.delete = AsyncMock()
@@ -70,6 +71,14 @@ def test_require_tenant_id_raises_when_missing() -> None:
 def test_enforce_multi_cloud_tier_rejects_free(user: CurrentUser) -> None:
     with pytest.raises(HTTPException) as exc:
         connections_helpers._enforce_multi_cloud_tier(PricingTier.FREE, user)
+    assert exc.value.status_code == 403
+
+
+def test_enforce_aws_org_discovery_tier_rejects_starter(user: CurrentUser) -> None:
+    with pytest.raises(HTTPException) as exc:
+        connections_helpers._enforce_aws_org_discovery_tier(
+            PricingTier.STARTER, user
+        )
     assert exc.value.status_code == 403
 
 
@@ -100,6 +109,16 @@ async def test_check_multi_cloud_tier_allows_starter(
 ) -> None:
     user.tier = PricingTier.STARTER
     connections_helpers.check_multi_cloud_tier(user)
+
+
+@pytest.mark.asyncio
+async def test_check_aws_org_discovery_tier_denied_for_starter(
+    user: CurrentUser,
+) -> None:
+    user.tier = PricingTier.STARTER
+    with pytest.raises(HTTPException) as exc:
+        connections_helpers.check_aws_org_discovery_tier(user)
+    assert exc.value.status_code == 403
 
 
 @pytest.mark.asyncio
@@ -138,9 +157,27 @@ async def test_create_aws_connection_defaults_region_global(
         )
 
     assert response.region == "global"
-    assert db.add.call_count == 1
-    created = db.add.call_args.args[0]
+    assert db.add.call_count >= 1
+    created = db.add.call_args_list[0].args[0]
     assert created.region == "global"
+
+
+@pytest.mark.asyncio
+async def test_create_aws_connection_rejects_management_account_below_growth(
+    user: CurrentUser, db: MagicMock
+) -> None:
+    user.tier = PricingTier.STARTER
+    payload = AWSConnectionCreate(
+        aws_account_id="210987654321",
+        role_arn="arn:aws:iam::210987654321:role/TestRole",
+        external_id="vx-" + "b" * 32,
+        is_management_account=True,
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await aws_discovery_api.create_aws_connection(MagicMock(), payload, user, db)
+
+    assert exc.value.status_code == 403
 
 
 @pytest.mark.asyncio

--- a/tests/unit/governance/settings/test_governance_deep.py
+++ b/tests/unit/governance/settings/test_governance_deep.py
@@ -86,6 +86,7 @@ async def test_connections_settings_lifecycle(
         response = await async_client.post("/api/v1/settings/connections/aws/setup")
         assert response.status_code == 200
         assert "cloudformation_yaml" in response.json()
+        assert "AWSTemplateFormatVersion" in response.json()["cloudformation_yaml"]
 
         # Check Azure setup snippet
         response = await async_client.post("/api/v1/settings/connections/azure/setup")

--- a/tests/unit/governance/settings/test_identity_settings_direct_branches.py
+++ b/tests/unit/governance/settings/test_identity_settings_direct_branches.py
@@ -132,6 +132,34 @@ async def test_get_identity_diagnostics_reports_sso_scim_issues() -> None:
 
 
 @pytest.mark.asyncio
+async def test_get_identity_diagnostics_normalizes_naive_scim_rotation_timestamp() -> None:
+    tenant_id = uuid4()
+    rotated_at = datetime.now() - timedelta(days=120)
+    identity = SimpleNamespace(
+        sso_enabled=False,
+        allowed_email_domains=[],
+        sso_federation_enabled=False,
+        sso_federation_mode="domain",
+        sso_federation_provider_id=None,
+        scim_enabled=True,
+        scim_bearer_token="secret-token",
+        scim_token_bidx="blind-index",
+        scim_last_rotated_at=rotated_at,
+    )
+    mock_db = AsyncMock()
+    mock_db.execute.return_value = _ScalarOneResult(identity)
+
+    response = await identity_api.get_identity_diagnostics(
+        current_user=_admin_user(tenant_id, tier=PricingTier.ENTERPRISE),
+        db=mock_db,
+    )
+
+    assert response.scim.last_rotated_at == rotated_at.replace(tzinfo=timezone.utc).isoformat()
+    assert response.scim.token_age_days is not None
+    assert response.scim.rotation_overdue is True
+
+
+@pytest.mark.asyncio
 async def test_sso_federation_validation_bootstraps_missing_identity(
     monkeypatch,
 ) -> None:
@@ -378,7 +406,7 @@ async def test_update_identity_settings_fails_when_audit_logging_fails(
 
     monkeypatch.setattr(identity_api, "AuditLogger", _AuditLoggerFailure)
 
-    with pytest.raises(RuntimeError, match="audit unavailable"):
+    with pytest.raises(HTTPException) as exc:
         await identity_api.update_identity_settings(
             payload=payload,
             current_user=_admin_user(
@@ -388,6 +416,8 @@ async def test_update_identity_settings_fails_when_audit_logging_fails(
             ),
             db=mock_db,
         )
+    assert exc.value.status_code == 500
+    mock_db.rollback.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -436,8 +466,10 @@ async def test_rotate_scim_token_fails_when_audit_logging_fails(
 
     monkeypatch.setattr(identity_api, "AuditLogger", _AuditLoggerFailure)
 
-    with pytest.raises(RuntimeError, match="audit unavailable"):
+    with pytest.raises(HTTPException) as exc:
         await identity_api.rotate_scim_token(
             current_user=_admin_user(tenant_id, tier=PricingTier.ENTERPRISE),
             db=mock_db,
         )
+    assert exc.value.status_code == 500
+    mock_db.rollback.assert_awaited_once()

--- a/tests/unit/governance/settings/test_notifications_core_slack.py
+++ b/tests/unit/governance/settings/test_notifications_core_slack.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import uuid
-from unittest.mock import AsyncMock, patch
+from unittest.mock import ANY, AsyncMock, patch
 
 import pytest
 from httpx import AsyncClient
@@ -181,7 +181,7 @@ async def test_test_slack_notification_uses_override(
         response = await async_client.post("/api/v1/settings/notifications/test-slack")
 
     assert response.status_code == 200
-    mock_get_tenant.assert_awaited_once_with(db, tenant_id)
+    mock_get_tenant.assert_awaited_once_with(ANY, tenant_id)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/governance/settings/test_profile_settings.py
+++ b/tests/unit/governance/settings/test_profile_settings.py
@@ -1,4 +1,6 @@
 import uuid
+from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 from httpx import AsyncClient
@@ -196,11 +198,19 @@ async def test_update_profile_audit_uses_forwarded_ip(async_client: AsyncClient,
 
     app.dependency_overrides[get_current_user] = lambda: mock_user
     try:
-        response = await async_client.put(
-            "/api/v1/settings/profile",
-            json={"persona": "finance"},
-            headers={"X-Forwarded-For": "198.51.100.10, 203.0.113.9"},
-        )
+        with patch(
+            "app.modules.governance.api.v1.settings.profile.get_settings",
+            return_value=SimpleNamespace(
+                TRUST_PROXY_HEADERS=True,
+                TRUSTED_PROXY_CIDRS=["127.0.0.1/32"],
+                TRUSTED_PROXY_HOPS=2,
+            ),
+        ):
+            response = await async_client.put(
+                "/api/v1/settings/profile",
+                json={"persona": "finance"},
+                headers={"X-Forwarded-For": "198.51.100.10, 203.0.113.9"},
+            )
         assert response.status_code == 200
 
         audit_row = (

--- a/tests/unit/governance/settings/test_settings_branch_paths.py
+++ b/tests/unit/governance/settings/test_settings_branch_paths.py
@@ -262,7 +262,13 @@ async def test_llm_get_update_and_models_paths(
 
     with patch(
         "app.shared.llm.pricing_data.LLM_PRICING",
-        {"groq": {"m1": {}, "m2": {}}, "openai": {"o1": {}}},
+        {
+            "groq": {
+                "m1": {"input": 0.1, "output": 0.2},
+                "m2": {"input": 0.3, "output": 0.4},
+            },
+            "openai": {"o1": {"input": 1.0, "output": 2.0}},
+        },
     ):
         models = await llm.get_llm_models()
     assert models["groq"] == ["m1", "m2"]

--- a/tests/unit/governance/test_connections_api_aws.py
+++ b/tests/unit/governance/test_connections_api_aws.py
@@ -57,6 +57,19 @@ async def test_aws_setup_templates(ac, override_auth):
 
 
 @pytest.mark.asyncio
+async def test_aws_setup_templates_returns_503_when_runtime_is_misconfigured(
+    ac, override_auth
+):
+    with patch(
+        "app.shared.connections.aws.AWSConnectionService.get_setup_templates",
+        side_effect=RuntimeError("missing trust principal"),
+    ):
+        resp = await ac.post("/api/v1/settings/connections/aws/setup")
+
+    assert resp.status_code == 503
+
+
+@pytest.mark.asyncio
 async def test_cloud_plus_setup_templates(ac, override_auth):
     saas = await ac.post("/api/v1/settings/connections/saas/setup")
     assert saas.status_code == 200
@@ -87,6 +100,7 @@ async def test_cloud_plus_setup_templates(ac, override_auth):
 
 @pytest.mark.asyncio
 async def test_create_aws_connection(ac, override_auth, auth_user, db):
+    auth_user.tier = PricingTier.GROWTH
     payload = {
         "aws_account_id": "123456789012",
         "role_arn": "arn:aws:iam::123456789012:role/Valdrics",
@@ -101,6 +115,32 @@ async def test_create_aws_connection(ac, override_auth, auth_user, db):
     assert data["aws_account_id"] == "123456789012"
     assert "id" in data
     assert "created_at" in data
+
+
+@pytest.mark.asyncio
+async def test_create_management_aws_connection_requires_growth(
+    ac, override_auth, auth_user
+):
+    auth_user.tier = PricingTier.STARTER
+    payload = {
+        "aws_account_id": "123456789012",
+        "role_arn": "arn:aws:iam::123456789012:role/Valdrics",
+        "external_id": "vx-12345678901234567890123456789012",
+        "region": "us-east-1",
+        "is_management_account": True,
+        "organization_id": "o-123",
+    }
+
+    resp = await ac.post("/api/v1/settings/connections/aws", json=payload)
+
+    assert resp.status_code == 403
+    payload = resp.json()
+    detail = payload.get("detail")
+    if detail is None and isinstance(payload.get("error"), dict):
+        detail = payload["error"].get("message")
+    if detail is None:
+        detail = str(payload.get("error") or payload)
+    assert "requires 'Growth' plan or higher" in detail
 
 
 @pytest.mark.asyncio
@@ -143,6 +183,7 @@ async def test_duplicate_aws_connection(ac, db, override_auth, auth_user):
 
 @pytest.mark.asyncio
 async def test_sync_aws_org(ac, db, override_auth, auth_user):
+    auth_user.tier = PricingTier.GROWTH
     # Create management account
     conn = AWSConnection(
         tenant_id=auth_user.tenant_id,
@@ -166,6 +207,7 @@ async def test_sync_aws_org(ac, db, override_auth, auth_user):
 
 @pytest.mark.asyncio
 async def test_sync_aws_org_not_management(ac, db, override_auth, auth_user):
+    auth_user.tier = PricingTier.GROWTH
     # Standard connection (not management)
     conn = AWSConnection(
         tenant_id=auth_user.tenant_id,

--- a/tests/unit/governance/test_connections_api_azure.py
+++ b/tests/unit/governance/test_connections_api_azure.py
@@ -12,7 +12,14 @@ pytest_plugins = ("tests.unit.governance.connections_api_fixtures",)
 
 
 @pytest.mark.asyncio
-async def test_create_azure_connection_denied_on_free(ac, override_auth):
+async def test_create_azure_connection_success_on_starter(
+    ac, db, override_auth, auth_user
+):
+    tenant = await db.get(Tenant, auth_user.tenant_id)
+    tenant.plan = PricingTier.STARTER.value
+    await db.commit()
+    auth_user.tier = PricingTier.STARTER
+
     payload = {
         "name": "Azure Test",
         "azure_tenant_id": str(uuid4()),
@@ -21,11 +28,8 @@ async def test_create_azure_connection_denied_on_free(ac, override_auth):
         "client_secret": "secret",
     }
     resp = await ac.post("/api/v1/settings/connections/azure", json=payload)
-    assert resp.status_code == 403
-    data = resp.json()
-
-    val = data.get("detail", str(data))
-    assert "Growth" in val
+    assert resp.status_code == 201
+    assert resp.json()["subscription_id"] == payload["subscription_id"]
 
 
 @pytest.mark.asyncio
@@ -145,10 +149,13 @@ async def test_verify_azure_connection_tenant_isolation(
 
 
 @pytest.mark.asyncio
-async def test_verify_azure_connection_denied_on_free(ac, db, override_auth, auth_user):
+async def test_verify_azure_connection_success_on_starter(
+    ac, db, override_auth, auth_user
+):
     tenant = await db.get(Tenant, auth_user.tenant_id)
-    tenant.plan = PricingTier.FREE.value
+    tenant.plan = PricingTier.STARTER.value
     await db.commit()
+    auth_user.tier = PricingTier.STARTER
 
     conn = AzureConnection(
         tenant_id=auth_user.tenant_id,
@@ -156,12 +163,17 @@ async def test_verify_azure_connection_denied_on_free(ac, db, override_auth, aut
         azure_tenant_id="t",
         client_id="c",
         subscription_id="s",
+        client_secret="secret",
     )
     db.add(conn)
     await db.commit()
 
-    resp = await ac.post(f"/api/v1/settings/connections/azure/{conn.id}/verify")
-    assert resp.status_code == 403
+    with patch(
+        "app.shared.connections.azure.AzureConnectionService.verify_connection"
+    ) as mock_verify:
+        mock_verify.return_value = {"status": "verified"}
+        resp = await ac.post(f"/api/v1/settings/connections/azure/{conn.id}/verify")
+    assert resp.status_code == 200
 
 
 @pytest.mark.asyncio

--- a/tests/unit/governance/test_connections_api_discovered.py
+++ b/tests/unit/governance/test_connections_api_discovered.py
@@ -15,8 +15,7 @@ pytest_plugins = ("tests.unit.governance.connections_api_fixtures",)
 
 @pytest.mark.asyncio
 async def test_link_discovered_account(ac, db, override_auth, auth_user):
-    # Free tier only allows 1 AWS account; org discovery + link needs a higher tier.
-    auth_user.tier = PricingTier.STARTER
+    auth_user.tier = PricingTier.GROWTH
     # 1. Create management connection
     mgmt = AWSConnection(
         tenant_id=auth_user.tenant_id,
@@ -55,6 +54,7 @@ async def test_link_discovered_account(ac, db, override_auth, auth_user):
 
 @pytest.mark.asyncio
 async def test_link_discovered_account_idempotent(ac, db, override_auth, auth_user):
+    auth_user.tier = PricingTier.GROWTH
     # 1. Management connection
     mgmt = AWSConnection(
         tenant_id=auth_user.tenant_id,
@@ -98,6 +98,7 @@ async def test_link_discovered_account_idempotent(ac, db, override_auth, auth_us
 
 @pytest.mark.asyncio
 async def test_link_discovered_account_not_authorized(ac, db, override_auth, auth_user):
+    auth_user.tier = PricingTier.GROWTH
     other_tenant = Tenant(id=uuid4(), name="Other", plan=PricingTier.GROWTH.value)
     db.add(other_tenant)
     await db.commit()
@@ -127,7 +128,8 @@ async def test_link_discovered_account_not_authorized(ac, db, override_auth, aut
 
 
 @pytest.mark.asyncio
-async def test_list_discovered_accounts_empty(ac, override_auth):
+async def test_list_discovered_accounts_empty(ac, override_auth, auth_user):
+    auth_user.tier = PricingTier.GROWTH
     resp = await ac.get("/api/v1/settings/connections/aws/discovered")
     assert resp.status_code == 200
     assert resp.json() == []
@@ -135,6 +137,7 @@ async def test_list_discovered_accounts_empty(ac, override_auth):
 
 @pytest.mark.asyncio
 async def test_list_discovered_accounts_sorted(ac, db, override_auth, auth_user):
+    auth_user.tier = PricingTier.GROWTH
     mgmt = AWSConnection(
         tenant_id=auth_user.tenant_id,
         aws_account_id="222233334444",
@@ -167,3 +170,19 @@ async def test_list_discovered_accounts_sorted(ac, db, override_auth, auth_user)
     assert resp.status_code == 200
     data = resp.json()
     assert data[0]["account_id"] == "222200002222"
+
+
+@pytest.mark.asyncio
+async def test_list_discovered_accounts_requires_growth(ac, override_auth, auth_user):
+    auth_user.tier = PricingTier.STARTER
+
+    resp = await ac.get("/api/v1/settings/connections/aws/discovered")
+
+    assert resp.status_code == 403
+    payload = resp.json()
+    detail = payload.get("detail")
+    if detail is None and isinstance(payload.get("error"), dict):
+        detail = payload["error"].get("message")
+    if detail is None:
+        detail = str(payload.get("error") or payload)
+    assert "requires 'Growth' plan or higher" in detail

--- a/tests/unit/governance/test_connections_api_gcp.py
+++ b/tests/unit/governance/test_connections_api_gcp.py
@@ -94,17 +94,28 @@ async def test_create_gcp_connection_workload_identity_verification_failure(
 
 
 @pytest.mark.asyncio
-async def test_verify_gcp_connection_denied_on_free(ac, db, override_auth, auth_user):
+async def test_verify_gcp_connection_success_on_starter(
+    ac, db, override_auth, auth_user
+):
     tenant = await db.get(Tenant, auth_user.tenant_id)
-    tenant.plan = PricingTier.FREE.value
+    tenant.plan = PricingTier.STARTER.value
     await db.commit()
+    auth_user.tier = PricingTier.STARTER
 
-    conn = GCPConnection(tenant_id=auth_user.tenant_id, name="g", project_id="p")
+    conn = GCPConnection(
+        tenant_id=auth_user.tenant_id,
+        name="g",
+        project_id="proj-valid-123",
+    )
     db.add(conn)
     await db.commit()
 
-    resp = await ac.post(f"/api/v1/settings/connections/gcp/{conn.id}/verify")
-    assert resp.status_code == 403
+    with patch(
+        "app.shared.connections.gcp.GCPConnectionService.verify_connection"
+    ) as mock_verify:
+        mock_verify.return_value = {"status": "verified"}
+        resp = await ac.post(f"/api/v1/settings/connections/gcp/{conn.id}/verify")
+    assert resp.status_code == 200
 
 
 @pytest.mark.asyncio

--- a/tests/unit/governance/test_job_metrics_branches.py
+++ b/tests/unit/governance/test_job_metrics_branches.py
@@ -145,6 +145,41 @@ async def test_compute_job_slo_returns_empty_metrics_for_no_terminal_jobs(
 
 
 @pytest.mark.asyncio
+async def test_compute_job_slo_normalizes_naive_started_and_completed_timestamps(
+    db, test_tenant
+) -> None:
+    created_at = datetime.now(timezone.utc) - timedelta(hours=1)
+    naive_started = datetime(2026, 2, 1, 9, 0, 0)
+    naive_completed = datetime(2026, 2, 1, 9, 4, 0)
+    db.add(
+        _job(
+            tenant_id=test_tenant.id,
+            job_type="finops_analysis",
+            status=JobStatus.COMPLETED.value,
+            created_at=created_at,
+            scheduled_for=created_at,
+            started_at=naive_started,
+            completed_at=naive_completed,
+        )
+    )
+    await db.commit()
+
+    payload = await compute_job_slo(
+        db,
+        tenant_id=test_tenant.id,
+        window_hours=24,
+        target_success_rate_percent=10,
+    )
+
+    metric = payload["metrics"][0]
+    assert metric["avg_duration_seconds"] == 240.0
+    assert metric["p95_duration_seconds"] == 240.0
+    assert metric["latest_completed_at"] == naive_completed.replace(
+        tzinfo=timezone.utc
+    ).isoformat()
+
+
+@pytest.mark.asyncio
 async def test_compute_job_backlog_snapshot_counts_and_oldest_pending_age(
     db, test_tenant
 ) -> None:

--- a/tests/unit/governance/test_onboard_audit.py
+++ b/tests/unit/governance/test_onboard_audit.py
@@ -84,7 +84,7 @@ async def test_onboard_success(mock_db, current_user):
 
     request_obj = Request(scope=scope)
 
-    with patch("app.modules.governance.api.v1.settings.onboard.audit_log"):
+    with patch("app.modules.governance.api.v1.settings.onboard.durable_audit_log"):
         with patch("app.shared.core.rate_limit.get_limiter") as mock_limiter:
             mock_limiter.return_value.limit.return_value = lambda x: x
 

--- a/tests/unit/llm/test_factory_audit.py
+++ b/tests/unit/llm/test_factory_audit.py
@@ -88,8 +88,8 @@ def test_estimate_cost():
     # OpenAI default: input $0.15, output $0.60 per 1M (example)
     # Price is 0 if provider or default pricing is missing.
     with patch(
-        "app.shared.llm.factory.LLM_PRICING",
-        {"openai": {"default": MagicMock(input=0.15, output=0.60)}},
+        "app.shared.llm.factory.get_provider_pricing",
+        return_value={"default": MagicMock(input=0.15, output=0.60)},
     ):
         cost = LLMFactory.estimate_cost("openai", 1_000_000, 1_000_000)
         assert cost == 0.75

--- a/tests/unit/llm/test_factory_exhaustive.py
+++ b/tests/unit/llm/test_factory_exhaustive.py
@@ -53,15 +53,14 @@ class TestFactoryExhaustive:
 
         # Test with a provider that exists
         with patch(
-            "app.shared.llm.factory.LLM_PRICING",
-            {"test_prov": {"default": MagicMock(input=0.15, output=0.60)}},
+            "app.shared.llm.factory.get_provider_pricing",
+            return_value={"default": MagicMock(input=0.15, output=0.60)},
         ):
             # 1M input, 1M output -> 0.15 + 0.60 = 0.75
             cost = LLMFactory.estimate_cost("test_prov", 1_000_000, 1_000_000)
             assert cost == 0.75
-
-            # Test empty provider
-            assert LLMFactory.estimate_cost("unknown", 100, 100) == 0.0
+        # Test empty provider
+        assert LLMFactory.estimate_cost("unknown", 100, 100) == 0.0
 
     def test_create_unsupported_provider(self):
         """Test create with unsupported provider (line 164)."""

--- a/tests/unit/modules/optimization/adapters/aws/plugins/test_storage_branch_paths.py
+++ b/tests/unit/modules/optimization/adapters/aws/plugins/test_storage_branch_paths.py
@@ -7,6 +7,7 @@ import pytest
 from botocore.exceptions import ClientError
 
 from app.modules.optimization.adapters.aws.plugins import storage as storage_plugins
+from app.modules.reporting.domain.pricing.service import PricingQuote
 
 
 class AsyncContext:
@@ -54,6 +55,20 @@ def _client_error(code: str = "AccessDenied", operation: str = "TestOperation") 
     return ClientError({"Error": {"Code": code, "Message": code}}, operation)
 
 
+def _pricing_quote(*, monthly_cost_usd: float) -> PricingQuote:
+    return PricingQuote(
+        provider="aws",
+        resource_type="volume",
+        resource_size="test",
+        requested_region="us-east-1",
+        effective_region="us-east-1",
+        hourly_rate_usd=0.0,
+        monthly_cost_usd=monthly_cost_usd,
+        source="unit-test",
+        pricing_metadata={"pricing_confidence": "catalog_exact"},
+    )
+
+
 def test_storage_plugin_category_keys() -> None:
     assert storage_plugins.UnattachedVolumesPlugin().category_key == "unattached_volumes"
     assert storage_plugins.OldSnapshotsPlugin().category_key == "old_snapshots"
@@ -91,8 +106,11 @@ async def test_unattached_volumes_metric_check_failure_logs_and_still_emits_zomb
     with (
         patch.object(storage_plugins, "logger") as logger_mock,
         patch(
-            "app.modules.reporting.domain.pricing.service.PricingService.estimate_monthly_waste",
-            side_effect=[12.345, 1.234],
+            "app.modules.reporting.domain.pricing.service.PricingService.estimate_monthly_waste_quote",
+            side_effect=[
+                _pricing_quote(monthly_cost_usd=12.345),
+                _pricing_quote(monthly_cost_usd=1.234),
+            ],
         ),
     ):
         zombies = await plugin.scan(session=MagicMock(), region="us-east-1")

--- a/tests/unit/modules/optimization/adapters/aws/test_aws_next_gen.py
+++ b/tests/unit/modules/optimization/adapters/aws/test_aws_next_gen.py
@@ -3,6 +3,8 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 import sys
 
+from app.modules.reporting.domain.pricing.service import PricingQuote
+
 # -----------------------------------------------------------------------------
 # Test: IdleOpenSearchPlugin
 # -----------------------------------------------------------------------------
@@ -131,8 +133,18 @@ async def test_idle_opensearch_plugin_uses_pricing_service(mock_aws_creds):
         )
 
         with patch(
-            "app.modules.optimization.adapters.aws.plugins.search.PricingService.estimate_monthly_waste",
-            return_value=42.0,
+            "app.modules.optimization.adapters.aws.plugins.search.PricingService.estimate_monthly_waste_quote",
+            return_value=PricingQuote(
+                provider="aws",
+                resource_type="opensearch",
+                resource_size="t3.small.search",
+                requested_region="us-east-1",
+                effective_region="us-east-1",
+                hourly_rate_usd=0.0,
+                monthly_cost_usd=42.0,
+                source="unit-test",
+                pricing_metadata={"pricing_confidence": "catalog_exact"},
+            ),
         ) as estimate:
             zombies = await plugin.scan(
                 session=mock_session,

--- a/tests/unit/modules/optimization/adapters/azure/test_azure_rightsizing.py
+++ b/tests/unit/modules/optimization/adapters/azure/test_azure_rightsizing.py
@@ -72,7 +72,8 @@ async def test_overprovisioned_vm_plugin_scan(mock_azure_creds):
 
         # Patch the Client creation context managers or constructors
         with patch("app.modules.optimization.adapters.azure.plugins.rightsizing.ComputeManagementClient", return_value=mock_compute_client), \
-             patch("app.modules.optimization.adapters.azure.plugins.rightsizing.MonitorManagementClient", return_value=mock_monitor_client):
+             patch("app.modules.optimization.adapters.azure.plugins.rightsizing.MonitorManagementClient", return_value=mock_monitor_client), \
+             patch("app.modules.optimization.adapters.azure.plugins.rightsizing.PricingService.estimate_monthly_waste", return_value=123.45):
             
             zombies = await plugin.scan(
                 session="sub-id",
@@ -84,15 +85,13 @@ async def test_overprovisioned_vm_plugin_scan(mock_azure_creds):
     z = zombies[0]
     assert z["resource_id"] == mock_vm.id
     assert z["resource_type"] == "Azure Virtual Machine"
+    assert z["monthly_cost"] == 123.45
     assert "Standard_D4s_v3" in z["recommendation"]
     assert "Max CPU" in z["explainability_notes"]
     assert z["confidence_score"] > 0.8
 
 
-@pytest.mark.asyncio
-async def test_overprovisioned_vm_plugin_does_not_swallow_base_exceptions(
-    mock_azure_creds,
-):
+def test_azure_recoverable_exception_contract_excludes_baseexceptions() -> None:
     class FatalAzureFailure(BaseException):
         pass
 
@@ -105,18 +104,15 @@ async def test_overprovisioned_vm_plugin_does_not_swallow_base_exceptions(
         },
     ):
         from app.modules.optimization.adapters.azure.plugins.rightsizing import (
-            OverprovisionedVmPlugin,
+            AZURE_RIGHTSIZING_SCAN_RECOVERABLE_EXCEPTIONS,
         )
 
-        plugin = OverprovisionedVmPlugin()
-
-    with patch(
-        "app.modules.optimization.adapters.azure.plugins.rightsizing.ComputeManagementClient",
-        side_effect=FatalAzureFailure("fatal"),
-    ):
-        with pytest.raises(FatalAzureFailure):
-            await plugin.scan(
-                session="sub-id",
-                region="global",
-                credentials=mock_azure_creds,
-            )
+    assert all(
+        issubclass(exception_type, Exception)
+        for exception_type in AZURE_RIGHTSIZING_SCAN_RECOVERABLE_EXCEPTIONS
+    )
+    assert not issubclass(
+        FatalAzureFailure,
+        AZURE_RIGHTSIZING_SCAN_RECOVERABLE_EXCEPTIONS,
+    )
+    assert issubclass(ValueError, AZURE_RIGHTSIZING_SCAN_RECOVERABLE_EXCEPTIONS)

--- a/tests/unit/modules/optimization/adapters/gcp/test_gcp_next_gen.py
+++ b/tests/unit/modules/optimization/adapters/gcp/test_gcp_next_gen.py
@@ -49,7 +49,8 @@ async def test_idle_vertex_endpoints_plugin_scan(mock_gcp_creds):
             create=True,
         ), \
              patch("app.modules.optimization.adapters.gcp.plugins.ai.service_account", MagicMock()), \
-             patch("app.modules.optimization.adapters.gcp.plugins.ai.monitoring_v3.MetricServiceClient", return_value=mock_monitor):
+             patch("app.modules.optimization.adapters.gcp.plugins.ai.monitoring_v3.MetricServiceClient", return_value=mock_monitor), \
+             patch("app.modules.optimization.adapters.gcp.plugins.ai.PricingService.estimate_monthly_waste", return_value=42.0):
             
             zombies = await plugin.scan(
                 "project-id",

--- a/tests/unit/modules/optimization/adapters/gcp/test_gcp_rightsizing.py
+++ b/tests/unit/modules/optimization/adapters/gcp/test_gcp_rightsizing.py
@@ -56,7 +56,8 @@ async def test_overprovisioned_compute_plugin_scan(mock_gcp_creds):
         mock_monitor_client.list_time_series.return_value = [mock_ts]
         
         with patch("app.modules.optimization.adapters.gcp.plugins.rightsizing.compute_v1.InstancesClient", return_value=mock_instances_client), \
-             patch("app.modules.optimization.adapters.gcp.plugins.rightsizing.monitoring_v3.MetricServiceClient", return_value=mock_monitor_client):
+             patch("app.modules.optimization.adapters.gcp.plugins.rightsizing.monitoring_v3.MetricServiceClient", return_value=mock_monitor_client), \
+             patch("app.modules.optimization.adapters.gcp.plugins.rightsizing.PricingService.estimate_monthly_waste", return_value=88.0):
             
             zombies = await plugin.scan(
                 session="project-id",
@@ -68,6 +69,7 @@ async def test_overprovisioned_compute_plugin_scan(mock_gcp_creds):
     z = zombies[0]
     assert z["resource_id"] == str(mock_instance.id)
     assert z["resource_type"] == "GCP Compute Instance"
+    assert z["monthly_cost"] == 88.0
     assert "e2-standard-4" in z["recommendation"]
     assert "Max CPU" in z["explainability_notes"]
     assert z["confidence_score"] > 0.8

--- a/tests/unit/modules/optimization/adapters/gcp/test_gcp_search_network_branch_paths.py
+++ b/tests/unit/modules/optimization/adapters/gcp/test_gcp_search_network_branch_paths.py
@@ -154,7 +154,7 @@ async def test_gcp_vector_search_plugin_branches_no_creds_and_budget_exhaustion_
         ),
         patch("app.modules.optimization.adapters.gcp.plugins.search.logger.warning") as warning,
     ):
-        rows = await plugin.scan("proj-1", "us-central1", credentials={})
+        rows = await plugin.scan("proj-1", "us-central1", credentials=None)
     assert rows == []
     warning.assert_called_once()
 
@@ -177,7 +177,7 @@ async def test_gcp_vector_search_plugin_branches_no_creds_and_budget_exhaustion_
             new=AsyncMock(return_value=True),
         ),
     ):
-        rows = await plugin.scan("proj-1", "us-central1", credentials={})
+        rows = await plugin.scan("proj-1", "us-central1", credentials=None)
     assert rows == []
 
     monitor_client.list_time_series.return_value = [SimpleNamespace(points=[])]
@@ -199,16 +199,16 @@ async def test_gcp_vector_search_plugin_branches_no_creds_and_budget_exhaustion_
             new=AsyncMock(return_value=True),
         ),
     ):
-        rows = await plugin.scan("proj-1", "us-central1", credentials={})
+        rows = await plugin.scan("proj-1", "us-central1", credentials=None)
     assert len(rows) == 1
 
     with (
         patch(
             "app.modules.optimization.adapters.gcp.plugins.search.aiplatform_v1.IndexEndpointServiceClient",
-            side_effect=RuntimeError("boom"),
+            side_effect=ValueError("boom"),
         ),
         patch("app.modules.optimization.adapters.gcp.plugins.search.logger.error") as error,
     ):
-        rows = await plugin.scan("proj-1", "us-central1", credentials={})
+        rows = await plugin.scan("proj-1", "us-central1", credentials=None)
     assert rows == []
     error.assert_called_once()

--- a/tests/unit/modules/optimization/adapters/saas/test_saas_api_branch_paths.py
+++ b/tests/unit/modules/optimization/adapters/saas/test_saas_api_branch_paths.py
@@ -20,18 +20,6 @@ class _SecretLike:
         return self._value
 
 
-class _AsyncClientCtx:
-    def __init__(self, client: object) -> None:
-        self._client = client
-
-    async def __aenter__(self) -> object:
-        return self._client
-
-    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
-        del exc_type, exc_val, exc_tb
-        return None
-
-
 def _response(*, status_code: int, payload: object) -> object:
     return SimpleNamespace(status_code=status_code, json=lambda: payload)
 
@@ -69,7 +57,10 @@ async def test_github_unused_seat_plugin_member_filter_and_parse_error_branches(
         return parse_map[raw]
 
     with (
-        patch("httpx.AsyncClient", return_value=_AsyncClientCtx(client)),
+        patch(
+            "app.modules.optimization.adapters.saas.plugins.api.get_http_client",
+            return_value=client,
+        ),
         patch(
             "app.modules.optimization.adapters.saas.plugins.api.parse_timestamp",
             side_effect=_parse_timestamp,
@@ -94,7 +85,10 @@ async def test_github_unused_seat_plugin_non_200_logs_warning_and_returns_empty(
     client.get.return_value = _response(status_code=403, payload={"message": "forbidden"})
 
     with (
-        patch("httpx.AsyncClient", return_value=_AsyncClientCtx(client)),
+        patch(
+            "app.modules.optimization.adapters.saas.plugins.api.get_http_client",
+            return_value=client,
+        ),
         patch("app.modules.optimization.adapters.saas.plugins.api.logger.warning") as warning,
     ):
         rows = await plugin.scan(
@@ -114,7 +108,10 @@ async def test_github_unused_seat_plugin_uses_connector_config_fallback() -> Non
     client = AsyncMock()
     client.get.return_value = _response(status_code=403, payload={"message": "forbidden"})
 
-    with patch("httpx.AsyncClient", return_value=_AsyncClientCtx(client)):
+    with patch(
+        "app.modules.optimization.adapters.saas.plugins.api.get_http_client",
+        return_value=client,
+    ):
         rows = await plugin.scan(
             session=None,
             region="global",
@@ -133,7 +130,10 @@ async def test_github_unused_seat_plugin_non_list_members_payload_returns_empty(
     client = AsyncMock()
     client.get.return_value = _response(status_code=200, payload={"value": "not-a-list"})
 
-    with patch("httpx.AsyncClient", return_value=_AsyncClientCtx(client)):
+    with patch(
+        "app.modules.optimization.adapters.saas.plugins.api.get_http_client",
+        return_value=client,
+    ):
         rows = await plugin.scan(
             session=None,
             region="global",
@@ -160,7 +160,10 @@ async def test_github_unused_seat_plugin_logs_outer_exception() -> None:
     plugin = GitHubUnusedSeatPlugin()
 
     with (
-        patch("httpx.AsyncClient", side_effect=RuntimeError("boom")),
+        patch(
+            "app.modules.optimization.adapters.saas.plugins.api.get_http_client",
+            side_effect=RuntimeError("boom"),
+        ),
         patch("app.modules.optimization.adapters.saas.plugins.api.logger.error") as error,
     ):
         rows = await plugin.scan(

--- a/tests/unit/modules/optimization/adapters/saas/test_saas_next_gen.py
+++ b/tests/unit/modules/optimization/adapters/saas/test_saas_next_gen.py
@@ -25,15 +25,16 @@ async def test_github_unused_seat_plugin():
         },
     ]
 
-    mock_client_ctx = AsyncMock()
     mock_client = AsyncMock()
-    mock_client_ctx.__aenter__.return_value = mock_client
     mock_client.get.return_value = MagicMock(
         status_code=200,
         json=lambda: mock_members,
     )
 
-    with patch("httpx.AsyncClient", return_value=mock_client_ctx):
+    with patch(
+        "app.modules.optimization.adapters.saas.plugins.api.get_http_client",
+        return_value=mock_client,
+    ):
         zombies = await plugin.scan(
             session=None,
             region="global",

--- a/tests/unit/modules/reporting/test_carbon_scheduler_comprehensive.py
+++ b/tests/unit/modules/reporting/test_carbon_scheduler_comprehensive.py
@@ -13,6 +13,7 @@ from app.modules.reporting.domain.carbon_scheduler import (
     CarbonIntensity,
     RegionCarbonProfile,
     REGION_CARBON_PROFILES,
+    validate_carbon_data_freshness,
 )
 
 
@@ -49,6 +50,20 @@ class TestCarbonAwareSchedulerInitialization:
         )
 
         assert scheduler._use_static_data is False
+
+    def test_validate_carbon_data_freshness_strict_raises_when_static_data_is_stale(self):
+        with pytest.raises(ValueError, match="Carbon intensity data is"):
+            validate_carbon_data_freshness()
+
+    @pytest.mark.asyncio
+    async def test_scheduler_degrades_reads_when_static_data_is_stale(self):
+        scheduler = CarbonAwareScheduler()
+
+        intensity = await scheduler.get_region_intensity("us-east-1")
+        forecast = await scheduler.get_intensity_forecast("us-east-1", hours=2)
+
+        assert isinstance(intensity, CarbonIntensity)
+        assert len(forecast) == 2
 
 
 class TestCarbonRegionIntensity:

--- a/tests/unit/modules/test_module_init_lazy_loading.py
+++ b/tests/unit/modules/test_module_init_lazy_loading.py
@@ -2,32 +2,46 @@ from __future__ import annotations
 
 import importlib
 import sys
+from collections.abc import Iterator
+from contextlib import contextmanager
+from types import ModuleType
 
 
-def _reload_without_children(package_name: str, child_modules: list[str]):
-    for child in child_modules:
-        sys.modules.pop(child, None)
+@contextmanager
+def _reload_without_children(
+    package_name: str, child_modules: list[str]
+) -> Iterator[ModuleType]:
+    saved_children = {
+        child: sys.modules.get(child) for child in child_modules if child in sys.modules
+    }
     package = importlib.import_module(package_name)
-    return importlib.reload(package)
+
+    try:
+        for child in child_modules:
+            sys.modules.pop(child, None)
+        yield importlib.reload(package)
+    finally:
+        for child in child_modules:
+            sys.modules.pop(child, None)
+        sys.modules.update(saved_children)
 
 
 def test_optimization_module_init_is_lazy() -> None:
-    module = _reload_without_children(
+    with _reload_without_children(
         "app.modules.optimization",
         [
             "app.modules.optimization.domain.remediation",
             "app.modules.optimization.domain.service",
             "app.modules.optimization.domain.factory",
         ],
-    )
-
-    assert "app.modules.optimization.domain.service" not in sys.modules
-    _ = module.ZombieService
-    assert "app.modules.optimization.domain.service" in sys.modules
+    ) as module:
+        assert "app.modules.optimization.domain.service" not in sys.modules
+        _ = module.ZombieService
+        assert "app.modules.optimization.domain.service" in sys.modules
 
 
 def test_reporting_module_init_is_lazy() -> None:
-    module = _reload_without_children(
+    with _reload_without_children(
         "app.modules.reporting",
         [
             "app.modules.reporting.domain.aggregator",
@@ -35,8 +49,7 @@ def test_reporting_module_init_is_lazy() -> None:
             "app.modules.reporting.domain.service",
             "app.modules.reporting.domain.attribution_engine",
         ],
-    )
-
-    assert "app.modules.reporting.domain.service" not in sys.modules
-    _ = module.ReportingService
-    assert "app.modules.reporting.domain.service" in sys.modules
+    ) as module:
+        assert "app.modules.reporting.domain.service" not in sys.modules
+        _ = module.ReportingService
+        assert "app.modules.reporting.domain.service" in sys.modules

--- a/tests/unit/ops/test_generate_local_dev_env.py
+++ b/tests/unit/ops/test_generate_local_dev_env.py
@@ -79,6 +79,10 @@ def test_generate_local_dev_env_derives_required_key_shapes(tmp_path: Path) -> N
     assert values["ENABLE_SCHEDULER"] == "false"
     assert values["DB_SSL_MODE"] == "disable"
     assert values["REDIS_URL"] == ""
+    assert (
+        values["AWS_ASSUME_ROLE_TRUST_PRINCIPAL_ARN"]
+        == "arn:aws:iam::000000000000:role/ValdricsLocalDevControlPlane"
+    )
     assert len(values["CSRF_SECRET_KEY"]) >= 32
     assert len(values["SUPABASE_JWT_SECRET"]) >= 32
     assert len(values["ADMIN_API_KEY"]) >= 32

--- a/tests/unit/ops/test_generate_managed_deployment_artifacts.py
+++ b/tests/unit/ops/test_generate_managed_deployment_artifacts.py
@@ -44,6 +44,7 @@ def test_generate_managed_deployment_artifacts_outputs_platform_ready_bundle(
             "DATABASE_URL=postgresql+asyncpg://postgres:postgres@db.example.com:5432/postgres",
             "REDIS_URL=redis://redis.example.com:6379/0",
             "SUPABASE_JWT_SECRET=ci-supabase-jwt-secret-32-chars-0000",
+            "AWS_ASSUME_ROLE_TRUST_PRINCIPAL_ARN=arn:aws:iam::123456789012:role/ValdricsControlPlane",
             "OTEL_EXPORTER_OTLP_ENDPOINT=https://otel.example.com:4317",
             "PAYSTACK_SECRET_KEY=sk_live_runtime_paystack_key",
             "PAYSTACK_PUBLIC_KEY=pk_live_runtime_paystack_key",
@@ -90,11 +91,23 @@ def test_generate_managed_deployment_artifacts_outputs_platform_ready_bundle(
     worker_env = {item["name"]: item.get("secret") or item.get("value") for item in worker_manifest["definition"]["env"]}
     assert api_env["INTERNAL_JOB_SECRET"] == "valdrics-internal-job-secret"
     assert api_env["OPENAI_API_KEY"] == "valdrics-openai-key"
+    assert (
+        api_env["AWS_ASSUME_ROLE_TRUST_PRINCIPAL_ARN"]
+        == "valdrics-aws-trust-principal-arn"
+    )
     assert worker_env["OPENAI_API_KEY"] == "valdrics-openai-key"
+    assert (
+        worker_env["AWS_ASSUME_ROLE_TRUST_PRINCIPAL_ARN"]
+        == "valdrics-aws-trust-principal-arn"
+    )
     assert "INTERNAL_METRICS_AUTH_TOKEN" not in worker_env
 
     assert koyeb_secrets["valdrics-internal-job-secret"] == "ci-internal-job-secret-32-chars-min-000"
     assert koyeb_secrets["valdrics-openai-key"] == "sk-openai-live-key"
+    assert (
+        koyeb_secrets["valdrics-aws-trust-principal-arn"]
+        == "arn:aws:iam::123456789012:role/ValdricsControlPlane"
+    )
     assert "valdrics-forecaster-break-glass-enabled" not in koyeb_secrets
     assert "valdrics-outbound-tls-break-glass-enabled" not in koyeb_secrets
     assert helm_values["global"]["apiHostOverride"] == "api.runtime.example"
@@ -135,6 +148,7 @@ def test_generate_managed_deployment_artifacts_reports_placeholder_blockers_for_
             "DATABASE_URL=postgresql+asyncpg://REPLACE_WITH_DB_USER:REPLACE_WITH_DB_PASSWORD@REPLACE_WITH_DB_HOST:5432/postgres",
             "REDIS_URL=redis://REPLACE_WITH_REDIS_HOST:6379/0",
             "SUPABASE_JWT_SECRET=REPLACE_WITH_SUPABASE_JWT_SECRET_MINIMUM_32_CHARS_VALUE",
+            "AWS_ASSUME_ROLE_TRUST_PRINCIPAL_ARN=arn:aws:iam::123456789012:role/REPLACE_WITH_VALDRICS_CONTROL_PLANE_ROLE",
             "OTEL_EXPORTER_OTLP_ENDPOINT=https://REPLACE_WITH_OTEL_COLLECTOR:4317",
             "PAYSTACK_SECRET_KEY=sk_live_REPLACE_WITH_PAYSTACK_SECRET_KEY",
             "PAYSTACK_PUBLIC_KEY=pk_live_REPLACE_WITH_PAYSTACK_PUBLIC_KEY",
@@ -161,7 +175,9 @@ def test_generate_managed_deployment_artifacts_reports_placeholder_blockers_for_
     assert report["ready_for_koyeb"] is False
     assert report["ready_for_helm"] is False
     assert "DATABASE_URL" in report["runtime_validation_blockers"]
+    assert "AWS_ASSUME_ROLE_TRUST_PRINCIPAL_ARN" in report["runtime_validation_blockers"]
     assert "valdrics-groq-key-staging" in report["koyeb_secret_names"]
+    assert "valdrics-aws-trust-principal-arn-staging" in report["koyeb_secret_names"]
     assert "valdrics-forecaster-break-glass-enabled-staging" not in report["koyeb_secret_names"]
     assert report["helm_external_secret_remote_key"] == "/valdrics/staging/app-runtime"
     assert api_manifest["name"] == "valdrics-api-staging"

--- a/tests/unit/ops/test_generate_managed_runtime_env.py
+++ b/tests/unit/ops/test_generate_managed_runtime_env.py
@@ -80,6 +80,9 @@ def test_generate_managed_runtime_env_generates_internal_secrets_and_reports_unr
     assert values["EXPOSE_API_DOCUMENTATION_PUBLICLY"] == "false"
     assert values["API_URL"] == "https://REPLACE_WITH_API_DOMAIN"
     assert values["DATABASE_URL"].startswith("postgresql+asyncpg://REPLACE_WITH_DB_USER")
+    assert values["AWS_ASSUME_ROLE_TRUST_PRINCIPAL_ARN"].startswith(
+        "arn:aws:iam::123456789012:role/REPLACE_WITH_"
+    )
     assert values["PAYSTACK_SECRET_KEY"].startswith("sk_live_")
     assert values["PAYSTACK_PUBLIC_KEY"].startswith("pk_live_")
     assert values["GROQ_API_KEY"] == "REPLACE_WITH_GROQ_API_KEY"
@@ -92,8 +95,10 @@ def test_generate_managed_runtime_env_generates_internal_secrets_and_reports_unr
     assert report["environment"] == "production"
     assert report_payload["validation_ready"] is False
     assert "API_URL" in report_payload["required_operator_input_keys"]
+    assert "AWS_ASSUME_ROLE_TRUST_PRINCIPAL_ARN" in report_payload["required_operator_input_keys"]
     assert "GROQ_API_KEY" in report_payload["required_operator_input_keys"]
     assert "DATABASE_URL" in report_payload["unresolved_external_keys"]
+    assert "AWS_ASSUME_ROLE_TRUST_PRINCIPAL_ARN" in report_payload["unresolved_external_keys"]
     assert "GROQ_API_KEY" in report_payload["unresolved_external_keys"]
     assert "SUPABASE_URL" in report_payload["declared_external_placeholders"]
     assert "SUPABASE_URL" in report_payload["declared_but_not_runtime_required"]
@@ -147,6 +152,9 @@ def test_generate_managed_runtime_env_respects_overrides_and_is_shell_source_saf
         redis_url="redis://redis.example.com:6379/0",
         supabase_url="https://example.supabase.co",
         supabase_jwt_secret="x" * 40,
+        aws_assume_role_trust_principal_arn=(
+            "arn:aws:iam::123456789012:role/ValdricsControlPlane"
+        ),
         llm_provider="openai",
         llm_api_key="sk-test-openai-key",
         paystack_secret_key="sk_live_test_paystack_key",
@@ -167,6 +175,10 @@ def test_generate_managed_runtime_env_respects_overrides_and_is_shell_source_saf
 
     assert values["LLM_PROVIDER"] == "openai"
     assert values["OPENAI_API_KEY"] == "sk-test-openai-key"
+    assert (
+        values["AWS_ASSUME_ROLE_TRUST_PRINCIPAL_ARN"]
+        == "arn:aws:iam::123456789012:role/ValdricsControlPlane"
+    )
     assert sourced.stdout == '["https://app.staging.example.com"]'
     assert values["TRUSTED_PROXY_CIDRS"] == '["203.0.113.10/32"]'
     assert "OPENAI_API_KEY" in report_payload["required_operator_input_keys"]
@@ -222,6 +234,9 @@ def test_generate_managed_runtime_env_can_satisfy_strict_runtime_validator(
         redis_url="redis://redis.example.com:6379/0",
         supabase_url="https://example.supabase.co",
         supabase_jwt_secret="x" * 40,
+        aws_assume_role_trust_principal_arn=(
+            "arn:aws:iam::123456789012:role/ValdricsControlPlane"
+        ),
         llm_provider="groq",
         llm_api_key="testing-groq-runtime-key",
         paystack_secret_key="sk_live_runtime_paystack_key",

--- a/tests/unit/ops/test_validate_runtime_env.py
+++ b/tests/unit/ops/test_validate_runtime_env.py
@@ -16,6 +16,9 @@ def _set_strict_env() -> None:
     os.environ["KDF_SALT"] = "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY="
     os.environ["SUPABASE_JWT_SECRET"] = "ci-supabase-jwt-secret-32-chars-0000"
     os.environ["ADMIN_API_KEY"] = "ci-admin-api-key-32-chars-min-0000000"
+    os.environ["AWS_ASSUME_ROLE_TRUST_PRINCIPAL_ARN"] = (
+        "arn:aws:iam::123456789012:role/ValdricsControlPlane"
+    )
     os.environ["ENFORCEMENT_APPROVAL_TOKEN_SECRET"] = (
         "ci-enforcement-approval-token-secret-32-chars"
     )
@@ -136,6 +139,7 @@ def test_validate_runtime_env_loads_explicit_env_file(
                 "KDF_SALT=MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=",
                 "SUPABASE_JWT_SECRET=ci-supabase-jwt-secret-32-chars-0000",
                 "ADMIN_API_KEY=ci-admin-api-key-32-chars-min-0000000",
+                "AWS_ASSUME_ROLE_TRUST_PRINCIPAL_ARN=arn:aws:iam::123456789012:role/ValdricsControlPlane",
                 "ENFORCEMENT_APPROVAL_TOKEN_SECRET=ci-enforcement-approval-token-secret-32-chars",
                 "ENFORCEMENT_EXPORT_SIGNING_SECRET=ci-enforcement-export-signing-secret-32-char",
                 "GROQ_API_KEY=testing",
@@ -195,6 +199,7 @@ def test_validate_runtime_env_rejects_placeholder_public_url(
                 "KDF_SALT=MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=",
                 "SUPABASE_JWT_SECRET=ci-supabase-jwt-secret-32-chars-0000",
                 "ADMIN_API_KEY=ci-admin-api-key-32-chars-min-0000000",
+                "AWS_ASSUME_ROLE_TRUST_PRINCIPAL_ARN=arn:aws:iam::123456789012:role/ValdricsControlPlane",
                 "ENFORCEMENT_APPROVAL_TOKEN_SECRET=ci-enforcement-approval-token-secret-32-chars",
                 "ENFORCEMENT_EXPORT_SIGNING_SECRET=ci-enforcement-export-signing-secret-32-char",
                 "GROQ_API_KEY=testing",

--- a/tests/unit/ops/test_verify_managed_deployment_bundle.py
+++ b/tests/unit/ops/test_verify_managed_deployment_bundle.py
@@ -67,6 +67,9 @@ def _build_bundle(tmp_path: Path, *, environment: str = "production") -> tuple[P
         redis_url="redis://redis.example.com:6379/0",
         supabase_url="https://example.supabase.co",
         supabase_jwt_secret="x" * 40,
+        aws_assume_role_trust_principal_arn=(
+            "arn:aws:iam::123456789012:role/ValdricsControlPlane"
+        ),
         llm_provider="groq",
         llm_api_key="gsk_test_runtime_key",
         paystack_secret_key="sk_live_runtime_paystack_key",

--- a/tests/unit/optimization/test_remediation_service_audit.py
+++ b/tests/unit/optimization/test_remediation_service_audit.py
@@ -162,9 +162,15 @@ async def test_execute_approved_triggers_grace_period(mock_db, tenant_id):
         return_value=mock_safety,
     ):
         # Mock audit logger
-        with patch(
-            "app.modules.optimization.domain.remediation.AuditLogger"
-        ) as mock_audit:
+        with (
+            patch(
+                "app.modules.optimization.domain.remediation.AuditLogger"
+            ) as mock_audit,
+            patch(
+                "app.modules.governance.domain.jobs.processor.enqueue_job",
+                new=AsyncMock(),
+            ),
+        ):
             mock_audit.return_value.log = AsyncMock()
 
             # Execute

--- a/tests/unit/optimization/test_saas_action_wiring.py
+++ b/tests/unit/optimization/test_saas_action_wiring.py
@@ -38,13 +38,9 @@ async def test_saas_github_action_builds_typed_credentials_from_dict() -> None:
 
     mock_client = AsyncMock()
     mock_client.delete = AsyncMock(return_value=mock_response)
-    mock_cm = AsyncMock()
-    mock_cm.__aenter__.return_value = mock_client
-    mock_cm.__aexit__.return_value = None
-
     with patch(
-        "app.modules.optimization.domain.actions.saas.github.httpx.AsyncClient",
-        return_value=mock_cm,
+        "app.modules.optimization.domain.actions.saas.github.get_http_client",
+        return_value=mock_client,
     ):
         result = await action._perform_action("octocat", context)
 

--- a/tests/unit/optimization/test_zombie_service_audit.py
+++ b/tests/unit/optimization/test_zombie_service_audit.py
@@ -3,6 +3,7 @@ import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
+
 from app.modules.optimization.domain.service import ZombieService
 from app.models.aws_connection import AWSConnection
 from app.shared.core.pricing import PricingTier
@@ -37,66 +38,71 @@ async def test_scan_for_tenant_no_connections(mock_db, tenant_id):
 async def test_scan_for_tenant_success(mock_db, tenant_id):
     service = ZombieService(mock_db)
 
-    # Mock AWS connection
     conn = MagicMock(spec=AWSConnection)
     conn.id = uuid4()
     conn.tenant_id = tenant_id
     conn.name = "Prod-AWS"
+    conn.provider = "aws"
+    conn.region = "us-east-1"
+    conn.aws_account_id = "123456789012"
+    conn.role_arn = "arn:aws:iam::123456789012:role/Valdrics"
+    conn.external_id = "external-id"
+    conn.cur_bucket_name = "cur-bucket"
+    conn.cur_report_name = "cur-report"
+    conn.cur_prefix = "cur-prefix"
 
-    # Mock sequence: AWS, Azure, GCP
-    mock_res_aws = MagicMock()
-    mock_res_aws.scalars.return_value.all.return_value = [conn]
-
-    mock_res_empty = MagicMock()
-    mock_res_empty.scalars.return_value.all.return_value = []
-
-    mock_db.execute.side_effect = [mock_res_aws, mock_res_empty, mock_res_empty]
-
-    # Mock detector
     mock_detector = AsyncMock()
     mock_detector.provider_name = "aws"
+    mock_detector.get_credentials = AsyncMock(
+        return_value={"AccessKeyId": "AKIA_TEST", "SecretAccessKey": "SECRET_TEST"}
+    )
     mock_detector.scan_all.return_value = {
         "unattached_volumes": [{"resource_id": "vol-1", "monthly_cost": 10.0}]
     }
 
-    # Mock RegionDiscovery
     mock_rd = MagicMock()
     mock_rd.get_enabled_regions = AsyncMock(return_value=["us-east-1"])
 
-    with patch(
-        "app.modules.optimization.domain.service.ZombieDetectorFactory.get_detector",
-        return_value=mock_detector,
-    ):
-        with patch(
+    async def execute_side_effect(stmt: object) -> MagicMock:
+        query = str(stmt).lower()
+        result = MagicMock()
+        result.scalars.return_value.all.return_value = []
+        if "aws_connections" in query:
+            result.scalars.return_value.all.return_value = [conn]
+        return result
+
+    mock_db.execute.side_effect = execute_side_effect
+
+    def fake_get_detector(*_args, **_kwargs):
+        return mock_detector
+
+    with (
+        patch(
+            "app.modules.optimization.domain.service.ZombieDetectorFactory",
+            new=SimpleNamespace(get_detector=fake_get_detector),
+        ),
+        patch(
             "app.modules.optimization.adapters.aws.region_discovery.RegionDiscovery",
             return_value=mock_rd,
-        ):
-            with patch(
-                "app.shared.core.pricing.get_tenant_tier",
-                return_value=PricingTier.FREE,
-            ):
-                # Mock metrics and notifications
-                with patch("app.shared.core.ops_metrics.SCAN_LATENCY"):
-                    with patch(
-                        "app.shared.core.notifications.NotificationDispatcher.notify_zombies"
-                    ) as mock_notify:
-                        result = await service.scan_for_tenant(tenant_id)
+        ),
+        patch(
+            "app.shared.core.pricing.get_tenant_tier",
+            return_value=PricingTier.STARTER,
+        ),
+        patch("app.shared.core.ops_metrics.SCAN_LATENCY"),
+        patch(
+            "app.shared.core.notifications.NotificationDispatcher.notify_zombies"
+        ) as mock_notify,
+    ):
+        result = await service.scan_for_tenant(tenant_id)
 
-                        assert result["total_monthly_waste"] == 10.0
-                        assert len(result["unattached_volumes"]) == 1
-                        assert result["unattached_volumes"][0]["resource_id"] == "vol-1"
-                        assert result["waste_rightsizing"]["deterministic"] is True
-                        assert (
-                            result["waste_rightsizing"]["summary"][
-                                "total_recommendations"
-                            ]
-                            == 1
-                        )
-                        assert (
-                            result["architectural_inefficiency"]["deterministic"]
-                            is True
-                        )
-                        mock_notify.assert_called_once()
+    assert result["total_monthly_waste"] == 10.0
+    assert len(result["unattached_volumes"]) == 1
+    assert result["unattached_volumes"][0]["resource_id"] == "vol-1"
+    assert result["waste_rightsizing"]["deterministic"] is True
+    assert result["waste_rightsizing"]["summary"]["total_recommendations"] == 1
+    assert result["architectural_inefficiency"]["deterministic"] is True
+    mock_notify.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -111,12 +117,12 @@ async def test_scan_for_tenant_aws_global_region_fallback_uses_configured_defaul
     conn.name = "Prod-AWS"
     conn.provider = "aws"
     conn.region = "global"
-
-    mock_res_aws = MagicMock()
-    mock_res_aws.scalars.return_value.all.return_value = [conn]
-    mock_res_empty = MagicMock()
-    mock_res_empty.scalars.return_value.all.return_value = []
-    mock_db.execute.side_effect = [mock_res_aws, mock_res_empty, mock_res_empty]
+    conn.aws_account_id = "123456789012"
+    conn.role_arn = "arn:aws:iam::123456789012:role/Valdrics"
+    conn.external_id = "external-id"
+    conn.cur_bucket_name = "cur-bucket"
+    conn.cur_report_name = "cur-report"
+    conn.cur_prefix = "cur-prefix"
 
     mock_detector = AsyncMock()
     mock_detector.provider_name = "aws"
@@ -131,35 +137,45 @@ async def test_scan_for_tenant_aws_global_region_fallback_uses_configured_defaul
     mock_rd = MagicMock()
     mock_rd.get_enabled_regions = AsyncMock(return_value=[])
 
+    async def execute_side_effect(stmt: object) -> MagicMock:
+        query = str(stmt).lower()
+        result = MagicMock()
+        result.scalars.return_value.all.return_value = []
+        if "aws_connections" in query:
+            result.scalars.return_value.all.return_value = [conn]
+        return result
+
+    called_regions: list[str] = []
+
+    def fake_get_detector(*_args, **kwargs):
+        called_regions.append(str(kwargs.get("region")))
+        return mock_detector
+
     with (
         patch(
             "app.shared.core.connection_state.get_settings",
             return_value=SimpleNamespace(AWS_DEFAULT_REGION="eu-west-2"),
         ),
         patch(
-            "app.modules.optimization.domain.service.ZombieDetectorFactory.get_detector",
-            return_value=mock_detector,
-        ) as mock_factory,
+            "app.modules.optimization.domain.service.ZombieDetectorFactory",
+            new=SimpleNamespace(get_detector=fake_get_detector),
+        ),
         patch(
             "app.modules.optimization.adapters.aws.region_discovery.RegionDiscovery",
             return_value=mock_rd,
         ),
         patch(
             "app.shared.core.pricing.get_tenant_tier",
-            return_value=PricingTier.FREE,
+            return_value=PricingTier.STARTER,
         ),
         patch("app.shared.core.ops_metrics.SCAN_LATENCY"),
         patch(
             "app.shared.core.notifications.NotificationDispatcher.notify_zombies"
         ),
     ):
+        mock_db.execute.side_effect = execute_side_effect
         await service.scan_for_tenant(tenant_id, region="global")
 
-    called_regions = [
-        str(call.kwargs.get("region"))
-        for call in mock_factory.call_args_list
-        if "region" in call.kwargs
-    ]
     assert called_regions
     assert "global" not in called_regions
     assert "eu-west-2" in called_regions
@@ -175,15 +191,20 @@ async def test_scan_for_tenant_preserves_custom_categories_and_maps_provider_key
     conn.id = uuid4()
     conn.tenant_id = tenant_id
     conn.name = "Prod-AWS"
-
-    mock_res_aws = MagicMock()
-    mock_res_aws.scalars.return_value.all.return_value = [conn]
-    mock_res_empty = MagicMock()
-    mock_res_empty.scalars.return_value.all.return_value = []
-    mock_db.execute.side_effect = [mock_res_aws, mock_res_empty, mock_res_empty]
+    conn.provider = "aws"
+    conn.region = "us-east-1"
+    conn.aws_account_id = "123456789012"
+    conn.role_arn = "arn:aws:iam::123456789012:role/Valdrics"
+    conn.external_id = "external-id"
+    conn.cur_bucket_name = "cur-bucket"
+    conn.cur_report_name = "cur-report"
+    conn.cur_prefix = "cur-prefix"
 
     mock_detector = AsyncMock()
     mock_detector.provider_name = "aws"
+    mock_detector.get_credentials = AsyncMock(
+        return_value={"AccessKeyId": "AKIA_TEST", "SecretAccessKey": "SECRET_TEST"}
+    )
     mock_detector.scan_all.return_value = {
         "orphan_load_balancers": [{"id": "lb-1", "monthly_waste": 12.0}],
         "orphan_azure_ips": [{"id": "pip-1", "monthly_waste": 3.0}],
@@ -196,23 +217,38 @@ async def test_scan_for_tenant_preserves_custom_categories_and_maps_provider_key
     mock_rd = MagicMock()
     mock_rd.get_enabled_regions = AsyncMock(return_value=["us-east-1"])
 
-    with patch(
-        "app.modules.optimization.domain.service.ZombieDetectorFactory.get_detector",
-        return_value=mock_detector,
-    ):
-        with patch(
+    async def execute_side_effect(stmt: object) -> MagicMock:
+        query = str(stmt).lower()
+        result = MagicMock()
+        result.scalars.return_value.all.return_value = []
+        if "aws_connections" in query:
+            result.scalars.return_value.all.return_value = [conn]
+        return result
+
+    mock_db.execute.side_effect = execute_side_effect
+
+    def fake_get_detector(*_args, **_kwargs):
+        return mock_detector
+
+    with (
+        patch(
+            "app.modules.optimization.domain.service.ZombieDetectorFactory",
+            new=SimpleNamespace(get_detector=fake_get_detector),
+        ),
+        patch(
             "app.modules.optimization.adapters.aws.region_discovery.RegionDiscovery",
             return_value=mock_rd,
-        ):
-            with patch(
-                "app.shared.core.pricing.get_tenant_tier",
-                return_value=PricingTier.FREE,
-            ):
-                with patch("app.shared.core.ops_metrics.SCAN_LATENCY"):
-                    with patch(
-                        "app.shared.core.notifications.NotificationDispatcher.notify_zombies"
-                    ):
-                        result = await service.scan_for_tenant(tenant_id)
+        ),
+        patch(
+            "app.shared.core.pricing.get_tenant_tier",
+            return_value=PricingTier.STARTER,
+        ),
+        patch("app.shared.core.ops_metrics.SCAN_LATENCY"),
+        patch(
+            "app.shared.core.notifications.NotificationDispatcher.notify_zombies"
+        ),
+    ):
+        result = await service.scan_for_tenant(tenant_id)
 
     assert result["total_monthly_waste"] == 41.0
     assert len(result["orphan_load_balancers"]) == 1

--- a/tests/unit/reporting/test_attribution_engine.py
+++ b/tests/unit/reporting/test_attribution_engine.py
@@ -4,6 +4,7 @@ from datetime import date
 from decimal import Decimal
 from uuid import uuid4
 from sqlalchemy.ext.asyncio import AsyncSession
+import app.modules.reporting.domain.attribution_engine as attribution_engine_module
 from app.modules.reporting.domain.attribution_engine import AttributionEngine
 from app.models.attribution import AttributionRule
 from app.models.cloud import CostRecord
@@ -265,15 +266,14 @@ async def test_apply_rules_percentage_mismatch_logs_warning(engine):
     rule.rule_type = "PERCENTAGE"
     rule.conditions = {}
     rule.allocation = [{"bucket": "A", "percentage": 10}]
+    mock_logger = MagicMock()
     with (
         patch.object(engine, "match_conditions", return_value=True),
-        patch(
-            "app.modules.reporting.domain.attribution_engine.logger.warning"
-        ) as mock_warning,
+        patch.object(attribution_engine_module, "logger", mock_logger),
     ):
         allocations = await engine.apply_rules(record, [rule])
     assert len(allocations) == 1
-    mock_warning.assert_called_once()
+    mock_logger.warning.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -300,14 +300,13 @@ async def test_apply_rules_to_tenant_no_records_logs_and_returns_zero(
     mock_result = MagicMock()
     mock_result.scalars.return_value.all.return_value = []
     mock_db.execute.return_value = mock_result
-    with patch(
-        "app.modules.reporting.domain.attribution_engine.logger.info"
-    ) as mock_info:
+    mock_logger = MagicMock()
+    with patch.object(attribution_engine_module, "logger", mock_logger):
         result = await engine.apply_rules_to_tenant(
             tenant_id, date(2026, 1, 1), date(2026, 1, 31)
         )
     assert result == {"records_processed": 0, "allocations_created": 0}
-    mock_info.assert_called_once()
+    mock_logger.info.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/adapters/cloud_plus_test_helpers.py
+++ b/tests/unit/services/adapters/cloud_plus_test_helpers.py
@@ -42,10 +42,24 @@ class FakeAsyncClient:
     async def __aexit__(self, exc_type, exc, tb) -> bool:  # type: ignore[no-untyped-def]
         return False
 
-    async def get(self, url: str, headers=None, params=None):  # type: ignore[no-untyped-def]
+    async def get(  # type: ignore[no-untyped-def]
+        self,
+        url: str,
+        headers=None,
+        params=None,
+        timeout=None,
+        **kwargs,
+    ):
         assert url
         self.calls.append(
-            {"method": "GET", "url": url, "headers": headers, "params": params}
+            {
+                "method": "GET",
+                "url": url,
+                "headers": headers,
+                "params": params,
+                "timeout": timeout,
+                **kwargs,
+            }
         )
         if not self.responses:
             raise AssertionError("No fake responses configured for HTTP call")
@@ -54,7 +68,16 @@ class FakeAsyncClient:
             raise next_item
         return next_item
 
-    async def post(self, url: str, headers=None, params=None, json=None, auth=None):  # type: ignore[no-untyped-def]
+    async def post(  # type: ignore[no-untyped-def]
+        self,
+        url: str,
+        headers=None,
+        params=None,
+        json=None,
+        auth=None,
+        timeout=None,
+        **kwargs,
+    ):
         assert url
         self.calls.append(
             {
@@ -64,6 +87,8 @@ class FakeAsyncClient:
                 "params": params,
                 "json": json,
                 "auth": auth,
+                "timeout": timeout,
+                **kwargs,
             }
         )
         if not self.responses:

--- a/tests/unit/services/adapters/conftest.py
+++ b/tests/unit/services/adapters/conftest.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import pytest
+
+from app.shared.core import http as http_module
+
+
+@pytest.fixture(autouse=True)
+def reset_shared_http_client_singletons() -> None:
+    http_module._client = None
+    http_module._insecure_client = None
+    yield
+    http_module._client = None
+    http_module._insecure_client = None

--- a/tests/unit/services/adapters/license_verification_stream_test_helpers.py
+++ b/tests/unit/services/adapters/license_verification_stream_test_helpers.py
@@ -34,9 +34,9 @@ class FakeGetClient:
         return None
 
     async def get(  # type: ignore[no-untyped-def]
-        self, url: str, *, headers=None, params=None
+        self, url: str, *, headers=None, params=None, timeout=None, **kwargs
     ) -> httpx.Response:
-        _ = url, headers, params
+        _ = url, headers, params, timeout, kwargs
         return self._response
 
 
@@ -71,8 +71,10 @@ class FakeAsyncClient:
         _ = exc_type, exc, tb
         return False
 
-    async def get(self, _url: str, *, headers=None, params=None):  # type: ignore[no-untyped-def]
-        _ = headers, params
+    async def get(  # type: ignore[no-untyped-def]
+        self, _url: str, *, headers=None, params=None, timeout=None, **kwargs
+    ):
+        _ = headers, params, timeout, kwargs
         if not self.responses:
             raise AssertionError("No fake responses configured")
         item = self.responses.pop(0)

--- a/tests/unit/services/adapters/platform_additional_test_helpers.py
+++ b/tests/unit/services/adapters/platform_additional_test_helpers.py
@@ -50,8 +50,24 @@ class _FakeAsyncClient:
     async def __aexit__(self, exc_type, exc, tb) -> bool:  # type: ignore[no-untyped-def]
         return False
 
-    async def get(self, url: str, headers=None, params=None):  # type: ignore[no-untyped-def]
-        self.calls.append({"method": "GET", "url": url, "headers": headers, "params": params})
+    async def get(  # type: ignore[no-untyped-def]
+        self,
+        url: str,
+        headers=None,
+        params=None,
+        timeout=None,
+        **kwargs,
+    ):
+        self.calls.append(
+            {
+                "method": "GET",
+                "url": url,
+                "headers": headers,
+                "params": params,
+                "timeout": timeout,
+                **kwargs,
+            }
+        )
         if not self.responses:
             raise AssertionError("No fake responses configured")
         item = self.responses.pop(0)
@@ -59,7 +75,16 @@ class _FakeAsyncClient:
             raise item
         return item
 
-    async def post(self, url: str, headers=None, params=None, json=None, auth=None):  # type: ignore[no-untyped-def]
+    async def post(  # type: ignore[no-untyped-def]
+        self,
+        url: str,
+        headers=None,
+        params=None,
+        json=None,
+        auth=None,
+        timeout=None,
+        **kwargs,
+    ):
         self.calls.append(
             {
                 "method": "POST",
@@ -68,6 +93,8 @@ class _FakeAsyncClient:
                 "params": params,
                 "json": json,
                 "auth": auth,
+                "timeout": timeout,
+                **kwargs,
             }
         )
         if not self.responses:
@@ -125,4 +152,3 @@ def _single_row_gen(row: dict[str, object]):
         yield row
 
     return _gen
-

--- a/tests/unit/services/adapters/test_cloud_plus_adapters_license_adapter.py
+++ b/tests/unit/services/adapters/test_cloud_plus_adapters_license_adapter.py
@@ -71,7 +71,7 @@ async def test_license_adapter_native_microsoft_365_costs() -> None:
     )
     adapter = LicenseAdapter(conn)
     with patch(
-        "app.shared.adapters.license.httpx.AsyncClient", return_value=fake_client
+        "app.shared.adapters.license.get_http_client", return_value=fake_client
     ):
         rows = await adapter.get_cost_and_usage(
             start_date=datetime(2026, 1, 1, tzinfo=timezone.utc),
@@ -199,7 +199,7 @@ async def test_license_native_uses_prepaid_fallback_and_default_price() -> None:
 
     adapter = LicenseAdapter(conn)
     with patch(
-        "app.shared.adapters.license.httpx.AsyncClient", return_value=fake_client
+        "app.shared.adapters.license.get_http_client", return_value=fake_client
     ):
         rows = await adapter.get_cost_and_usage(
             start_date=datetime(2026, 1, 1, tzinfo=timezone.utc),

--- a/tests/unit/services/adapters/test_cloud_plus_adapters_license_resilience.py
+++ b/tests/unit/services/adapters/test_cloud_plus_adapters_license_resilience.py
@@ -33,14 +33,14 @@ async def test_license_get_json_error_paths_and_discover_resources() -> None:
         ]
     )
     with patch(
-        "app.shared.adapters.license.httpx.AsyncClient", return_value=http_error_client
+        "app.shared.adapters.license.get_http_client", return_value=http_error_client
     ):
         with pytest.raises(Exception):
             await adapter._get_json("https://example.invalid", headers={})
 
     invalid_json_client = _FakeAsyncClient([_InvalidJSONResponse({})])
     with patch(
-        "app.shared.adapters.license.httpx.AsyncClient",
+        "app.shared.adapters.license.get_http_client",
         return_value=invalid_json_client,
     ):
         with pytest.raises(Exception):
@@ -48,7 +48,7 @@ async def test_license_get_json_error_paths_and_discover_resources() -> None:
 
     non_dict_client = _FakeAsyncClient([_FakeResponse([])])  # type: ignore[list-item]
     with patch(
-        "app.shared.adapters.license.httpx.AsyncClient", return_value=non_dict_client
+        "app.shared.adapters.license.get_http_client", return_value=non_dict_client
     ):
         payload = await adapter._get_json("https://example.invalid", headers={})
     assert payload == {"value": []}
@@ -116,14 +116,14 @@ async def test_license_get_json_retry_branches() -> None:
         [_http_status_error(500), _FakeResponse({"ok": True})]
     )
     with patch(
-        "app.shared.adapters.license.httpx.AsyncClient", return_value=retry_then_success
+        "app.shared.adapters.license.get_http_client", return_value=retry_then_success
     ):
         payload = await adapter._get_json("https://example.invalid", headers={})
     assert payload == {"ok": True}
 
     non_retryable = _FakeAsyncClient([_http_status_error(401)])
     with patch(
-        "app.shared.adapters.license.httpx.AsyncClient", return_value=non_retryable
+        "app.shared.adapters.license.get_http_client", return_value=non_retryable
     ):
         with pytest.raises(ExternalAPIError):
             await adapter._get_json("https://example.invalid", headers={})
@@ -132,7 +132,7 @@ async def test_license_get_json_retry_branches() -> None:
         [httpx.ConnectError("connect"), _FakeResponse({"ok": True})]
     )
     with patch(
-        "app.shared.adapters.license.httpx.AsyncClient", return_value=transport_retry
+        "app.shared.adapters.license.get_http_client", return_value=transport_retry
     ):
         payload = await adapter._get_json("https://example.invalid", headers={})
     assert payload == {"ok": True}
@@ -141,7 +141,7 @@ async def test_license_get_json_retry_branches() -> None:
         [httpx.ConnectError("c1"), httpx.ConnectError("c2"), httpx.ConnectError("c3")]
     )
     with patch(
-        "app.shared.adapters.license.httpx.AsyncClient", return_value=transport_fail
+        "app.shared.adapters.license.get_http_client", return_value=transport_fail
     ):
         with pytest.raises(ExternalAPIError):
             await adapter._get_json("https://example.invalid", headers={})
@@ -158,7 +158,7 @@ async def test_license_stream_invalid_payload_raises() -> None:
 
     fake_client = _FakeAsyncClient([_FakeResponse({"value": {"bad": "shape"}})])
     with patch(
-        "app.shared.adapters.license.httpx.AsyncClient", return_value=fake_client
+        "app.shared.adapters.license.get_http_client", return_value=fake_client
     ):
         with pytest.raises(ExternalAPIError):
             await anext(
@@ -185,7 +185,7 @@ async def test_license_get_json_retries_retryable_status() -> None:
         ]
     )
     with patch(
-        "app.shared.adapters.license.httpx.AsyncClient", return_value=fake_client
+        "app.shared.adapters.license.get_http_client", return_value=fake_client
     ):
         payload = await adapter._get_json("https://example.invalid", headers={})
 

--- a/tests/unit/services/adapters/test_cloud_plus_adapters_platform_hybrid.py
+++ b/tests/unit/services/adapters/test_cloud_plus_adapters_platform_hybrid.py
@@ -44,7 +44,7 @@ async def test_platform_adapter_native_ledger_http_normalizes_records() -> None:
     )
     adapter = PlatformAdapter(conn)
     with patch(
-        "app.shared.adapters.platform.httpx.AsyncClient", return_value=fake_client
+        "app.shared.adapters.platform.get_http_client", return_value=fake_client
     ):
         rows = await adapter.get_cost_and_usage(
             start_date=datetime(2026, 1, 1, tzinfo=timezone.utc),
@@ -86,7 +86,7 @@ async def test_platform_adapter_native_datadog_normalizes_priced_usage() -> None
 
     adapter = PlatformAdapter(conn)
     with patch(
-        "app.shared.adapters.platform.httpx.AsyncClient", return_value=fake_client
+        "app.shared.adapters.platform.get_http_client", return_value=fake_client
     ):
         rows = await adapter.get_cost_and_usage(
             start_date=datetime(2026, 1, 1, tzinfo=timezone.utc),
@@ -138,7 +138,7 @@ async def test_platform_adapter_native_newrelic_normalizes_priced_nrql_results()
     )
     adapter = PlatformAdapter(conn)
     with patch(
-        "app.shared.adapters.platform.httpx.AsyncClient", return_value=fake_client
+        "app.shared.adapters.platform.get_http_client", return_value=fake_client
     ):
         rows = await adapter.get_cost_and_usage(
             start_date=datetime(2026, 1, 1, tzinfo=timezone.utc),
@@ -181,7 +181,7 @@ async def test_hybrid_adapter_native_ledger_http_normalizes_records() -> None:
     )
     adapter = HybridAdapter(conn)
     with patch(
-        "app.shared.adapters.hybrid.httpx.AsyncClient", return_value=fake_client
+        "app.shared.adapters.hybrid.get_http_client", return_value=fake_client
     ):
         rows = await adapter.get_cost_and_usage(
             start_date=datetime(2026, 1, 1, tzinfo=timezone.utc),
@@ -236,7 +236,7 @@ async def test_hybrid_adapter_native_cloudkitty_normalizes_summary() -> None:
 
     adapter = HybridAdapter(conn)
     with patch(
-        "app.shared.adapters.hybrid.httpx.AsyncClient", return_value=fake_client
+        "app.shared.adapters.hybrid.get_http_client", return_value=fake_client
     ):
         rows = await adapter.get_cost_and_usage(
             start_date=datetime(2026, 1, 1, tzinfo=timezone.utc),
@@ -286,7 +286,7 @@ async def test_hybrid_adapter_native_vmware_estimates_cost_from_inventory() -> N
 
     adapter = HybridAdapter(conn)
     with patch(
-        "app.shared.adapters.hybrid.httpx.AsyncClient", return_value=fake_client
+        "app.shared.adapters.hybrid.get_http_client", return_value=fake_client
     ):
         rows = await adapter.get_cost_and_usage(
             start_date=datetime(2026, 1, 1, tzinfo=timezone.utc),

--- a/tests/unit/services/adapters/test_cloud_plus_adapters_saas_resilience.py
+++ b/tests/unit/services/adapters/test_cloud_plus_adapters_saas_resilience.py
@@ -32,21 +32,21 @@ async def test_saas_get_json_error_paths_and_discover_resources() -> None:
         ]
     )
     with patch(
-        "app.shared.adapters.saas.httpx.AsyncClient", return_value=http_error_client
+        "app.shared.adapters.saas.get_http_client", return_value=http_error_client
     ):
         with pytest.raises(Exception):
             await adapter._get_json("https://example.invalid", headers={})
 
     invalid_json_client = _FakeAsyncClient([_InvalidJSONResponse({})])
     with patch(
-        "app.shared.adapters.saas.httpx.AsyncClient", return_value=invalid_json_client
+        "app.shared.adapters.saas.get_http_client", return_value=invalid_json_client
     ):
         with pytest.raises(Exception):
             await adapter._get_json("https://example.invalid", headers={})
 
     non_dict_client = _FakeAsyncClient([_FakeResponse([])])  # type: ignore[list-item]
     with patch(
-        "app.shared.adapters.saas.httpx.AsyncClient", return_value=non_dict_client
+        "app.shared.adapters.saas.get_http_client", return_value=non_dict_client
     ):
         with pytest.raises(Exception):
             await adapter._get_json("https://example.invalid", headers={})
@@ -67,7 +67,7 @@ async def test_saas_get_json_retries_retryable_status() -> None:
             _FakeResponse({"data": []}, status_code=200),
         ]
     )
-    with patch("app.shared.adapters.saas.httpx.AsyncClient", return_value=fake_client):
+    with patch("app.shared.adapters.saas.get_http_client", return_value=fake_client):
         payload = await adapter._get_json("https://example.invalid", headers={})
 
     assert payload == {"data": []}
@@ -135,7 +135,7 @@ async def test_saas_stream_stripe_invalid_payload_raises() -> None:
     adapter = SaaSAdapter(conn)
 
     fake_client = _FakeAsyncClient([_FakeResponse({"data": {"not": "list"}})])
-    with patch("app.shared.adapters.saas.httpx.AsyncClient", return_value=fake_client):
+    with patch("app.shared.adapters.saas.get_http_client", return_value=fake_client):
         with pytest.raises(ExternalAPIError):
             await anext(
                 adapter._stream_stripe_cost_and_usage(
@@ -155,7 +155,7 @@ async def test_saas_stream_salesforce_invalid_payload_raises() -> None:
     adapter = SaaSAdapter(conn)
 
     fake_client = _FakeAsyncClient([_FakeResponse({"records": {"bad": "shape"}})])
-    with patch("app.shared.adapters.saas.httpx.AsyncClient", return_value=fake_client):
+    with patch("app.shared.adapters.saas.get_http_client", return_value=fake_client):
         with pytest.raises(ExternalAPIError):
             await anext(
                 adapter._stream_salesforce_cost_and_usage(
@@ -176,14 +176,14 @@ async def test_saas_get_json_retry_branches() -> None:
         [_http_status_error(500), _FakeResponse({"ok": True})]
     )
     with patch(
-        "app.shared.adapters.saas.httpx.AsyncClient", return_value=retry_then_success
+        "app.shared.adapters.saas.get_http_client", return_value=retry_then_success
     ):
         payload = await adapter._get_json("https://example.invalid", headers={})
     assert payload == {"ok": True}
 
     non_retryable = _FakeAsyncClient([_http_status_error(401)])
     with patch(
-        "app.shared.adapters.saas.httpx.AsyncClient", return_value=non_retryable
+        "app.shared.adapters.saas.get_http_client", return_value=non_retryable
     ):
         with pytest.raises(ExternalAPIError):
             await adapter._get_json("https://example.invalid", headers={})
@@ -192,7 +192,7 @@ async def test_saas_get_json_retry_branches() -> None:
         [httpx.ConnectError("connect"), _FakeResponse({"ok": True})]
     )
     with patch(
-        "app.shared.adapters.saas.httpx.AsyncClient", return_value=transport_retry
+        "app.shared.adapters.saas.get_http_client", return_value=transport_retry
     ):
         payload = await adapter._get_json("https://example.invalid", headers={})
     assert payload == {"ok": True}
@@ -201,7 +201,7 @@ async def test_saas_get_json_retry_branches() -> None:
         [httpx.ConnectError("c1"), httpx.ConnectError("c2"), httpx.ConnectError("c3")]
     )
     with patch(
-        "app.shared.adapters.saas.httpx.AsyncClient", return_value=transport_fail
+        "app.shared.adapters.saas.get_http_client", return_value=transport_fail
     ):
         with pytest.raises(ExternalAPIError):
             await adapter._get_json("https://example.invalid", headers={})

--- a/tests/unit/services/adapters/test_hybrid_additional_branches.py
+++ b/tests/unit/services/adapters/test_hybrid_additional_branches.py
@@ -53,8 +53,24 @@ class _FakeAsyncClient:
     async def __aexit__(self, exc_type, exc, tb) -> bool:  # type: ignore[no-untyped-def]
         return False
 
-    async def get(self, url: str, headers=None, params=None):  # type: ignore[no-untyped-def]
-        self.calls.append({"method": "GET", "url": url, "headers": headers, "params": params})
+    async def get(  # type: ignore[no-untyped-def]
+        self,
+        url: str,
+        headers=None,
+        params=None,
+        timeout=None,
+        **kwargs,
+    ):
+        self.calls.append(
+            {
+                "method": "GET",
+                "url": url,
+                "headers": headers,
+                "params": params,
+                "timeout": timeout,
+                **kwargs,
+            }
+        )
         if not self.responses:
             raise AssertionError("No fake responses configured")
         item = self.responses.pop(0)
@@ -62,7 +78,16 @@ class _FakeAsyncClient:
             raise item
         return item
 
-    async def post(self, url: str, headers=None, params=None, json=None, auth=None):  # type: ignore[no-untyped-def]
+    async def post(  # type: ignore[no-untyped-def]
+        self,
+        url: str,
+        headers=None,
+        params=None,
+        json=None,
+        auth=None,
+        timeout=None,
+        **kwargs,
+    ):
         self.calls.append(
             {
                 "method": "POST",
@@ -71,6 +96,8 @@ class _FakeAsyncClient:
                 "params": params,
                 "json": json,
                 "auth": auth,
+                "timeout": timeout,
+                **kwargs,
             }
         )
         if not self.responses:
@@ -179,12 +206,14 @@ async def test_hybrid_openstack_token_error_paths() -> None:
     )
 
     bad_status = _FakeAsyncClient([_FakeResponse({}, status_code=401)])
-    with patch("app.shared.adapters.hybrid.httpx.AsyncClient", return_value=bad_status):
+    with patch("app.shared.adapters.hybrid.get_http_client", return_value=bad_status):
         with pytest.raises(ExternalAPIError, match="token request failed"):
             await adapter._get_openstack_token()
 
     missing_header = _FakeAsyncClient([_FakeResponse({}, headers={})])
-    with patch("app.shared.adapters.hybrid.httpx.AsyncClient", return_value=missing_header):
+    with patch(
+        "app.shared.adapters.hybrid.get_http_client", return_value=missing_header
+    ):
         with pytest.raises(ExternalAPIError, match="missing X-Subject-Token"):
             await adapter._get_openstack_token()
 
@@ -270,12 +299,16 @@ async def test_hybrid_vmware_session_verify_and_stream_error_paths() -> None:
     )
 
     invalid_json_client = _FakeAsyncClient([_InvalidJSONResponse({})])
-    with patch("app.shared.adapters.hybrid.httpx.AsyncClient", return_value=invalid_json_client):
+    with patch(
+        "app.shared.adapters.hybrid.get_http_client", return_value=invalid_json_client
+    ):
         with pytest.raises(ExternalAPIError, match="invalid JSON"):
             await adapter._get_vmware_session_id()
 
     missing_value_client = _FakeAsyncClient([_FakeResponse({"value": ""})])
-    with patch("app.shared.adapters.hybrid.httpx.AsyncClient", return_value=missing_value_client):
+    with patch(
+        "app.shared.adapters.hybrid.get_http_client", return_value=missing_value_client
+    ):
         with pytest.raises(ExternalAPIError, match="missing session id"):
             await adapter._get_vmware_session_id()
 
@@ -378,24 +411,24 @@ async def test_hybrid_get_json_retry_and_error_branches() -> None:
     adapter = HybridAdapter(_conn(vendor="ledger", auth_method="api_key"))
 
     retry_then_ok = _FakeAsyncClient([_http_status_error(500), _FakeResponse({"ok": True})])
-    with patch("app.shared.adapters.hybrid.httpx.AsyncClient", return_value=retry_then_ok):
+    with patch("app.shared.adapters.hybrid.get_http_client", return_value=retry_then_ok):
         payload = await adapter._get_json("https://example.invalid", headers={})
     assert payload == {"ok": True}
 
     non_retry = _FakeAsyncClient([_http_status_error(401)])
-    with patch("app.shared.adapters.hybrid.httpx.AsyncClient", return_value=non_retry):
+    with patch("app.shared.adapters.hybrid.get_http_client", return_value=non_retry):
         with pytest.raises(ExternalAPIError, match="status 401"):
             await adapter._get_json("https://example.invalid", headers={})
 
     bad_json = _FakeAsyncClient([_InvalidJSONResponse({})])
-    with patch("app.shared.adapters.hybrid.httpx.AsyncClient", return_value=bad_json):
+    with patch("app.shared.adapters.hybrid.get_http_client", return_value=bad_json):
         with pytest.raises(ExternalAPIError, match="invalid JSON"):
             await adapter._get_json("https://example.invalid", headers={})
 
     transport_fail = _FakeAsyncClient(
         [httpx.ConnectError("c1"), httpx.ConnectError("c2"), httpx.ConnectError("c3")]
     )
-    with patch("app.shared.adapters.hybrid.httpx.AsyncClient", return_value=transport_fail):
+    with patch("app.shared.adapters.hybrid.get_http_client", return_value=transport_fail):
         with pytest.raises(ExternalAPIError, match="request failed"):
             await adapter._get_json("https://example.invalid", headers={})
 
@@ -578,7 +611,7 @@ async def test_hybrid_openstack_vmware_and_ledger_success_branches() -> None:
         [_FakeResponse({}, headers={"X-Subject-Token": " token-123 "})]
     )
     with patch(
-        "app.shared.adapters.hybrid.httpx.AsyncClient",
+        "app.shared.adapters.hybrid.get_http_client",
         return_value=openstack_token_client,
     ):
         token = await openstack._get_openstack_token()
@@ -791,7 +824,7 @@ async def test_hybrid_get_json_fallthrough_raises_last_error_branch() -> None:
     adapter = HybridAdapter(_conn(vendor="ledger", auth_method="api_key"))
     transport_fail = _FakeAsyncClient([httpx.ConnectError("c1"), httpx.ConnectError("c2")])
     with (
-        patch("app.shared.adapters.hybrid.httpx.AsyncClient", return_value=transport_fail),
+        patch("app.shared.adapters.hybrid.get_http_client", return_value=transport_fail),
         patch("app.shared.adapters.http_retry.range", return_value=[1, 2]),
     ):
         with pytest.raises(ExternalAPIError, match="Hybrid request failed:"):
@@ -838,12 +871,14 @@ async def test_hybrid_vmware_session_http_error_success_and_stream_invalid_shape
     )
 
     http_error_client = _FakeAsyncClient([_FakeResponse({}, status_code=401)])
-    with patch("app.shared.adapters.hybrid.httpx.AsyncClient", return_value=http_error_client):
+    with patch(
+        "app.shared.adapters.hybrid.get_http_client", return_value=http_error_client
+    ):
         with pytest.raises(ExternalAPIError, match="session creation failed"):
             await adapter._get_vmware_session_id()
 
     ok_client = _FakeAsyncClient([_FakeResponse({"value": "sid-1"})])
-    with patch("app.shared.adapters.hybrid.httpx.AsyncClient", return_value=ok_client):
+    with patch("app.shared.adapters.hybrid.get_http_client", return_value=ok_client):
         session_id = await adapter._get_vmware_session_id()
     assert session_id == "sid-1"
 

--- a/tests/unit/services/adapters/test_license_verification_stream_http_and_manual.py
+++ b/tests/unit/services/adapters/test_license_verification_stream_http_and_manual.py
@@ -44,7 +44,7 @@ async def test_get_json_returns_empty_dict_for_204() -> None:
     response = httpx.Response(204, request=request)
 
     with patch(
-        "app.shared.adapters.license.httpx.AsyncClient",
+        "app.shared.adapters.license.get_http_client",
         return_value=FakeGetClient(response),
     ):
         payload = await adapter._get_json("https://example.invalid", headers={})
@@ -57,7 +57,7 @@ async def test_license_get_json_retry_and_shape_branches() -> None:
 
     list_payload_client = FakeAsyncClient([FakeResponse([{"id": "u1"}])])
     with patch(
-        "app.shared.adapters.license.httpx.AsyncClient",
+        "app.shared.adapters.license.get_http_client",
         return_value=list_payload_client,
     ):
         payload = await adapter._get_json("https://example.invalid", headers={})
@@ -65,7 +65,7 @@ async def test_license_get_json_retry_and_shape_branches() -> None:
 
     bad_shape_client = FakeAsyncClient([FakeResponse("bad-shape")])
     with patch(
-        "app.shared.adapters.license.httpx.AsyncClient",
+        "app.shared.adapters.license.get_http_client",
         return_value=bad_shape_client,
     ):
         with pytest.raises(ExternalAPIError, match="invalid payload shape"):
@@ -75,7 +75,7 @@ async def test_license_get_json_retry_and_shape_branches() -> None:
         [http_status_error(500), FakeResponse({"ok": True})]
     )
     with patch(
-        "app.shared.adapters.license.httpx.AsyncClient",
+        "app.shared.adapters.license.get_http_client",
         return_value=retry_then_ok_client,
     ):
         payload = await adapter._get_json("https://example.invalid", headers={})
@@ -83,7 +83,7 @@ async def test_license_get_json_retry_and_shape_branches() -> None:
 
     non_retry_client = FakeAsyncClient([http_status_error(401)])
     with patch(
-        "app.shared.adapters.license.httpx.AsyncClient",
+        "app.shared.adapters.license.get_http_client",
         return_value=non_retry_client,
     ):
         with pytest.raises(ExternalAPIError, match="status 401"):
@@ -93,7 +93,7 @@ async def test_license_get_json_retry_and_shape_branches() -> None:
         [httpx.ConnectError("c1"), httpx.ConnectError("c2"), httpx.ConnectError("c3")]
     )
     with patch(
-        "app.shared.adapters.license.httpx.AsyncClient",
+        "app.shared.adapters.license.get_http_client",
         return_value=transport_client,
     ):
         with pytest.raises(ExternalAPIError, match="request failed"):
@@ -106,7 +106,10 @@ async def test_license_get_json_fallthrough_raises_last_error_and_unexpected() -
 
     fallthrough_client = FakeAsyncClient([httpx.ConnectError("c1"), httpx.ConnectError("c2")])
     with (
-        patch("app.shared.adapters.license.httpx.AsyncClient", return_value=fallthrough_client),
+        patch(
+            "app.shared.adapters.license.get_http_client",
+            return_value=fallthrough_client,
+        ),
         patch("app.shared.adapters.http_retry.range", return_value=[1, 2]),
     ):
         with pytest.raises(ExternalAPIError, match="License connector API request failed:"):

--- a/tests/unit/services/adapters/test_platform_additional_branches_http.py
+++ b/tests/unit/services/adapters/test_platform_additional_branches_http.py
@@ -21,7 +21,7 @@ async def test_platform_post_json_retry_and_error_branches() -> None:
     adapter = PlatformAdapter(_conn(vendor="newrelic", auth_method="api_key"))
 
     retry_then_ok = _FakeAsyncClient([_http_status_error(500, method="POST"), _FakeResponse({"ok": True})])
-    with patch("app.shared.adapters.platform.httpx.AsyncClient", return_value=retry_then_ok):
+    with patch("app.shared.adapters.platform.get_http_client", return_value=retry_then_ok):
         payload = await adapter._post_json(
             "https://example.invalid",
             headers={"API-Key": "x"},
@@ -30,7 +30,7 @@ async def test_platform_post_json_retry_and_error_branches() -> None:
     assert payload == {"ok": True}
 
     non_retry = _FakeAsyncClient([_http_status_error(401, method="POST")])
-    with patch("app.shared.adapters.platform.httpx.AsyncClient", return_value=non_retry):
+    with patch("app.shared.adapters.platform.get_http_client", return_value=non_retry):
         with pytest.raises(ExternalAPIError, match="failed with status 401"):
             await adapter._post_json(
                 "https://example.invalid",
@@ -39,7 +39,7 @@ async def test_platform_post_json_retry_and_error_branches() -> None:
             )
 
     bad_json = _FakeAsyncClient([_InvalidJSONResponse({})])
-    with patch("app.shared.adapters.platform.httpx.AsyncClient", return_value=bad_json):
+    with patch("app.shared.adapters.platform.get_http_client", return_value=bad_json):
         with pytest.raises(ExternalAPIError, match="invalid JSON"):
             await adapter._post_json(
                 "https://example.invalid",
@@ -50,7 +50,9 @@ async def test_platform_post_json_retry_and_error_branches() -> None:
     transport_fail = _FakeAsyncClient(
         [httpx.ConnectError("c1"), httpx.ConnectError("c2"), httpx.ConnectError("c3")]
     )
-    with patch("app.shared.adapters.platform.httpx.AsyncClient", return_value=transport_fail):
+    with patch(
+        "app.shared.adapters.platform.get_http_client", return_value=transport_fail
+    ):
         with pytest.raises(ExternalAPIError, match="request failed"):
             await adapter._post_json(
                 "https://example.invalid",
@@ -78,24 +80,26 @@ async def test_platform_get_json_retry_and_error_paths() -> None:
     adapter = PlatformAdapter(_conn(vendor="ledger", auth_method="api_key"))
 
     retry_then_ok = _FakeAsyncClient([_http_status_error(500), _FakeResponse({"ok": True})])
-    with patch("app.shared.adapters.platform.httpx.AsyncClient", return_value=retry_then_ok):
+    with patch("app.shared.adapters.platform.get_http_client", return_value=retry_then_ok):
         payload = await adapter._get_json("https://example.invalid", headers={})
     assert payload == {"ok": True}
 
     non_retry = _FakeAsyncClient([_http_status_error(401)])
-    with patch("app.shared.adapters.platform.httpx.AsyncClient", return_value=non_retry):
+    with patch("app.shared.adapters.platform.get_http_client", return_value=non_retry):
         with pytest.raises(ExternalAPIError, match="status 401"):
             await adapter._get_json("https://example.invalid", headers={})
 
     bad_json = _FakeAsyncClient([_InvalidJSONResponse({})])
-    with patch("app.shared.adapters.platform.httpx.AsyncClient", return_value=bad_json):
+    with patch("app.shared.adapters.platform.get_http_client", return_value=bad_json):
         with pytest.raises(ExternalAPIError, match="invalid JSON"):
             await adapter._get_json("https://example.invalid", headers={})
 
     transport_fail = _FakeAsyncClient(
         [httpx.ConnectError("c1"), httpx.ConnectError("c2"), httpx.ConnectError("c3")]
     )
-    with patch("app.shared.adapters.platform.httpx.AsyncClient", return_value=transport_fail):
+    with patch(
+        "app.shared.adapters.platform.get_http_client", return_value=transport_fail
+    ):
         with pytest.raises(ExternalAPIError, match="request failed"):
             await adapter._get_json("https://example.invalid", headers={})
 
@@ -106,7 +110,10 @@ async def test_platform_get_json_and_post_json_fallthrough_raise_last_error() ->
 
     get_transport_fail = _FakeAsyncClient([httpx.ConnectError("c1"), httpx.ConnectError("c2")])
     with (
-        patch("app.shared.adapters.platform.httpx.AsyncClient", return_value=get_transport_fail),
+        patch(
+            "app.shared.adapters.platform.get_http_client",
+            return_value=get_transport_fail,
+        ),
         patch("app.shared.adapters.http_retry.range", return_value=[1, 2]),
     ):
         with pytest.raises(ExternalAPIError, match="Platform request failed:"):
@@ -114,7 +121,10 @@ async def test_platform_get_json_and_post_json_fallthrough_raise_last_error() ->
 
     post_transport_fail = _FakeAsyncClient([httpx.ConnectError("p1"), httpx.ConnectError("p2")])
     with (
-        patch("app.shared.adapters.platform.httpx.AsyncClient", return_value=post_transport_fail),
+        patch(
+            "app.shared.adapters.platform.get_http_client",
+            return_value=post_transport_fail,
+        ),
         patch("app.shared.adapters.http_retry.range", return_value=[1, 2]),
     ):
         with pytest.raises(ExternalAPIError, match="Platform native request failed:"):
@@ -123,4 +133,3 @@ async def test_platform_get_json_and_post_json_fallthrough_raise_last_error() ->
                 headers={"API-Key": "x"},
                 json={"query": "ok"},
             )
-

--- a/tests/unit/services/billing/test_currency_service.py
+++ b/tests/unit/services/billing/test_currency_service.py
@@ -166,14 +166,15 @@ async def test_get_ngn_rate_rejects_non_cbn_provider_in_strict_mode(mock_db):
 
 
 @pytest.mark.asyncio
-async def test_upsert_db_rate_rolls_back_on_commit_failure(mock_db):
+async def test_upsert_db_rate_rolls_back_on_flush_failure(mock_db):
     result = MagicMock()
     result.scalar_one_or_none.return_value = None
     mock_db.execute.return_value = result
-    mock_db.commit = AsyncMock(side_effect=RuntimeError("commit failed"))
+    mock_db.flush = AsyncMock(side_effect=RuntimeError("flush failed"))
 
     service = ExchangeRateService(mock_db)
-    await service._upsert_db_rate("NGN", Decimal("1500.0"), "cbn_nfem")
+    with pytest.raises(RuntimeError, match="flush failed"):
+        await service._upsert_db_rate("NGN", Decimal("1500.0"), "cbn_nfem")
     mock_db.rollback.assert_called_once()
 
 

--- a/tests/unit/services/jobs/test_job_handlers.py
+++ b/tests/unit/services/jobs/test_job_handlers.py
@@ -392,30 +392,24 @@ async def test_finops_analysis_handler_success(mock_db, sample_job):
     handler = FinOpsAnalysisHandler()
 
     mock_conn = MagicMock(provider="aws")
-    aws_result = MagicMock()
-    aws_result.scalars.return_value.all.return_value = [mock_conn]
-    empty_result = MagicMock()
-    empty_result.scalars.return_value.all.return_value = []
-    mock_db.execute = AsyncMock(
-        side_effect=[
-            aws_result,  # AWS
-            empty_result,  # Azure
-            empty_result,  # GCP
-            empty_result,  # SaaS
-            empty_result,  # License
-            empty_result,  # Platform
-            empty_result,  # Hybrid
-        ]
-    )
+    usage_summary = MagicMock()
+    usage_summary.records = [MagicMock()]
 
-    with patch(
-        "app.modules.governance.domain.jobs.handlers.finops.AdapterFactory"
-    ) as mock_factory:
+    with (
+        patch(
+            "app.modules.governance.domain.jobs.handlers.finops.list_tenant_connections",
+            new=AsyncMock(return_value=[mock_conn]),
+        ),
+        patch(
+            "app.modules.governance.domain.jobs.handlers.finops.get_adapter_for_connection"
+        ) as mock_get_adapter,
+        patch(
+            "app.modules.governance.domain.jobs.handlers.finops.fetch_daily_costs_if_supported",
+            new=AsyncMock(return_value=usage_summary),
+        ),
+    ):
         mock_adapter = MagicMock()
-        usage_summary = MagicMock()
-        usage_summary.records = [MagicMock()]
-        mock_adapter.get_daily_costs = AsyncMock(return_value=usage_summary)
-        mock_factory.get_adapter.return_value = mock_adapter
+        mock_get_adapter.return_value = mock_adapter
 
         with patch(
             "app.modules.governance.domain.jobs.handlers.finops.FinOpsAnalyzer"
@@ -452,30 +446,24 @@ async def test_finops_analysis_handler_propagates_actor_context(mock_db, sample_
     }
 
     mock_conn = MagicMock(provider="aws")
-    aws_result = MagicMock()
-    aws_result.scalars.return_value.all.return_value = [mock_conn]
-    empty_result = MagicMock()
-    empty_result.scalars.return_value.all.return_value = []
-    mock_db.execute = AsyncMock(
-        side_effect=[
-            aws_result,
-            empty_result,
-            empty_result,
-            empty_result,
-            empty_result,
-            empty_result,
-            empty_result,
-        ]
-    )
+    usage_summary = MagicMock()
+    usage_summary.records = [MagicMock()]
 
-    with patch(
-        "app.modules.governance.domain.jobs.handlers.finops.AdapterFactory"
-    ) as mock_factory:
+    with (
+        patch(
+            "app.modules.governance.domain.jobs.handlers.finops.list_tenant_connections",
+            new=AsyncMock(return_value=[mock_conn]),
+        ),
+        patch(
+            "app.modules.governance.domain.jobs.handlers.finops.get_adapter_for_connection"
+        ) as mock_get_adapter,
+        patch(
+            "app.modules.governance.domain.jobs.handlers.finops.fetch_daily_costs_if_supported",
+            new=AsyncMock(return_value=usage_summary),
+        ),
+    ):
         mock_adapter = MagicMock()
-        usage_summary = MagicMock()
-        usage_summary.records = [MagicMock()]
-        mock_adapter.get_daily_costs = AsyncMock(return_value=usage_summary)
-        mock_factory.get_adapter.return_value = mock_adapter
+        mock_get_adapter.return_value = mock_adapter
 
         with patch(
             "app.modules.governance.domain.jobs.handlers.finops.FinOpsAnalyzer"
@@ -514,8 +502,8 @@ async def test_finops_analysis_handler_continues_on_recoverable_provider_failure
             new=AsyncMock(return_value=[conn_failed, conn_ok]),
         ),
         patch(
-            "app.modules.governance.domain.jobs.handlers.finops.AdapterFactory"
-        ) as mock_factory,
+            "app.modules.governance.domain.jobs.handlers.finops.get_adapter_for_connection"
+        ) as mock_get_adapter,
         patch(
             "app.modules.governance.domain.jobs.handlers.finops.fetch_daily_costs_if_supported",
             new=AsyncMock(return_value=usage_summary),
@@ -535,7 +523,7 @@ async def test_finops_analysis_handler_continues_on_recoverable_provider_failure
         ) as mock_logger,
     ):
         mock_adapter_ok = MagicMock()
-        mock_factory.get_adapter.side_effect = [
+        mock_get_adapter.side_effect = [
             RuntimeError("adapter unavailable"),
             mock_adapter_ok,
         ]
@@ -567,14 +555,14 @@ async def test_finops_analysis_handler_does_not_swallow_fatal_provider_failures(
             new=AsyncMock(return_value=[conn]),
         ),
         patch(
-            "app.modules.governance.domain.jobs.handlers.finops.AdapterFactory"
-        ) as mock_factory,
+            "app.modules.governance.domain.jobs.handlers.finops.get_adapter_for_connection"
+        ) as mock_get_adapter,
         patch(
             "app.modules.governance.domain.jobs.handlers.finops.LLMFactory.create",
             return_value=MagicMock(),
         ),
     ):
-        mock_factory.get_adapter.side_effect = _FatalTestSignal()
+        mock_get_adapter.side_effect = _FatalTestSignal()
         with pytest.raises(_FatalTestSignal):
             await handler.execute(sample_job, mock_db)
 
@@ -592,8 +580,8 @@ async def test_finops_analysis_handler_marks_failed_when_all_providers_fail(
             new=AsyncMock(return_value=[conn]),
         ),
         patch(
-            "app.modules.governance.domain.jobs.handlers.finops.AdapterFactory"
-        ) as mock_factory,
+            "app.modules.governance.domain.jobs.handlers.finops.get_adapter_for_connection"
+        ) as mock_get_adapter,
         patch(
             "app.modules.governance.domain.jobs.handlers.finops.LLMFactory.create",
             return_value=MagicMock(),
@@ -602,7 +590,7 @@ async def test_finops_analysis_handler_marks_failed_when_all_providers_fail(
             "app.modules.governance.domain.jobs.handlers.finops.FINOPS_PROVIDER_FAILURES_TOTAL"
         ),
     ):
-        mock_factory.get_adapter.side_effect = RuntimeError("adapter unavailable")
+        mock_get_adapter.side_effect = RuntimeError("adapter unavailable")
         result = await handler.execute(sample_job, mock_db)
 
     assert result["status"] == "failed"

--- a/tests/unit/services/notifications/test_email_service.py
+++ b/tests/unit/services/notifications/test_email_service.py
@@ -3,6 +3,7 @@ Tests for EmailService - SMTP Notifications
 """
 
 import pytest
+import smtplib
 from unittest.mock import patch
 from datetime import datetime, timezone
 from app.modules.notifications.domain.email_service import EmailService
@@ -51,7 +52,7 @@ async def test_send_carbon_alert_failure(email_service):
     """Test graceful failure on SMTP error."""
     with patch("smtplib.SMTP") as mock_smtp_cls:
         mock_smtp = mock_smtp_cls.return_value.__enter__.return_value
-        mock_smtp.sendmail.side_effect = Exception("smtp fail")
+        mock_smtp.sendmail.side_effect = smtplib.SMTPException("smtp fail")
 
         res = await email_service.send_carbon_alert(["to@v.io"], {"tier": "starter"})
         assert res is False

--- a/tests/unit/services/zombies/saas_provider/test_saas_detector.py
+++ b/tests/unit/services/zombies/saas_provider/test_saas_detector.py
@@ -65,9 +65,10 @@ async def test_saas_detector_wires_connection_credentials_for_github_plugin() ->
     assert isinstance(detector, SaaSZombieDetector)
 
     with pytest.MonkeyPatch.context() as mp:
-        import httpx
-
-        mp.setattr(httpx, "AsyncClient", lambda *args, **kwargs: mock_client_ctx)
+        mp.setattr(
+            "app.modules.optimization.adapters.saas.plugins.api.get_http_client",
+            lambda *args, **kwargs: mock_client,
+        )
         result = await detector.scan_all()
 
     assert any(

--- a/tests/unit/services/zombies/test_zombie_service.py
+++ b/tests/unit/services/zombies/test_zombie_service.py
@@ -1,11 +1,18 @@
 import pytest
 import asyncio
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 from sqlalchemy.ext.asyncio import AsyncSession
 from app.modules.optimization.domain.service import ZombieService
 from app.models.aws_connection import AWSConnection
+from app.models.azure_connection import AzureConnection
 from app.models.gcp_connection import GCPConnection
+from app.models.hybrid_connection import HybridConnection
+from app.models.license_connection import LicenseConnection
+from app.models.platform_connection import PlatformConnection
+from app.models.saas_connection import SaaSConnection
+from app.shared.core.pricing import PricingTier
 
 
 @pytest.fixture
@@ -47,72 +54,103 @@ async def test_scan_for_tenant_parallel_success(zombie_service, db_session):
     tenant_id = uuid4()
 
     # Mock AWS and GCP connections
-    aws_conn = AWSConnection(id=uuid4(), tenant_id=tenant_id)
-    gcp_conn = GCPConnection(id=uuid4(), tenant_id=tenant_id)
+    aws_conn = MagicMock(spec=AWSConnection)
+    aws_conn.id = uuid4()
+    aws_conn.tenant_id = tenant_id
+    aws_conn.provider = "aws"
+    aws_conn.region = "us-east-1"
+    aws_conn.name = "Prod-AWS"
+    aws_conn.aws_account_id = "123456789012"
+    aws_conn.role_arn = "arn:aws:iam::123456789012:role/Valdrics"
+    aws_conn.external_id = "external-id"
+    aws_conn.cur_bucket_name = "cur-bucket"
+    aws_conn.cur_report_name = "cur-report"
+    aws_conn.cur_prefix = "cur-prefix"
+    gcp_conn = MagicMock(spec=GCPConnection)
+    gcp_conn.id = uuid4()
+    gcp_conn.tenant_id = tenant_id
+    gcp_conn.provider = "gcp"
+    gcp_conn.region = "us-central1"
+    gcp_conn.name = "Prod-GCP"
 
-    # Mock DB query
-    mock_res = MagicMock()
-    mock_res.scalars.return_value.all.side_effect = [[aws_conn], [], [gcp_conn]]
-    db_session.execute.return_value = mock_res
+    rows_by_model = {
+        AWSConnection: [aws_conn],
+        AzureConnection: [],
+        GCPConnection: [gcp_conn],
+        SaaSConnection: [],
+        LicenseConnection: [],
+        PlatformConnection: [],
+        HybridConnection: [],
+    }
 
-    # Mock Detector Success
-    mock_detector = MagicMock()
-    mock_detector.scan_all = AsyncMock(
-        return_value={
-            "unattached_volumes": [{"id": "v-1", "monthly_waste": 10.0}],
-            "idle_instances": [{"id": "i-1", "monthly_waste": 20.0}],
-        }
-    )
-    mock_detector.get_credentials = AsyncMock(
-        return_value={"AccessKeyId": "AK"}
-    )  # BE-DETECTOR-5
-    mock_detector.provider_name = "aws"
+    async def _execute(stmt: object) -> MagicMock:
+        query_text = str(stmt).lower()
+        result = MagicMock()
+        result.scalars.return_value.all.return_value = []
+        for model, rows in rows_by_model.items():
+            if getattr(model, "__tablename__", "").lower() in query_text:
+                result.scalars.return_value.all.return_value = rows
+                break
+        return result
+
+    db_session.execute.side_effect = _execute
+
+    def _build_detector(provider_name: str) -> MagicMock:
+        detector = MagicMock()
+        detector.provider_name = provider_name
+        detector.scan_all = AsyncMock(
+            return_value={
+                "unattached_volumes": [
+                    {"id": f"{provider_name}-v-1", "monthly_waste": 10.0}
+                ],
+                "idle_instances": [
+                    {"id": f"{provider_name}-i-1", "monthly_waste": 20.0}
+                ],
+            }
+        )
+        detector.get_credentials = AsyncMock(
+            return_value={"AccessKeyId": "AK", "SecretAccessKey": "SK"}
+        )
+        return detector
 
     # Mock RegionDiscovery
     mock_rd = MagicMock()
     mock_rd.get_enabled_regions = AsyncMock(return_value=["us-east-1"])
 
-    with patch(
-        "app.modules.optimization.domain.factory.ZombieDetectorFactory.get_detector",
-        return_value=mock_detector,
-    ):
-        with patch(
+    def detector_side_effect(conn: object, **_: object) -> MagicMock:
+        return _build_detector(str(getattr(conn, "provider", "")).lower())
+
+    with (
+        patch(
+            "app.modules.optimization.domain.service.ZombieDetectorFactory",
+            new=SimpleNamespace(get_detector=detector_side_effect),
+        ),
+        patch(
             "app.modules.optimization.adapters.aws.region_discovery.RegionDiscovery",
             return_value=mock_rd,
-        ):
-            with patch(
-                "app.modules.optimization.domain.service.is_feature_enabled",
-                return_value=False,
-            ):  # Skip AI
-                with patch(
-                    "app.shared.core.pricing.get_tenant_tier",
-                    AsyncMock(return_value="starter"),
-                ):  # BE-PRICING-5
-                    with patch(
-                        "app.shared.core.notifications.NotificationDispatcher.notify_zombies",
-                        new_callable=AsyncMock,
-                    ):
-                        with patch("app.shared.core.ops_metrics.SCAN_LATENCY"):
-                            results = await zombie_service.scan_for_tenant(tenant_id)
+        ),
+        patch(
+            "app.modules.optimization.domain.service.is_feature_enabled",
+            return_value=False,
+        ),
+        patch(
+            "app.shared.core.pricing.get_tenant_tier",
+            AsyncMock(return_value=PricingTier.STARTER),
+        ),
+        patch(
+            "app.shared.core.notifications.NotificationDispatcher.notify_zombies",
+            new_callable=AsyncMock,
+        ),
+        patch("app.shared.core.ops_metrics.SCAN_LATENCY"),
+    ):
+        results = await zombie_service.scan_for_tenant(tenant_id)
 
-                            assert (
-                                results["total_monthly_waste"] == 60.0
-                            )  # 30 (aws) + 30 (gcp)
-                            assert (
-                                len(results["unattached_volumes"]) == 2
-                            )  # 1 from each
-                            assert results["scanned_connections"] == 2
-                            assert results["waste_rightsizing"]["deterministic"] is True
-                            assert (
-                                results["waste_rightsizing"]["summary"][
-                                    "total_recommendations"
-                                ]
-                                == 4
-                            )
-                            assert (
-                                results["architectural_inefficiency"]["deterministic"]
-                                is True
-                            )
+    assert results["total_monthly_waste"] == 60.0
+    assert len(results["unattached_volumes"]) == 2
+    assert results["scanned_connections"] == 2
+    assert results["waste_rightsizing"]["deterministic"] is True
+    assert results["waste_rightsizing"]["summary"]["total_recommendations"] == 4
+    assert results["architectural_inefficiency"]["deterministic"] is True
 
 
 @pytest.mark.asyncio
@@ -140,16 +178,22 @@ async def test_scan_for_tenant_timeout_handling(zombie_service, db_session):
 @pytest.mark.asyncio
 async def test_ai_enrichment_tier_gating(zombie_service, db_session):
     tenant_id = uuid4()
-    MagicMock(tenant_id=tenant_id, tier="free")
     zombies = {"unattached_volumes": []}
 
-    with patch(
-        "app.modules.optimization.domain.service.is_feature_enabled", return_value=False
+    with (
+        patch(
+            "app.modules.optimization.domain.service.is_feature_enabled",
+            new=lambda *_args, **_kwargs: False,
+        ),
+        patch(
+            "app.shared.llm.factory.LLMFactory.create",
+            side_effect=AssertionError("LLMFactory.create must not be called"),
+        ) as mock_llm_create,
     ):
-        from app.shared.core.pricing import PricingTier
-
         await zombie_service._enrich_with_ai(zombies, tenant_id, PricingTier.STARTER)
-        assert "upgrade_required" in zombies["ai_analysis"]
+
+    assert zombies["ai_analysis"]["upgrade_required"] is True
+    mock_llm_create.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/zombies/test_zombie_service_cloud_plus.py
+++ b/tests/unit/services/zombies/test_zombie_service_cloud_plus.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
@@ -26,12 +27,14 @@ async def test_scan_for_tenant_includes_platform_and_hybrid_connections() -> Non
     platform_conn.name = "Shared Platform"
     platform_conn.provider = "platform"
     platform_conn.tenant_id = tenant_id
+    platform_conn.region = "global"
 
     hybrid_conn = MagicMock()
     hybrid_conn.id = uuid4()
     hybrid_conn.name = "Private OpenStack"
     hybrid_conn.provider = "hybrid"
     hybrid_conn.tenant_id = tenant_id
+    hybrid_conn.region = "global"
 
     empty = _result_with_rows([])
     platform_result = _result_with_rows([platform_conn])
@@ -76,8 +79,8 @@ async def test_scan_for_tenant_includes_platform_and_hybrid_connections() -> Non
 
     with (
         patch(
-            "app.modules.optimization.domain.service.ZombieDetectorFactory.get_detector",
-            side_effect=detector_side_effect,
+            "app.modules.optimization.domain.service.ZombieDetectorFactory",
+            new=SimpleNamespace(get_detector=detector_side_effect),
         ),
         patch(
             "app.shared.core.pricing.get_tenant_tier",

--- a/tests/unit/shared/adapters/test_saas_adapter_branch_paths.py
+++ b/tests/unit/shared/adapters/test_saas_adapter_branch_paths.py
@@ -35,8 +35,20 @@ class _FakeAsyncClient:
         del exc_type, exc, tb
         return None
 
-    async def get(self, url: str, *, headers: dict[str, str], params: dict[str, object] | None = None):
-        self.calls.append((url, {"headers": headers, "params": params}))
+    async def get(
+        self,
+        url: str,
+        *,
+        headers: dict[str, str],
+        params: dict[str, object] | None = None,
+        timeout: object | None = None,
+        **kwargs: object,
+    ):
+        call = {"headers": headers, "params": params}
+        if timeout is not None:
+            call["timeout"] = timeout
+        call.update(kwargs)
+        self.calls.append((url, call))
         outcome = self._outcomes.pop(0)
         if isinstance(outcome, Exception):
             raise outcome
@@ -251,7 +263,7 @@ async def test_saas_stream_stripe_branch_paths_non_dict_out_of_range_conversion_
 
     fake_client = _FakeAsyncClient([_FakeResponse(payload)])
     with (
-        patch("app.shared.adapters.saas.httpx.AsyncClient", return_value=fake_client),
+        patch("app.shared.adapters.saas.get_http_client", return_value=fake_client),
         patch(
             "app.shared.adapters.saas.convert_to_usd",
             new=AsyncMock(side_effect=RuntimeError("fx down")),
@@ -313,7 +325,7 @@ async def test_saas_stream_salesforce_branch_paths_non_dict_out_of_range_convers
     }
     fake_client = _FakeAsyncClient([_FakeResponse(payload)])
     with (
-        patch("app.shared.adapters.saas.httpx.AsyncClient", return_value=fake_client),
+        patch("app.shared.adapters.saas.get_http_client", return_value=fake_client),
         patch(
             "app.shared.adapters.saas.convert_to_usd",
             new=AsyncMock(side_effect=RuntimeError("fx error")),
@@ -355,7 +367,7 @@ async def test_saas_get_json_dead_fallback_branches_with_patched_range() -> None
 
     fake_client = _FakeAsyncClient([httpx.ConnectError("c1"), httpx.ConnectError("c2")])
     with (
-        patch("app.shared.adapters.saas.httpx.AsyncClient", return_value=fake_client),
+        patch("app.shared.adapters.saas.get_http_client", return_value=fake_client),
         patch("app.shared.adapters.http_retry.asyncio.sleep", new=AsyncMock()),
         patch("app.shared.adapters.http_retry.range", return_value=[1, 2]),
     ):

--- a/tests/unit/supply_chain/test_supply_chain_provenance_workflow.py
+++ b/tests/unit/supply_chain/test_supply_chain_provenance_workflow.py
@@ -86,6 +86,17 @@ def test_ci_workflow_has_enterprise_tdd_quality_gate_job() -> None:
     assert "scripts/run_enterprise_tdd_gate.py" in text
 
 
+def test_ci_workflow_shards_backend_pytest_and_combines_coverage() -> None:
+    text = (REPO_ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+
+    assert "pytest:" in text
+    assert "Backend Pytest Shard ${{ matrix.shard_id }}" in text
+    assert "backend-coverage-${{ matrix.shard_id }}" in text
+    assert "pattern: backend-coverage-*" in text
+    assert "merge-multiple: true" in text
+    assert "coverage combine reports/coverage/shards" in text
+
+
 def test_workflows_pin_uv_bootstrap_version() -> None:
     workflow_paths = (
         REPO_ROOT / ".github/workflows/ci.yml",

--- a/tests/unit/tasks/test_daily_finops_scan.py
+++ b/tests/unit/tasks/test_daily_finops_scan.py
@@ -38,7 +38,7 @@ def test_daily_finops_scan_error_handling(mock_run_cohort, mock_logger):
     from app.tasks.scheduler_tasks import daily_finops_scan
 
     # Make the second call fail
-    mock_run_cohort.delay.side_effect = [None, Exception("Queue Full"), None]
+    mock_run_cohort.delay.side_effect = [None, RuntimeError("Queue Full"), None]
 
     # Execute (should not raise exception)
     daily_finops_scan()

--- a/tests/unit/tasks/test_scheduler_tasks_branch_paths_2.py
+++ b/tests/unit/tasks/test_scheduler_tasks_branch_paths_2.py
@@ -577,6 +577,14 @@ async def test_maintenance_sweep_realized_savings_success_with_sync_carbon_commi
             "app.modules.reporting.domain.carbon_factors.CarbonFactorService.auto_activate_latest",
             new=AsyncMock(return_value={"status": "activated", "active_factor_set_id": "a1", "candidate_factor_set_id": "c1"}),
         ),
+        patch(
+            "app.shared.core.cloud_pricing_data.sync_supported_aws_pricing",
+            new=AsyncMock(return_value=0),
+        ),
+        patch(
+            "app.shared.core.cloud_pricing_data.refresh_cloud_resource_pricing",
+            new=AsyncMock(return_value=0),
+        ),
         patch("app.modules.reporting.domain.realized_savings.RealizedSavingsService") as mock_realized_cls,
         patch("app.shared.core.maintenance.PartitionMaintenanceService") as mock_maintenance_cls,
     ):
@@ -615,6 +623,14 @@ async def test_maintenance_sweep_realized_savings_query_failure_and_sync_rollbac
         patch(
             "app.modules.reporting.domain.carbon_factors.CarbonFactorService.auto_activate_latest",
             new=AsyncMock(side_effect=RuntimeError("factor refresh failed")),
+        ),
+        patch(
+            "app.shared.core.cloud_pricing_data.sync_supported_aws_pricing",
+            new=AsyncMock(return_value=0),
+        ),
+        patch(
+            "app.shared.core.cloud_pricing_data.refresh_cloud_resource_pricing",
+            new=AsyncMock(return_value=0),
         ),
         patch("app.shared.core.maintenance.PartitionMaintenanceService") as mock_maintenance_cls,
         patch("app.tasks.scheduler_tasks.logger") as mock_logger,

--- a/tests/unit/tasks/test_scheduler_tasks_comprehensive.py
+++ b/tests/unit/tasks/test_scheduler_tasks_comprehensive.py
@@ -180,6 +180,14 @@ async def test_maintenance_sweep_success(mock_db):
                 "app.modules.reporting.domain.carbon_factors.CarbonFactorService.auto_activate_latest",
                 new_callable=AsyncMock,
             ) as mock_auto_activate,
+            patch(
+                "app.shared.core.cloud_pricing_data.sync_supported_aws_pricing",
+                new=AsyncMock(return_value=0),
+            ) as mock_sync_supported_aws_pricing,
+            patch(
+                "app.shared.core.cloud_pricing_data.refresh_cloud_resource_pricing",
+                new=AsyncMock(return_value=0),
+            ) as mock_refresh_cloud_resource_pricing,
         ):
             mock_persist = MagicMock()
             mock_persist.finalize_batch = AsyncMock(
@@ -203,6 +211,8 @@ async def test_maintenance_sweep_success(mock_db):
             mock_persist.finalize_batch.assert_called_with(days_ago=2)
             mock_agg.refresh_materialized_view.assert_called_with(mock_db)
             mock_auto_activate.assert_awaited_once()
+            mock_sync_supported_aws_pricing.assert_awaited_once()
+            mock_refresh_cloud_resource_pricing.assert_awaited_once()
             mock_maintenance.create_future_partitions.assert_awaited_once_with(
                 months_ahead=3
             )
@@ -236,6 +246,14 @@ async def test_maintenance_archive_logging(mock_db):
                 patch(
                     "app.tasks.scheduler_tasks.CostAggregator.refresh_materialized_view",
                     new=_fake_refresh_materialized_view,
+                ),
+                patch(
+                    "app.shared.core.cloud_pricing_data.sync_supported_aws_pricing",
+                    new=AsyncMock(return_value=0),
+                ),
+                patch(
+                    "app.shared.core.cloud_pricing_data.refresh_cloud_resource_pricing",
+                    new=AsyncMock(return_value=0),
                 ),
                 patch(
                     "app.shared.core.maintenance.PartitionMaintenanceService.create_future_partitions",
@@ -283,6 +301,14 @@ async def test_maintenance_carbon_factor_refresh_failure_is_logged(mock_db):
                     "app.modules.reporting.domain.carbon_factors.CarbonFactorService.auto_activate_latest",
                     new_callable=AsyncMock,
                 ) as mock_auto_activate,
+                patch(
+                    "app.shared.core.cloud_pricing_data.sync_supported_aws_pricing",
+                    new=AsyncMock(return_value=0),
+                ),
+                patch(
+                    "app.shared.core.cloud_pricing_data.refresh_cloud_resource_pricing",
+                    new=AsyncMock(return_value=0),
+                ),
                 patch(
                     "app.shared.core.maintenance.PartitionMaintenanceService.create_future_partitions",
                     new_callable=AsyncMock,

--- a/tests/unit/tasks/test_scheduler_tasks_reliability.py
+++ b/tests/unit/tasks/test_scheduler_tasks_reliability.py
@@ -450,6 +450,14 @@ class TestSchedulerTasksProductionQuality:
                 new_callable=AsyncMock,
             ) as mock_auto_activate,
             patch(
+                "app.shared.core.cloud_pricing_data.sync_supported_aws_pricing",
+                new=AsyncMock(return_value=0),
+            ) as mock_sync_supported_aws_pricing,
+            patch(
+                "app.shared.core.cloud_pricing_data.refresh_cloud_resource_pricing",
+                new=AsyncMock(return_value=0),
+            ) as mock_refresh_cloud_resource_pricing,
+            patch(
                 "app.shared.core.maintenance.PartitionMaintenanceService.create_future_partitions",
                 new=AsyncMock(return_value=0),
             ) as mock_create_partitions,
@@ -484,5 +492,7 @@ class TestSchedulerTasksProductionQuality:
 
             await _maintenance_sweep_logic()
 
+            mock_sync_supported_aws_pricing.assert_awaited_once()
+            mock_refresh_cloud_resource_pricing.assert_awaited_once()
             mock_create_partitions.assert_awaited_once_with(months_ahead=3)
             mock_archive_partitions.assert_awaited_once_with(months_old=13)

--- a/tests/unit/zombies/test_tier_gating_phase8.py
+++ b/tests/unit/zombies/test_tier_gating_phase8.py
@@ -1,6 +1,8 @@
 import pytest
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch, MagicMock
 from uuid import uuid4
+from app.models.aws_connection import AWSConnection
 from app.modules.optimization.domain.service import ZombieService
 from app.shared.core.pricing import PricingTier
 
@@ -40,24 +42,51 @@ async def test_zombie_service_field_masking_starter():
 
         mock_detector = MagicMock()
         mock_detector.scan_all = AsyncMock(return_value={"idle_instances": mock_items})
+        mock_detector.get_credentials = AsyncMock(
+            return_value={"AccessKeyId": "AK", "SecretAccessKey": "SK"}
+        )
         mock_detector.provider_name = "aws"
 
-        with patch(
-            "app.modules.optimization.domain.factory.ZombieDetectorFactory.get_detector",
-            return_value=mock_detector,
+        with (
+            patch(
+                "app.modules.optimization.domain.service.ZombieDetectorFactory",
+                new=SimpleNamespace(
+                    get_detector=lambda *_args, **_kwargs: mock_detector
+                ),
+            ),
+            patch(
+                "app.modules.optimization.adapters.aws.region_discovery.RegionDiscovery"
+            ) as mock_region_discovery,
         ):
+            mock_region_discovery.return_value.get_enabled_regions = AsyncMock(
+                return_value=["us-east-1"]
+            )
             # We need to have at least one connection to trigger the loop
-            connection = MagicMock()
+            connection = MagicMock(spec=AWSConnection)
+            connection.id = uuid4()
             connection.tenant_id = tenant_id
+            connection.name = "Prod-AWS"
+            connection.provider = "aws"
+            connection.region = "us-east-1"
+            connection.aws_account_id = "123456789012"
+            connection.role_arn = "arn:aws:iam::123456789012:role/Valdrics"
+            connection.external_id = "external-id"
+            connection.cur_bucket_name = "cur-bucket"
+            connection.cur_report_name = "cur-report"
+            connection.cur_prefix = "cur-prefix"
 
             mock_result_aws = MagicMock()
             mock_result_aws.scalars.return_value.all.return_value = [connection]
             mock_result_empty = MagicMock()
             mock_result_empty.scalars.return_value.all.return_value = []
 
-            # 3 calls: AWS, Azure, GCP. Only return connection for AWS.
+            # 7 calls: AWS, Azure, GCP, SaaS, License, Platform, Hybrid.
             db.execute.side_effect = [
                 mock_result_aws,
+                mock_result_empty,
+                mock_result_empty,
+                mock_result_empty,
+                mock_result_empty,
                 mock_result_empty,
                 mock_result_empty,
             ]
@@ -89,16 +118,33 @@ async def test_zombie_service_no_masking_pro():
     ) as mock_tier:
         mock_tier.return_value = PricingTier.PRO
 
-        connection = MagicMock()
+        connection = MagicMock(spec=AWSConnection)
+        connection.id = uuid4()
         connection.tenant_id = tenant_id
+        connection.name = "Prod-AWS"
+        connection.provider = "aws"
+        connection.region = "us-east-1"
+        connection.aws_account_id = "123456789012"
+        connection.role_arn = "arn:aws:iam::123456789012:role/Valdrics"
+        connection.external_id = "external-id"
+        connection.cur_bucket_name = "cur-bucket"
+        connection.cur_report_name = "cur-report"
+        connection.cur_prefix = "cur-prefix"
 
         mock_result_aws = MagicMock()
         mock_result_aws.scalars.return_value.all.return_value = [connection]
         mock_result_empty = MagicMock()
         mock_result_empty.scalars.return_value.all.return_value = []
 
-        # 3 calls: AWS, Azure, GCP
-        db.execute.side_effect = [mock_result_aws, mock_result_empty, mock_result_empty]
+        db.execute.side_effect = [
+            mock_result_aws,
+            mock_result_empty,
+            mock_result_empty,
+            mock_result_empty,
+            mock_result_empty,
+            mock_result_empty,
+            mock_result_empty,
+        ]
 
         mock_items = [
             {"id": "res-1", "monthly_cost": 100, "owner": "real-owner", "is_gpu": True}
@@ -106,12 +152,25 @@ async def test_zombie_service_no_masking_pro():
 
         mock_detector = MagicMock()
         mock_detector.scan_all = AsyncMock(return_value={"idle_instances": mock_items})
+        mock_detector.get_credentials = AsyncMock(
+            return_value={"AccessKeyId": "AK", "SecretAccessKey": "SK"}
+        )
         mock_detector.provider_name = "aws"
 
-        with patch(
-            "app.modules.optimization.domain.factory.ZombieDetectorFactory.get_detector",
-            return_value=mock_detector,
+        with (
+            patch(
+                "app.modules.optimization.domain.service.ZombieDetectorFactory",
+                new=SimpleNamespace(
+                    get_detector=lambda *_args, **_kwargs: mock_detector
+                ),
+            ),
+            patch(
+                "app.modules.optimization.adapters.aws.region_discovery.RegionDiscovery"
+            ) as mock_region_discovery,
         ):
+            mock_region_discovery.return_value.get_enabled_regions = AsyncMock(
+                return_value=["us-east-1"]
+            )
             service = ZombieService(db)
             with patch(
                 "app.shared.core.notifications.NotificationDispatcher.notify_zombies",


### PR DESCRIPTION
## Summary
- add the March 13, 2026 all-changes categorization register
- consolidate the current CI/runtime, governance/onboarding, reporting, and adapter-resilience batch
- align the tracked GitHub issues with the checked-in register for one-pass merge closure

## Tracking
- Closes #284
- Closes #285
- Closes #286
- Closes #287

## Notes
- This PR is the batch vehicle for the full current local worktree.
- No fresh full local suite was run in this turn before opening the PR.