### PR TITLE
chore: categorize and consolidate all pending changes (2026-03-18)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
           SLACK_CHANNEL_ID: ""
           JIRA_BASE_URL: ""
           GITHUB_ACTIONS_TOKEN: ""
-          CORS_ORIGINS: "[\"https://app.validation.example.com\"]"
+          CORS_ORIGINS: '["https://app.validation.example.com"]'
           SENTRY_DSN: "https://example@sentry.io/1"
           OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector:4317"
           FORECASTER_ALLOW_HOLT_WINTERS_FALLBACK: "true"
@@ -452,6 +452,85 @@ jobs:
       - name: Dashboard Bundle Budgets
         working-directory: ./dashboard
         run: pnpm run check:bundle
+
+  dashboard-public-browser-gates:
+    name: Dashboard Public ${{ matrix.label }}
+    runs-on: ubuntu-24.04
+    needs: [dashboard-quality]
+    env:
+      PUBLIC_API_URL: "https://api.example.com/api/v1"
+      PUBLIC_SUPABASE_URL: "https://example.supabase.co"
+      PUBLIC_SUPABASE_ANON_KEY: "ci-public-anon-key"
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: Marketing Smoke
+            spec: e2e/public-marketing.spec.ts
+            artifact: playwright-report-public-marketing
+          - label: Accessibility Gate
+            spec: e2e/public-a11y.spec.ts
+            artifact: playwright-report-public-a11y
+          - label: Performance Gate
+            spec: e2e/performance.spec.ts
+            artifact: playwright-report-public-perf
+          - label: Layout Audit
+            spec: e2e/landing-layout-audit.spec.ts
+            artifact: playwright-report-public-layout
+          - label: Progressive Enhancement Gate
+            spec: e2e/public-progressive-enhancement.spec.ts
+            artifact: playwright-report-public-progressive
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Node
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Setup pnpm via Corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@${{ env.PNPM_VERSION }} --activate
+
+      - name: Cache pnpm dependencies
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: ~/.pnpm-store
+          key: pnpm-${{ runner.os }}-${{ hashFiles('dashboard/pnpm-lock.yaml') }}
+          restore-keys: pnpm-${{ runner.os }}-
+
+      - name: Install Dashboard Dependencies
+        working-directory: ./dashboard
+        run: pnpm install --frozen-lockfile
+
+      - name: Cache Playwright Browsers
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        id: playwright-cache-public
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('dashboard/pnpm-lock.yaml') }}
+
+      - name: Install Playwright Browsers
+        if: steps.playwright-cache-public.outputs.cache-hit != 'true'
+        working-directory: ./dashboard
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Run Public Playwright Suite
+        working-directory: ./dashboard
+        run: pnpm exec playwright test ${{ matrix.spec }} --reporter=html
+        env:
+          PLAYWRIGHT_PUBLIC_ONLY: "1"
+          DASHBOARD_URL: http://localhost:4173
+
+      - name: Upload Public Playwright Report
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        if: always()
+        with:
+          name: ${{ matrix.artifact }}
+          path: dashboard/playwright-report/
+          retention-days: 7
 
   performance-health-gate:
     name: Performance Gate - Health

--- a/app/main.py
+++ b/app/main.py
@@ -57,7 +57,12 @@ from app.shared.db.local_sqlite_bootstrap import (
     bootstrap_local_sqlite_schema,
     should_bootstrap_local_sqlite,
 )
-from app.shared.db.session import async_session_maker, get_engine, reset_db_runtime
+from app.shared.db.session import (
+    async_session_maker,
+    dispose_db_runtime,
+    get_engine,
+    reset_db_runtime,
+)
 from app.shared.core.exceptions import ValdricsException
 from app.shared.core.rate_limit import (
     setup_rate_limiting,
@@ -119,7 +124,7 @@ API_DOCUMENTATION_PATHS = frozenset({"/openapi.json", "/docs", "/redoc"})
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     global settings
     settings = reload_settings_from_environment()
-    reset_db_runtime()
+    await dispose_db_runtime()
     validate_runtime_dependencies(settings)
     init_sentry()
 

--- a/app/models/optimization.py
+++ b/app/models/optimization.py
@@ -12,6 +12,9 @@ from sqlalchemy import (
     ForeignKey,
     DateTime,
     Uuid as PG_UUID,
+    Enum as SQLEnum,
+    Index,
+    UniqueConstraint,
 )
 from sqlalchemy.dialects.postgresql import JSONB
 
@@ -44,6 +47,15 @@ class StrategyType(str, Enum):
     RIGHTSIZING = "rightsizing"
 
 
+class FindingSource(str, Enum):
+    ZOMBIE_SCAN = "zombie_scan"
+
+
+class FindingStatus(str, Enum):
+    OPEN = "open"
+    RESOLVED = "resolved"
+
+
 class OptimizationStrategy(Base):
     """
     Configuration for an optimization strategy available to a tenant.
@@ -65,6 +77,95 @@ class OptimizationStrategy(Base):
     is_active: Mapped[bool] = mapped_column(Boolean, default=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+
+
+class OptimizationFinding(Base):
+    """
+    Durable actionable finding generated from tenant optimization scans.
+
+    The record tracks the latest observed state for a stable resource/category
+    fingerprint while preserving the immutable snapshot later copied onto
+    remediation requests.
+    """
+
+    __tablename__ = "optimization_findings"
+    __table_args__ = (
+        UniqueConstraint(
+            "tenant_id",
+            "fingerprint",
+            name="uix_optimization_findings_tenant_fingerprint",
+        ),
+        Index(
+            "ix_optimization_findings_tenant_status_last_detected",
+            "tenant_id",
+            "status",
+            "last_detected_at",
+        ),
+        Index(
+            "ix_optimization_findings_tenant_connection_region",
+            "tenant_id",
+            "connection_id",
+            "region",
+        ),
+    )
+
+    id: Mapped[UUID] = mapped_column(PG_UUID(), primary_key=True, default=uuid4)
+    tenant_id: Mapped[UUID] = mapped_column(
+        PG_UUID(),
+        ForeignKey("tenants.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    source: Mapped[FindingSource] = mapped_column(
+        SQLEnum(FindingSource),
+        nullable=False,
+        default=FindingSource.ZOMBIE_SCAN,
+        index=True,
+    )
+    status: Mapped[FindingStatus] = mapped_column(
+        SQLEnum(FindingStatus),
+        nullable=False,
+        default=FindingStatus.OPEN,
+        index=True,
+    )
+    fingerprint: Mapped[str] = mapped_column(String(64), nullable=False)
+    provider: Mapped[str] = mapped_column(String(20), nullable=False, index=True)
+    category: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+    connection_id: Mapped[UUID] = mapped_column(PG_UUID(), nullable=False, index=True)
+    connection_name: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    resource_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    resource_type: Mapped[str] = mapped_column(String(100), nullable=False)
+    region: Mapped[str] = mapped_column(String(64), nullable=False, default="global")
+    estimated_monthly_savings: Mapped[Optional[Decimal]] = mapped_column(
+        Numeric(12, 2), nullable=True
+    )
+    confidence_score: Mapped[Optional[Decimal]] = mapped_column(
+        Numeric(4, 3), nullable=True
+    )
+    explainability_notes: Mapped[Optional[str]] = mapped_column(
+        String(2000), nullable=True
+    )
+    requires_manual_review: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False
+    )
+    automated_action_allowed: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True
+    )
+    decision_gate: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
+    payload: Mapped[Dict[str, Any]] = mapped_column(
+        JSON().with_variant(JSONB, "postgresql"), default=dict
+    )
+    first_detected_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+    last_detected_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        index=True,
+    )
+    resolved_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
     )
 
 

--- a/app/models/realized_savings.py
+++ b/app/models/realized_savings.py
@@ -55,6 +55,15 @@ class RealizedSavingsEvent(Base):
         nullable=False,
         index=True,
     )
+    finding_id: Mapped[Optional[UUID]] = mapped_column(
+        PG_UUID(),
+        ForeignKey("optimization_findings.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    finding_category: Mapped[Optional[str]] = mapped_column(
+        String(length=100), nullable=True, index=True
+    )
 
     provider: Mapped[str] = mapped_column(String(length=20), nullable=False, index=True)
     account_id: Mapped[Optional[UUID]] = mapped_column(

--- a/app/models/remediation.py
+++ b/app/models/remediation.py
@@ -30,6 +30,7 @@ from sqlalchemy import (
     DateTime,
     func,
     Uuid as PG_UUID,
+    text,
 )
 
 # from sqlalchemy.dialects.postgresql import UUID as PG_UUID
@@ -41,6 +42,7 @@ from app.shared.db.base import Base
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from app.models.optimization import OptimizationFinding
     from app.models.tenant import Tenant, User
 
 
@@ -104,6 +106,21 @@ class RemediationRequest(Base):
     __tablename__ = "remediation_requests"
     __table_args__ = (
         Index("ix_remediation_tenant_resource", "tenant_id", "resource_id"),
+        Index(
+            "uix_remediation_requests_open_finding_action",
+            "tenant_id",
+            "finding_id",
+            "action",
+            unique=True,
+            postgresql_where=text(
+                "finding_id IS NOT NULL AND status IN "
+                "('PENDING', 'PENDING_APPROVAL', 'APPROVED', 'SCHEDULED', 'EXECUTING')"
+            ),
+            sqlite_where=text(
+                "finding_id IS NOT NULL AND status IN "
+                "('PENDING', 'PENDING_APPROVAL', 'APPROVED', 'SCHEDULED', 'EXECUTING')"
+            ),
+        ),
     )
 
     # Primary Key
@@ -126,6 +143,12 @@ class RemediationRequest(Base):
     connection_id: Mapped[Optional[UUID]] = mapped_column(
         PG_UUID(), nullable=True
     )  # ID of the specific cloud connection
+    finding_id: Mapped[Optional[UUID]] = mapped_column(
+        PG_UUID(),
+        ForeignKey("optimization_findings.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
     region: Mapped[str] = mapped_column(String(20), nullable=False, default="global")
 
     # Action details
@@ -198,6 +221,9 @@ class RemediationRequest(Base):
     action_parameters: Mapped[Optional[dict[str, Any]]] = mapped_column(
         JSON().with_variant(JSONB, "postgresql"), nullable=True
     )
+    finding_snapshot: Mapped[Optional[dict[str, Any]]] = mapped_column(
+        JSON().with_variant(JSONB, "postgresql"), nullable=True
+    )
 
     # Timestamps
     created_at: Mapped[datetime] = mapped_column(
@@ -215,6 +241,7 @@ class RemediationRequest(Base):
     reviewed_by: Mapped[Optional["User"]] = relationship(
         "User", foreign_keys=[reviewed_by_user_id]
     )
+    finding: Mapped[Optional["OptimizationFinding"]] = relationship("OptimizationFinding")
 
     def __repr__(self) -> str:
         return f"<RemediationRequest {self.resource_id} [{self.status.value}]>"

--- a/app/modules/enforcement/domain/export_bundle_ops.py
+++ b/app/modules/enforcement/domain/export_bundle_ops.py
@@ -128,11 +128,11 @@ async def build_export_bundle_payload(
     normalize_policy_document_schema_version_fn: Callable[[str | None], str],
     normalize_policy_document_sha256_fn: Callable[[str | None], str],
     computed_context_snapshot_fn: Callable[[dict[str, Any] | None], dict[str, Any]],
+    parse_iso_datetime_fn: Callable[[Any], datetime | None],
     json_default_fn: Callable[[Any], Any],
     render_decisions_csv_fn: Callable[[list[EnforcementDecision]], str],
     render_approvals_csv_fn: Callable[[list[EnforcementApprovalRequest]], str],
     export_events_counter: Any,
-    utcnow_fn: Callable[[], datetime],
 ) -> dict[str, Any]:
     bounded_max_rows = int(max_rows)
     if bounded_max_rows < 1:
@@ -181,6 +181,7 @@ async def build_export_bundle_payload(
     )
     decisions = list(decision_rows.scalars().all())
     decision_count_exported = len(decisions)
+    bundle_generated_at_candidates: list[datetime] = []
 
     approval_count_db = int(
         (
@@ -247,7 +248,14 @@ async def build_export_bundle_payload(
         dict[str, Any],
     ] = {}
     for decision in decisions:
+        decision_created_at = getattr(decision, "created_at", None)
+        if isinstance(decision_created_at, datetime):
+            bundle_generated_at_candidates.append(as_utc_fn(decision_created_at))
+
         snapshot = computed_context_snapshot_fn(decision.response_payload)
+        snapshot_generated_at_dt = parse_iso_datetime_fn(snapshot.get("generated_at"))
+        if snapshot_generated_at_dt is not None:
+            bundle_generated_at_candidates.append(snapshot_generated_at_dt)
         context_key = (
             str(snapshot["context_version"]),
             str(snapshot["month_start"]),
@@ -312,6 +320,11 @@ async def build_export_bundle_payload(
     ).hexdigest()
 
     approval_count_exported = len(approvals)
+    for approval in approvals:
+        approval_created_at = getattr(approval, "created_at", None)
+        if isinstance(approval_created_at, datetime):
+            bundle_generated_at_candidates.append(as_utc_fn(approval_created_at))
+
     decisions_csv = render_decisions_csv_fn(decisions)
     approvals_csv = render_approvals_csv_fn(approvals)
     decisions_sha256 = hashlib.sha256(decisions_csv.encode("utf-8")).hexdigest()
@@ -324,9 +337,14 @@ async def build_export_bundle_payload(
         artifact="bundle",
         outcome=("success" if parity_ok else "mismatch"),
     ).inc()
+    bundle_generated_at = (
+        max(bundle_generated_at_candidates)
+        if bundle_generated_at_candidates
+        else normalized_end
+    )
 
     return {
-        "generated_at": utcnow_fn(),
+        "generated_at": bundle_generated_at,
         "window_start": normalized_start,
         "window_end": normalized_end,
         "decision_count_db": decision_count_db,

--- a/app/modules/enforcement/domain/service_runtime_ops.py
+++ b/app/modules/enforcement/domain/service_runtime_ops.py
@@ -346,11 +346,11 @@ async def build_export_bundle(
         normalize_policy_document_schema_version_fn=_normalize_policy_document_schema_version,
         normalize_policy_document_sha256_fn=_normalize_policy_document_sha256,
         computed_context_snapshot_fn=_computed_context_snapshot,
+        parse_iso_datetime_fn=_parse_iso_datetime,
         json_default_fn=_json_default,
         render_decisions_csv_fn=service._render_decisions_csv,
         render_approvals_csv_fn=service._render_approvals_csv,
         export_events_counter=ENFORCEMENT_EXPORT_EVENTS_TOTAL,
-        utcnow_fn=_utcnow,
     )
     return EnforcementExportBundle(**payload)
 

--- a/app/modules/optimization/api/v1/zombies.py
+++ b/app/modules/optimization/api/v1/zombies.py
@@ -2,8 +2,10 @@ from typing import Annotated, Dict, Any, Optional
 from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import inspect as sa_inspect
 from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import NO_VALUE
 import structlog
 
 from app.shared.core.auth import CurrentUser, requires_role, require_tenant_access
@@ -57,13 +59,93 @@ _load_remediation_request_for_authorization = (
 _required_approval_permission = _required_approval_permission_impl
 
 
+def _request_finding_status(request_row: RemediationRequest) -> str | None:
+    finding = _request_loaded_finding(request_row)
+    if finding is not None:
+        return getattr(getattr(finding, "status", None), "value", None)
+    snapshot = getattr(request_row, "finding_snapshot", None)
+    if isinstance(snapshot, dict):
+        value = str(snapshot.get("status") or "").strip()
+        return value or None
+    return None
+
+
+def _request_finding_category(request_row: RemediationRequest) -> str | None:
+    finding = _request_loaded_finding(request_row)
+    if finding is not None:
+        value = str(getattr(finding, "category", "") or "").strip()
+        return value or None
+    snapshot = getattr(request_row, "finding_snapshot", None)
+    if isinstance(snapshot, dict):
+        value = str(snapshot.get("category") or "").strip()
+        return value or None
+    return None
+
+
+def _request_loaded_finding(request_row: RemediationRequest) -> Any | None:
+    state = sa_inspect(request_row)
+    attr_state = state.attrs.finding
+    loaded_value = attr_state.loaded_value
+    if loaded_value is NO_VALUE:
+        return None
+    return loaded_value
+
+
+def _serialize_request_row(
+    request_row: RemediationRequest,
+    *,
+    default_region: str,
+    include_execution_fields: bool = False,
+) -> dict[str, Any]:
+    created_at = request_row.created_at
+    payload: dict[str, Any] = {
+        "id": str(request_row.id),
+        "status": request_row.status.value,
+        "resource_id": request_row.resource_id,
+        "resource_type": request_row.resource_type,
+        "action": request_row.action.value,
+        "provider": normalize_provider(getattr(request_row, "provider", None))
+        or "unknown",
+        "region": getattr(request_row, "region", default_region),
+        "connection_id": str(request_row.connection_id)
+        if getattr(request_row, "connection_id", None)
+        else None,
+        "finding_id": str(request_row.finding_id)
+        if getattr(request_row, "finding_id", None)
+        else None,
+        "finding_status": _request_finding_status(request_row),
+        "finding_category": _request_finding_category(request_row),
+        "estimated_savings": float(request_row.estimated_monthly_savings or 0),
+        "created_at": created_at.isoformat() if created_at else None,
+    }
+    if include_execution_fields:
+        executed_at = getattr(request_row, "executed_at", None)
+        payload["executed_at"] = (
+            executed_at.isoformat() if executed_at is not None else None
+        )
+        payload["execution_error"] = getattr(request_row, "execution_error", None)
+    else:
+        scheduled_execution_at = request_row.scheduled_execution_at
+        payload["scheduled_execution_at"] = (
+            scheduled_execution_at.isoformat()
+            if scheduled_execution_at is not None
+            else None
+        )
+        payload["escalation_required"] = bool(
+            getattr(request_row, "escalation_required", False)
+        )
+        payload["escalation_reason"] = getattr(request_row, "escalation_reason", None)
+        payload["escalated_at"] = (
+            escalated_at.isoformat()
+            if (escalated_at := getattr(request_row, "escalated_at", None))
+            else None
+        )
+    return payload
+
+
 class RemediationRequestCreate(BaseModel):
-    resource_id: str
-    resource_type: str
+    finding_id: UUID
     action: str
-    provider: str
-    connection_id: Optional[UUID] = None
-    estimated_savings: float
     create_backup: bool = False
     backup_retention_days: int = 30
     backup_cost_estimate: float = 0
@@ -83,13 +165,8 @@ class PolicyPreviewResponse(BaseModel):
 
 
 class PolicyPreviewCreate(BaseModel):
-    resource_id: str
-    resource_type: str
+    finding_id: UUID
     action: str
-    provider: str
-    connection_id: Optional[UUID] = None
-    confidence_score: float | None = None
-    explainability_notes: str | None = None
     review_notes: str | None = None
     parameters: Optional[Dict[str, Any]] = None
 
@@ -175,20 +252,27 @@ async def create_remediation_request(
     action_enum = _parse_remediation_action(request.action)
 
     service = RemediationService(db=db, region=region_hint)
-    result = await service.create_request(
-        tenant_id=tenant_id,
-        user_id=user.id,
-        resource_id=request.resource_id,
-        resource_type=request.resource_type,
-        action=action_enum,
-        estimated_savings=request.estimated_savings,
-        create_backup=request.create_backup,
-        backup_retention_days=request.backup_retention_days,
-        backup_cost_estimate=request.backup_cost_estimate,
-        provider=request.provider,
-        connection_id=request.connection_id,
-        parameters=request.parameters,
-    )
+    try:
+        result = await service.create_request_from_finding(
+            tenant_id=tenant_id,
+            user_id=user.id,
+            finding_id=request.finding_id,
+            action=action_enum,
+            create_backup=request.create_backup,
+            backup_retention_days=request.backup_retention_days,
+            backup_cost_estimate=request.backup_cost_estimate,
+            parameters=request.parameters,
+        )
+    except ResourceNotFoundError:
+        raise
+    except ValdricsException:
+        raise
+    except ValueError as exc:
+        raise ValdricsException(
+            message=str(exc),
+            code="remediation_request_invalid",
+            status_code=400,
+        ) from exc
     return {"status": "pending", "request_id": str(result.id)}
 
 
@@ -214,32 +298,53 @@ async def list_pending_requests(
     return {
         "pending_count": len(pending),
         "requests": [
-            {
-                "id": str(r.id),
-                "status": r.status.value,
-                "resource_id": r.resource_id,
-                "resource_type": r.resource_type,
-                "action": r.action.value,
-                "provider": normalize_provider(getattr(r, "provider", None))
-                or "unknown",
-                "region": getattr(r, "region", region_hint),
-                "connection_id": str(r.connection_id)
-                if getattr(r, "connection_id", None)
-                else None,
-                "estimated_savings": float(r.estimated_monthly_savings or 0),
-                "scheduled_execution_at": (
-                    r.scheduled_execution_at.isoformat()
-                    if r.scheduled_execution_at is not None
-                    else None
-                ),
-                "escalation_required": bool(getattr(r, "escalation_required", False)),
-                "escalation_reason": getattr(r, "escalation_reason", None),
-                "escalated_at": escalated_at.isoformat()
-                if (escalated_at := getattr(r, "escalated_at", None))
-                else None,
-                "created_at": r.created_at.isoformat() if r.created_at else None,
-            }
-            for r in pending
+            _serialize_request_row(r, default_region=region_hint) for r in pending
+        ],
+    }
+
+
+@router.get("/history")
+async def list_remediation_history(
+    tenant_id: Annotated[UUID, Depends(require_tenant_access)],
+    user: Annotated[CurrentUser, Depends(requires_role("member"))],
+    db: AsyncSession = Depends(get_db),
+    region: str = Query(default=DEFAULT_REGION_HINT),
+    status: str = Query(
+        default="completed", pattern="^(completed|failed|rejected|cancelled|all)$"
+    ),
+    limit: int = Query(default=20, ge=1, le=100),
+    offset: int = Query(default=0, ge=0),
+) -> Dict[str, Any]:
+    """List recent non-open remediation requests for an operator-facing history view."""
+    region_hint = _coerce_region_hint(region)
+    normalized_status = str(status or "completed").strip().lower()
+    page_limit = _coerce_query_int(limit, default=20, minimum=1)
+    page_offset = _coerce_query_int(offset, default=0, minimum=0)
+    service = RemediationService(db=db, region=region_hint)
+    try:
+        history = await service.list_history(
+            tenant_id,
+            status=normalized_status,
+            limit=page_limit,
+            offset=page_offset,
+        )
+    except ValueError as exc:
+        raise ValdricsException(
+            message=str(exc),
+            code="remediation_history_invalid_status",
+            status_code=400,
+        ) from exc
+
+    return {
+        "history_count": len(history),
+        "status": normalized_status,
+        "requests": [
+            _serialize_request_row(
+                request_row,
+                default_region=region_hint,
+                include_execution_fields=True,
+            )
+            for request_row in history
         ],
     }
 
@@ -326,19 +431,25 @@ async def preview_remediation_policy_payload(
     action_enum = _parse_remediation_action(payload.action)
 
     service = RemediationService(db=db, region=region_hint)
-    preview = await service.preview_policy_input(
-        tenant_id=tenant_id,
-        user_id=user.id,
-        resource_id=payload.resource_id,
-        resource_type=payload.resource_type,
-        action=action_enum,
-        provider=payload.provider,
-        connection_id=payload.connection_id,
-        confidence_score=payload.confidence_score,
-        explainability_notes=payload.explainability_notes,
-        review_notes=payload.review_notes,
-        parameters=payload.parameters,
-    )
+    try:
+        preview = await service.preview_policy_for_finding(
+            tenant_id=tenant_id,
+            user_id=user.id,
+            finding_id=payload.finding_id,
+            action=action_enum,
+            review_notes=payload.review_notes,
+            parameters=payload.parameters,
+        )
+    except ResourceNotFoundError:
+        raise
+    except ValdricsException:
+        raise
+    except ValueError as exc:
+        raise ValdricsException(
+            message=str(exc),
+            code="remediation_policy_preview_invalid",
+            status_code=400,
+        ) from exc
     return PolicyPreviewResponse(**preview)
 
 

--- a/app/modules/optimization/domain/findings.py
+++ b/app/modules/optimization/domain/findings.py
@@ -1,0 +1,485 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Any, cast
+from uuid import UUID, uuid4
+
+import structlog
+from sqlalchemy import select
+from sqlalchemy.exc import SQLAlchemyError
+
+from app.models.optimization import (
+    FindingSource,
+    FindingStatus,
+    OptimizationFinding,
+)
+from app.shared.core.exceptions import ResourceNotFoundError, ValdricsException
+from app.shared.core.provider import normalize_provider
+
+logger = structlog.get_logger()
+
+FINDING_PERSISTENCE_RECOVERABLE_EXCEPTIONS: tuple[type[Exception], ...] = (
+    SQLAlchemyError,
+    RuntimeError,
+    OSError,
+    TimeoutError,
+    TypeError,
+    ValueError,
+    KeyError,
+    LookupError,
+    AttributeError,
+)
+_NON_ACTIONABLE_BUCKETS = {
+    "errors",
+    "scan_completeness",
+}
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _coerce_uuid(value: Any) -> UUID | None:
+    if isinstance(value, UUID):
+        return value
+    if isinstance(value, str):
+        raw = value.strip()
+        if not raw:
+            return None
+        try:
+            return UUID(raw)
+        except ValueError:
+            return None
+    return None
+
+
+def _coerce_decimal(value: Any) -> Decimal | None:
+    if value is None:
+        return None
+    if isinstance(value, Decimal):
+        return value
+    try:
+        return Decimal(str(value))
+    except (ValueError, TypeError, ArithmeticError):
+        return None
+
+
+def _normalize_region(value: Any) -> str:
+    normalized = str(value or "").strip().lower()
+    return normalized or "global"
+
+
+def _snapshot_payload(item: dict[str, Any]) -> dict[str, Any]:
+    payload = dict(item)
+    payload.pop("finding_id", None)
+    payload.pop("finding_status", None)
+    return payload
+
+
+def build_finding_fingerprint(
+    *,
+    source: str,
+    provider: str,
+    connection_id: UUID,
+    category: str,
+    region: str,
+    resource_id: str,
+    resource_type: str,
+) -> str:
+    canonical = json.dumps(
+        {
+            "source": source,
+            "provider": provider,
+            "connection_id": str(connection_id),
+            "category": category,
+            "region": region,
+            "resource_id": resource_id,
+            "resource_type": resource_type,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def build_request_finding_snapshot(finding: OptimizationFinding) -> dict[str, Any]:
+    return {
+        "finding_id": str(finding.id),
+        "source": (
+            finding.source.value
+            if hasattr(finding.source, "value")
+            else str(finding.source or "")
+        ),
+        "status": (
+            finding.status.value
+            if hasattr(finding.status, "value")
+            else str(finding.status or "")
+        ),
+        "fingerprint": str(finding.fingerprint or ""),
+        "provider": str(finding.provider or ""),
+        "category": str(finding.category or ""),
+        "connection_id": str(finding.connection_id),
+        "connection_name": str(finding.connection_name or ""),
+        "resource_id": str(finding.resource_id or ""),
+        "resource_type": str(finding.resource_type or ""),
+        "region": str(finding.region or "global"),
+        "estimated_monthly_savings": (
+            str(finding.estimated_monthly_savings)
+            if finding.estimated_monthly_savings is not None
+            else None
+        ),
+        "confidence_score": (
+            float(finding.confidence_score)
+            if finding.confidence_score is not None
+            else None
+        ),
+        "explainability_notes": str(finding.explainability_notes or "")
+        if finding.explainability_notes is not None
+        else None,
+        "requires_manual_review": bool(finding.requires_manual_review),
+        "automated_action_allowed": bool(finding.automated_action_allowed),
+        "decision_gate": str(finding.decision_gate or "")
+        if finding.decision_gate is not None
+        else None,
+        "payload": dict(finding.payload or {}),
+        "first_detected_at": (
+            finding.first_detected_at.isoformat()
+            if finding.first_detected_at is not None
+            else None
+        ),
+        "last_detected_at": (
+            finding.last_detected_at.isoformat()
+            if finding.last_detected_at is not None
+            else None
+        ),
+    }
+
+
+async def get_open_finding_for_tenant(
+    service: Any,
+    *,
+    tenant_id: UUID,
+    finding_id: UUID,
+    source: FindingSource = FindingSource.ZOMBIE_SCAN,
+) -> OptimizationFinding:
+    try:
+        finding = cast(
+            OptimizationFinding,
+            await service.get_by_id(OptimizationFinding, finding_id, tenant_id),
+        )
+    except ResourceNotFoundError as exc:
+        raise ResourceNotFoundError(
+            f"Finding {finding_id} not found for this tenant.",
+            code="optimization_finding_not_found",
+        ) from exc
+
+    if finding.source != source:
+        raise ValdricsException(
+            message="Finding source is not valid for this remediation flow.",
+            code="optimization_finding_invalid_source",
+            status_code=400,
+            details={"finding_id": str(finding_id)},
+        )
+    if finding.status != FindingStatus.OPEN:
+        raise ValdricsException(
+            message="Finding is no longer open for remediation.",
+            code="optimization_finding_resolved",
+            status_code=409,
+            details={"finding_id": str(finding_id)},
+        )
+    return finding
+
+
+async def validate_request_finding_binding(
+    service: Any,
+    *,
+    tenant_id: UUID,
+    request: Any,
+) -> OptimizationFinding | None:
+    finding_id = _coerce_uuid(getattr(request, "finding_id", None))
+    snapshot_candidate = getattr(request, "finding_snapshot", None)
+    snapshot_raw = (
+        snapshot_candidate if isinstance(snapshot_candidate, dict) else None
+    )
+    if finding_id is None and snapshot_raw is None:
+        return None
+
+    if snapshot_raw is None:
+        raise ValdricsException(
+            message="Remediation request is missing its immutable finding snapshot.",
+            code="remediation_finding_snapshot_missing",
+            status_code=409,
+        )
+
+    expected_provider = normalize_provider(snapshot_raw.get("provider"))
+    current_provider = normalize_provider(getattr(request, "provider", None))
+    expected_connection_id = _coerce_uuid(snapshot_raw.get("connection_id"))
+    current_connection_id = getattr(request, "connection_id", None)
+    expected_region = _normalize_region(snapshot_raw.get("region"))
+    current_region = _normalize_region(getattr(request, "region", None))
+    expected_resource_id = str(snapshot_raw.get("resource_id") or "").strip()
+    current_resource_id = str(getattr(request, "resource_id", "") or "").strip()
+    expected_resource_type = str(snapshot_raw.get("resource_type") or "").strip()
+    current_resource_type = str(getattr(request, "resource_type", "") or "").strip()
+
+    mismatches: dict[str, dict[str, Any]] = {}
+    if expected_provider != current_provider:
+        mismatches["provider"] = {"expected": expected_provider, "actual": current_provider}
+    if expected_connection_id != current_connection_id:
+        mismatches["connection_id"] = {
+            "expected": str(expected_connection_id) if expected_connection_id else None,
+            "actual": str(current_connection_id) if current_connection_id else None,
+        }
+    if expected_region != current_region:
+        mismatches["region"] = {"expected": expected_region, "actual": current_region}
+    if expected_resource_id != current_resource_id:
+        mismatches["resource_id"] = {
+            "expected": expected_resource_id,
+            "actual": current_resource_id,
+        }
+    if expected_resource_type != current_resource_type:
+        mismatches["resource_type"] = {
+            "expected": expected_resource_type,
+            "actual": current_resource_type,
+        }
+    if mismatches:
+        raise ValdricsException(
+            message="Remediation request no longer matches its bound finding context.",
+            code="remediation_finding_context_mismatch",
+            status_code=409,
+            details={"mismatches": mismatches},
+        )
+
+    if finding_id is None:
+        return None
+
+    finding = await get_open_finding_for_tenant(
+        service,
+        tenant_id=tenant_id,
+        finding_id=finding_id,
+    )
+
+    snapshot_fingerprint = str(snapshot_raw.get("fingerprint") or "").strip()
+    if snapshot_fingerprint and snapshot_fingerprint != str(finding.fingerprint or ""):
+        raise ValdricsException(
+            message="Remediation finding has drifted from the approved snapshot.",
+            code="remediation_finding_drifted",
+            status_code=409,
+            details={
+                "finding_id": str(finding_id),
+                "snapshot_fingerprint": snapshot_fingerprint,
+                "current_fingerprint": str(finding.fingerprint or ""),
+            },
+        )
+    return finding
+
+
+async def persist_scan_findings(
+    service: Any,
+    *,
+    tenant_id: UUID,
+    scan_payload: dict[str, Any],
+) -> None:
+    now = _utcnow()
+    scopes: set[tuple[str, UUID, str]] = set()
+    normalized_items: list[tuple[str, dict[str, Any], dict[str, Any]]] = []
+
+    completeness_rows = scan_payload.get("scan_completeness")
+    if isinstance(completeness_rows, list):
+        for summary in completeness_rows:
+            if not isinstance(summary, dict):
+                continue
+            provider = normalize_provider(summary.get("provider"))
+            connection_id = _coerce_uuid(summary.get("connection_id"))
+            if not provider or connection_id is None:
+                continue
+            scopes.add((provider, connection_id, _normalize_region(summary.get("region"))))
+
+    for category, bucket in scan_payload.items():
+        if category in _NON_ACTIONABLE_BUCKETS or not isinstance(bucket, list):
+            continue
+        for item in bucket:
+            if not isinstance(item, dict):
+                continue
+            provider = normalize_provider(item.get("provider"))
+            connection_id = _coerce_uuid(item.get("connection_id"))
+            resource_id = str(item.get("resource_id") or item.get("id") or "").strip()
+            if not provider or connection_id is None or not resource_id:
+                continue
+            resource_type = str(item.get("resource_type") or category).strip() or category
+            region = _normalize_region(item.get("region"))
+            fingerprint = build_finding_fingerprint(
+                source=FindingSource.ZOMBIE_SCAN.value,
+                provider=provider,
+                connection_id=connection_id,
+                category=category,
+                region=region,
+                resource_id=resource_id,
+                resource_type=resource_type,
+            )
+            scopes.add((provider, connection_id, region))
+            normalized: dict[str, Any] = {
+                "provider": provider,
+                "connection_id": connection_id,
+                "connection_name": str(item.get("connection_name") or "").strip() or None,
+                "category": category,
+                "resource_id": resource_id,
+                "resource_type": resource_type,
+                "region": region,
+                "estimated_monthly_savings": _coerce_decimal(
+                    item.get("estimated_monthly_savings", item.get("monthly_cost"))
+                ),
+                "confidence_score": _coerce_decimal(item.get("confidence_score")),
+                "explainability_notes": (
+                    str(item.get("explainability_notes")).strip()
+                    if item.get("explainability_notes") is not None
+                    else None
+                ),
+                "requires_manual_review": bool(item.get("requires_manual_review", False)),
+                "automated_action_allowed": bool(
+                    item.get("automated_action_allowed", True)
+                ),
+                "decision_gate": (
+                    str(item.get("decision_gate")).strip()
+                    if item.get("decision_gate") is not None
+                    else None
+                ),
+                "payload": _snapshot_payload(item),
+                "fingerprint": fingerprint,
+            }
+            normalized_items.append((category, item, normalized))
+
+    connection_ids = {connection_id for _provider, connection_id, _region in scopes}
+    existing_rows: list[OptimizationFinding] = []
+    if connection_ids:
+        query_result = await service.db.execute(
+            select(OptimizationFinding).where(
+                OptimizationFinding.tenant_id == tenant_id,
+                OptimizationFinding.source == FindingSource.ZOMBIE_SCAN,
+                OptimizationFinding.connection_id.in_(list(connection_ids)),
+            )
+        )
+        scalar_result = query_result.scalars()
+        existing_rows = [
+            row
+            for row in list(
+                scalar_result.all() if hasattr(scalar_result, "all") else scalar_result
+            )
+            if isinstance(row, OptimizationFinding)
+        ]
+
+    existing_by_fingerprint = {
+        str(row.fingerprint): row for row in existing_rows if row.fingerprint
+    }
+    seen_fingerprints: set[str] = set()
+
+    for _category, item, normalized in normalized_items:
+        fingerprint = str(normalized["fingerprint"])
+        finding = existing_by_fingerprint.get(fingerprint)
+        connection_id = cast(UUID, normalized["connection_id"])
+        connection_name = cast(str | None, normalized["connection_name"])
+        estimated_monthly_savings = cast(
+            Decimal | None,
+            normalized["estimated_monthly_savings"],
+        )
+        confidence_score = cast(Decimal | None, normalized["confidence_score"])
+        explainability_notes = cast(str | None, normalized["explainability_notes"])
+        decision_gate = cast(str | None, normalized["decision_gate"])
+        payload = cast(dict[str, Any], normalized["payload"])
+        if finding is None:
+            finding = OptimizationFinding(
+                id=uuid4(),
+                tenant_id=tenant_id,
+                source=FindingSource.ZOMBIE_SCAN,
+                status=FindingStatus.OPEN,
+                fingerprint=fingerprint,
+                provider=str(normalized["provider"]),
+                category=str(normalized["category"]),
+                connection_id=connection_id,
+                connection_name=connection_name,
+                resource_id=str(normalized["resource_id"]),
+                resource_type=str(normalized["resource_type"]),
+                region=str(normalized["region"]),
+                estimated_monthly_savings=estimated_monthly_savings,
+                confidence_score=confidence_score,
+                explainability_notes=explainability_notes,
+                requires_manual_review=bool(normalized["requires_manual_review"]),
+                automated_action_allowed=bool(normalized["automated_action_allowed"]),
+                decision_gate=decision_gate,
+                payload=dict(payload),
+                first_detected_at=now,
+                last_detected_at=now,
+                resolved_at=None,
+            )
+            service.db.add(finding)
+            existing_by_fingerprint[fingerprint] = finding
+        else:
+            finding.status = FindingStatus.OPEN
+            finding.provider = str(normalized["provider"])
+            finding.category = str(normalized["category"])
+            finding.connection_id = connection_id
+            finding.connection_name = connection_name
+            finding.resource_id = str(normalized["resource_id"])
+            finding.resource_type = str(normalized["resource_type"])
+            finding.region = str(normalized["region"])
+            finding.estimated_monthly_savings = estimated_monthly_savings
+            finding.confidence_score = confidence_score
+            finding.explainability_notes = explainability_notes
+            finding.requires_manual_review = bool(normalized["requires_manual_review"])
+            finding.automated_action_allowed = bool(
+                normalized["automated_action_allowed"]
+            )
+            finding.decision_gate = decision_gate
+            finding.payload = dict(payload)
+            finding.last_detected_at = now
+            finding.resolved_at = None
+
+        seen_fingerprints.add(fingerprint)
+        item["finding_id"] = str(finding.id)
+        item["finding_status"] = FindingStatus.OPEN.value
+
+    if not bool(scan_payload.get("partial_results")):
+        for row in existing_rows:
+            scope = (
+                normalize_provider(row.provider) or str(row.provider),
+                row.connection_id,
+                _normalize_region(row.region),
+            )
+            if scope not in scopes:
+                continue
+            if row.fingerprint in seen_fingerprints:
+                continue
+            if row.status == FindingStatus.RESOLVED:
+                continue
+            row.status = FindingStatus.RESOLVED
+            row.resolved_at = now
+
+
+async def persist_scan_findings_with_guard(
+    service: Any,
+    *,
+    tenant_id: UUID,
+    scan_payload: dict[str, Any],
+) -> None:
+    try:
+        await persist_scan_findings(
+            service,
+            tenant_id=tenant_id,
+            scan_payload=scan_payload,
+        )
+        await service.db.commit()
+    except FINDING_PERSISTENCE_RECOVERABLE_EXCEPTIONS as exc:
+        await service.db.rollback()
+        logger.exception(
+            "optimization_finding_persistence_failed",
+            tenant_id=str(tenant_id),
+            error=str(exc),
+        )
+        raise ValdricsException(
+            message="Failed to persist actionable findings for this scan.",
+            code="optimization_finding_persistence_failed",
+            status_code=500,
+        ) from exc

--- a/app/modules/optimization/domain/remediation.py
+++ b/app/modules/optimization/domain/remediation.py
@@ -280,6 +280,30 @@ class RemediationService(BaseService):
             connection_id=connection_id,
         )
 
+    async def preview_policy_for_finding(
+        self,
+        *,
+        tenant_id: UUID,
+        user_id: UUID,
+        finding_id: UUID,
+        action: RemediationAction,
+        review_notes: Optional[str] = None,
+        parameters: Optional[Dict[str, Any]] = None,
+    ) -> dict[str, Any]:
+        from app.modules.optimization.domain.remediation_workflow import (
+            preview_policy_for_finding_payload,
+        )
+
+        return await preview_policy_for_finding_payload(
+            self,
+            tenant_id=tenant_id,
+            user_id=user_id,
+            finding_id=finding_id,
+            action=action,
+            review_notes=review_notes,
+            parameters=parameters,
+        )
+
     async def create_request(
         self,
         tenant_id: UUID,
@@ -319,6 +343,34 @@ class RemediationService(BaseService):
             parameters=parameters,
         )
 
+    async def create_request_from_finding(
+        self,
+        *,
+        tenant_id: UUID,
+        user_id: UUID,
+        finding_id: UUID,
+        action: RemediationAction,
+        create_backup: bool = False,
+        backup_retention_days: int = 30,
+        backup_cost_estimate: float = 0,
+        parameters: Optional[Dict[str, Any]] = None,
+    ) -> RemediationRequest:
+        from app.modules.optimization.domain.remediation_workflow import (
+            create_remediation_request_from_finding,
+        )
+
+        return await create_remediation_request_from_finding(
+            self,
+            tenant_id=tenant_id,
+            user_id=user_id,
+            finding_id=finding_id,
+            action=action,
+            create_backup=create_backup,
+            backup_retention_days=backup_retention_days,
+            backup_cost_estimate=backup_cost_estimate,
+            parameters=parameters,
+        )
+
     async def list_pending(
         self, tenant_id: UUID, limit: int = 50, offset: int = 0
     ) -> List[RemediationRequest]:
@@ -329,6 +381,26 @@ class RemediationService(BaseService):
         return await list_pending_requests(
             self,
             tenant_id,
+            limit=limit,
+            offset=offset,
+        )
+
+    async def list_history(
+        self,
+        tenant_id: UUID,
+        *,
+        status: str = "completed",
+        limit: int = 20,
+        offset: int = 0,
+    ) -> List[RemediationRequest]:
+        from app.modules.optimization.domain.remediation_workflow import (
+            list_request_history,
+        )
+
+        return await list_request_history(
+            self,
+            tenant_id,
+            status=status,
             limit=limit,
             offset=offset,
         )

--- a/app/modules/optimization/domain/remediation_credentials.py
+++ b/app/modules/optimization/domain/remediation_credentials.py
@@ -8,7 +8,10 @@ from sqlalchemy import select
 
 from app.models.remediation import RemediationRequest
 from app.shared.core.connection_queries import get_connection_model
-from app.shared.core.connection_state import resolve_connection_region
+from app.shared.core.connection_state import (
+    is_connection_active,
+    resolve_connection_region,
+)
 from app.shared.core.provider import normalize_provider
 
 logger = structlog.get_logger()
@@ -44,25 +47,32 @@ async def resolve_connection_credentials(
     def _coerce_list(value: Any) -> list[Any]:
         return list(value) if isinstance(value, list) else []
 
-    stmt = select(connection_model).where(connection_model.tenant_id == tenant_id)
-    if connection_id:
-        stmt = stmt.where(connection_model.id == connection_id)
-    else:
-        if hasattr(connection_model, "status"):
-            stmt = stmt.where(connection_model.status == "active")
-        elif hasattr(connection_model, "is_active"):
-            stmt = stmt.where(connection_model.is_active.is_(True))
+    if not connection_id:
+        logger.warning(
+            "remediation_credentials_missing_connection_binding",
+            tenant_id=str(tenant_id),
+            provider=provider,
+        )
+        return {}
 
-        order_clauses = []
-        if hasattr(connection_model, "last_verified_at"):
-            order_clauses.append(connection_model.last_verified_at.desc())
-        order_clauses.append(connection_model.id.desc())
-        stmt = stmt.order_by(*order_clauses)
+    stmt = (
+        select(connection_model)
+        .where(connection_model.tenant_id == tenant_id)
+        .where(connection_model.id == connection_id)
+    )
 
     result = await service.db.execute(stmt)
     connection = await service._scalar_one_or_none(result)
     if connection is None:
         return missing_connection_result
+    if not is_connection_active(connection):
+        logger.warning(
+            "remediation_credentials_inactive_connection",
+            tenant_id=str(tenant_id),
+            provider=provider,
+            connection_id=str(connection_id),
+        )
+        return {}
 
     if provider == "aws":
         role_arn = getattr(connection, "role_arn", None)

--- a/app/modules/optimization/domain/remediation_execute.py
+++ b/app/modules/optimization/domain/remediation_execute.py
@@ -11,7 +11,9 @@ from sqlalchemy import select
 from sqlalchemy.exc import SQLAlchemyError
 
 from app.models.remediation import RemediationRequest, RemediationStatus
+from app.models.optimization import FindingStatus
 from app.modules.governance.domain.security.remediation_policy import PolicyDecision, RemediationPolicyEngine
+from app.modules.optimization.domain.findings import validate_request_finding_binding
 from app.modules.optimization.domain.remediation_execute_helpers import (
     apply_execution_result,
     build_remediation_context,
@@ -27,6 +29,7 @@ from app.shared.core.exceptions import (
     ExternalAPIError,
     KillSwitchTriggeredError,
     ResourceNotFoundError,
+    ValdricsException,
 )
 from app.shared.core.ops_metrics import REMEDIATION_DURATION_SECONDS
 from app.shared.core.pricing import PricingTier
@@ -52,6 +55,7 @@ REMEDIATION_ACTION_PARSE_RECOVERABLE_EXCEPTIONS: tuple[type[Exception], ...] = (
 REMEDIATION_EXECUTION_RECOVERABLE_EXCEPTIONS: tuple[type[BaseException], ...] = (
     ExternalAPIError,
     KillSwitchTriggeredError,
+    ValdricsException,
     *_REMEDIATION_COMMON_RECOVERABLE_EXCEPTIONS,
 )
 
@@ -95,23 +99,30 @@ async def execute_remediation_request(
     if not provider:
         raise ValueError("Invalid or missing provider on remediation request")
     actor_id = str(getattr(request, "reviewed_by_user_id", None) or SYSTEM_USER_ID)
-
-    action = coerce_remediation_action(
-        request,
-        recoverable_errors=REMEDIATION_ACTION_PARSE_RECOVERABLE_EXCEPTIONS,
-    )
-    action_value = action.value
-
-    savings_value = normalize_estimated_savings(
-        getattr(request, "estimated_monthly_savings", Decimal("0"))
-    )
+    finding_id = str(getattr(request, "finding_id", None) or "")
 
     audit_logger = remediation_module.AuditLogger(
         db=service.db, tenant_id=str(tenant_id)
     )
     grace_period_bypassed = False
+    action_value = str(getattr(getattr(request, "action", None), "value", "") or "")
+    savings_value = normalize_estimated_savings(
+        getattr(request, "estimated_monthly_savings", Decimal("0"))
+    )
+    bound_finding = None
 
     try:
+        bound_finding = await validate_request_finding_binding(
+            service,
+            tenant_id=tenant_id,
+            request=request,
+        )
+
+        action = coerce_remediation_action(
+            request,
+            recoverable_errors=REMEDIATION_ACTION_PARSE_RECOVERABLE_EXCEPTIONS,
+        )
+        action_value = action.value
         safety = remediation_module.SafetyGuardrailService(service.db)
         await safety.check_all_guards(tenant_id, savings_value)
 
@@ -153,6 +164,7 @@ async def execute_remediation_request(
             "request_id": str(request_id),
             "action": action_value,
             "stage": "pre_execution",
+            "finding_id": finding_id or None,
             "tier": tier_value,
             "policy": policy_evaluation.to_dict(),
             "policy_context_source": (
@@ -227,6 +239,7 @@ async def execute_remediation_request(
                 "action": action_value,
                 "triggered_by": "background_worker",
                 "grace_period_bypassed": grace_period_bypassed,
+                "finding_id": finding_id or None,
             },
         )
 
@@ -253,6 +266,9 @@ async def execute_remediation_request(
         execution_result = await strategy.execute(resource_id, context)
 
         apply_execution_result(request=request, execution_result=execution_result)
+        if request.status == RemediationStatus.COMPLETED and bound_finding is not None:
+            bound_finding.status = FindingStatus.RESOLVED
+            bound_finding.resolved_at = request.executed_at or datetime.now(timezone.utc)
 
         logger.info(
             "remediation_executed",
@@ -274,6 +290,7 @@ async def execute_remediation_request(
                 "execution_status": execution_result.status.value,
                 "backup_id": request.backup_resource_id,
                 "savings": float(savings_value),
+                "finding_id": finding_id or None,
             },
         )
 
@@ -293,7 +310,11 @@ async def execute_remediation_request(
             resource_type=resource_type,
             success=False,
             error_message=str(exc),
-            details={"request_id": str(request_id), "action": action_value},
+            details={
+                "request_id": str(request_id),
+                "action": action_value,
+                "finding_id": finding_id or None,
+            },
         )
 
         logger.error(

--- a/app/modules/optimization/domain/remediation_iac.py
+++ b/app/modules/optimization/domain/remediation_iac.py
@@ -132,4 +132,8 @@ async def bulk_generate_iac_plan_for_requests(
         "# Valdrics Bulk IaC Remediation Plan\n"
         f"# Generated: {datetime.now(timezone.utc).isoformat()}\n\n"
     )
-    return header + "\n\n" + "\n" + "-" * 40 + "\n".join(plans)
+    if not plans:
+        return header
+
+    separator = "\n" + ("-" * 40) + "\n"
+    return header + separator + separator.join(plans)

--- a/app/modules/optimization/domain/remediation_workflow.py
+++ b/app/modules/optimization/domain/remediation_workflow.py
@@ -5,31 +5,136 @@ from typing import Any, cast
 from uuid import UUID, uuid4
 
 import structlog
-from sqlalchemy import select
-from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy import case, select
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
+from sqlalchemy.orm import selectinload
 
 from app.models.remediation import (
     RemediationAction,
     RemediationRequest,
     RemediationStatus,
 )
-from app.shared.core.exceptions import ResourceNotFoundError
+from app.modules.optimization.domain.findings import (
+    build_request_finding_snapshot,
+    get_open_finding_for_tenant,
+)
+from app.shared.core.connection_state import is_connection_active
+from app.shared.core.exceptions import ResourceNotFoundError, ValdricsException
 from app.shared.core.provider import normalize_provider
 
 logger = structlog.get_logger()
 
 REMEDIATION_CONNECTION_SCOPE_RECOVERABLE_EXCEPTIONS: tuple[type[Exception], ...] = (
-    ResourceNotFoundError,
     SQLAlchemyError,
     RuntimeError,
     OSError,
     TimeoutError,
-    ValueError,
     TypeError,
     KeyError,
     LookupError,
     AttributeError,
 )
+_OPEN_FINDING_REQUEST_STATUSES = (
+    RemediationStatus.PENDING,
+    RemediationStatus.PENDING_APPROVAL,
+    RemediationStatus.APPROVED,
+    RemediationStatus.SCHEDULED,
+    RemediationStatus.EXECUTING,
+)
+_HISTORY_REQUEST_STATUSES = (
+    RemediationStatus.COMPLETED,
+    RemediationStatus.FAILED,
+    RemediationStatus.REJECTED,
+    RemediationStatus.CANCELLED,
+)
+
+
+def _invalid_provider_error(provider: str, *, operation: str) -> ValdricsException:
+    return ValdricsException(
+        message=f"Invalid provider for remediation {operation}.",
+        code="invalid_provider",
+        status_code=400,
+        details={"provider": provider, "operation": operation},
+    )
+
+
+def _missing_connection_error(
+    *,
+    provider: str,
+    operation: str,
+) -> ValdricsException:
+    return ValdricsException(
+        message=(
+            "An explicit active connection_id is required for remediation "
+            f"{operation}."
+        ),
+        code="remediation_connection_required",
+        status_code=400,
+        details={"provider": provider, "operation": operation},
+    )
+
+
+async def _require_scoped_active_connection(
+    service: Any,
+    *,
+    tenant_id: UUID,
+    provider: str,
+    connection_id: UUID | None,
+    operation: str,
+) -> Any:
+    provider_norm = normalize_provider(provider)
+    if not provider_norm:
+        raise _invalid_provider_error(provider, operation=operation)
+    if connection_id is None:
+        raise _missing_connection_error(provider=provider_norm, operation=operation)
+
+    import app.modules.optimization.domain.remediation as remediation_module
+
+    connection_model = remediation_module.get_connection_model(provider_norm)
+    if connection_model is None:
+        raise _invalid_provider_error(provider_norm, operation=operation)
+
+    try:
+        connection = await service.get_by_id(connection_model, connection_id, tenant_id)
+    except ResourceNotFoundError as exc:
+        raise ResourceNotFoundError(
+            f"Connection {connection_id} not found for this tenant.",
+            code="remediation_connection_not_found",
+            details={"provider": provider_norm, "operation": operation},
+        ) from exc
+    except REMEDIATION_CONNECTION_SCOPE_RECOVERABLE_EXCEPTIONS as exc:
+        logger.warning(
+            "remediation_connection_scope_failed",
+            tenant_id=str(tenant_id),
+            provider=provider_norm,
+            connection_id=str(connection_id),
+            operation=operation,
+            error=str(exc),
+        )
+        raise ValdricsException(
+            message="Failed to validate remediation connection.",
+            code="remediation_connection_validation_failed",
+            status_code=500,
+            details={
+                "provider": provider_norm,
+                "connection_id": str(connection_id),
+                "operation": operation,
+            },
+        ) from exc
+
+    if not is_connection_active(connection):
+        raise ValdricsException(
+            message="Remediation requires an active verified connection.",
+            code="remediation_connection_inactive",
+            status_code=400,
+            details={
+                "provider": provider_norm,
+                "connection_id": str(connection_id),
+                "operation": operation,
+            },
+        )
+
+    return connection
 
 
 async def preview_policy_for_request(
@@ -92,11 +197,19 @@ async def preview_policy_input_payload(
     """
     provider_norm = normalize_provider(provider)
     if not provider_norm:
-        raise ValueError("Invalid provider for policy preview")
+        raise _invalid_provider_error(provider, operation="policy preview")
+    scoped_connection = await _require_scoped_active_connection(
+        service,
+        tenant_id=tenant_id,
+        provider=provider_norm,
+        connection_id=connection_id,
+        operation="policy preview",
+    )
     preview_region = (
         await service._resolve_aws_region_hint(
             tenant_id=tenant_id,
             connection_id=connection_id,
+            connection=scoped_connection,
         )
         if provider_norm == "aws"
         else "global"
@@ -133,6 +246,64 @@ async def preview_policy_input_payload(
     )
 
 
+async def preview_policy_for_finding_payload(
+    service: Any,
+    *,
+    tenant_id: UUID,
+    user_id: UUID,
+    finding_id: UUID,
+    action: RemediationAction,
+    review_notes: str | None = None,
+    parameters: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    finding = await get_open_finding_for_tenant(
+        service,
+        tenant_id=tenant_id,
+        finding_id=finding_id,
+    )
+    provider_norm = normalize_provider(finding.provider)
+    if not provider_norm:
+        raise _invalid_provider_error(str(finding.provider or ""), operation="policy preview")
+    await _require_scoped_active_connection(
+        service,
+        tenant_id=tenant_id,
+        provider=provider_norm,
+        connection_id=finding.connection_id,
+        operation="policy preview",
+    )
+
+    system_context = await service._build_system_policy_context(
+        tenant_id=tenant_id,
+        provider=provider_norm,
+        connection_id=finding.connection_id,
+    )
+    synthetic_request = RemediationRequest(
+        id=uuid4(),
+        tenant_id=tenant_id,
+        resource_id=str(finding.resource_id or ""),
+        resource_type=str(finding.resource_type or ""),
+        provider=provider_norm,
+        connection_id=finding.connection_id,
+        finding_id=finding.id,
+        finding_snapshot=build_request_finding_snapshot(finding),
+        region=str(finding.region or "global"),
+        action=action,
+        status=RemediationStatus.PENDING,
+        estimated_monthly_savings=finding.estimated_monthly_savings or Decimal("0"),
+        confidence_score=finding.confidence_score,
+        explainability_notes=finding.explainability_notes,
+        requested_by_user_id=user_id,
+        review_notes=review_notes,
+        action_parameters=service._sanitize_action_parameters(
+            parameters, system_policy_context=system_context
+        ),
+    )
+    return cast(
+        dict[str, Any],
+        await service.preview_policy(synthetic_request, tenant_id),
+    )
+
+
 async def create_remediation_request(
     service: Any,
     *,
@@ -154,30 +325,14 @@ async def create_remediation_request(
     """Create a new remediation request (pending approval)."""
     provider_norm = normalize_provider(provider)
     if not provider_norm:
-        raise ValueError(f"Invalid provider: {provider}")
-    scoped_connection: Any | None = None
-
-    if connection_id:
-        import app.modules.optimization.domain.remediation as remediation_module
-
-        try:
-            connection_model = remediation_module.get_connection_model(provider_norm)
-            if connection_model is None:
-                raise ValueError(f"Invalid provider model for {provider_norm}")
-            scoped_connection = await service.get_by_id(
-                connection_model, connection_id, tenant_id
-            )
-        except REMEDIATION_CONNECTION_SCOPE_RECOVERABLE_EXCEPTIONS as exc:
-            logger.warning(
-                "remediation_connection_scope_failed",
-                tenant_id=str(tenant_id),
-                provider=provider_norm,
-                connection_id=str(connection_id),
-                error=str(exc),
-            )
-            raise ValueError(
-                "Unauthorized: Connection does not belong to tenant"
-            ) from exc
+        raise _invalid_provider_error(provider, operation="request creation")
+    scoped_connection = await _require_scoped_active_connection(
+        service,
+        tenant_id=tenant_id,
+        provider=provider_norm,
+        connection_id=connection_id,
+        operation="request creation",
+    )
 
     request_region = (
         await service._resolve_aws_region_hint(
@@ -235,6 +390,115 @@ async def create_remediation_request(
     return request
 
 
+async def create_remediation_request_from_finding(
+    service: Any,
+    *,
+    tenant_id: UUID,
+    user_id: UUID,
+    finding_id: UUID,
+    action: RemediationAction,
+    create_backup: bool = False,
+    backup_retention_days: int = 30,
+    backup_cost_estimate: float = 0,
+    parameters: dict[str, Any] | None = None,
+) -> RemediationRequest:
+    """Create a remediation request bound to a persisted actionable finding."""
+    finding = await get_open_finding_for_tenant(
+        service,
+        tenant_id=tenant_id,
+        finding_id=finding_id,
+    )
+    provider_norm = normalize_provider(finding.provider)
+    if not provider_norm:
+        raise _invalid_provider_error(
+            str(finding.provider or ""),
+            operation="request creation",
+        )
+    await _require_scoped_active_connection(
+        service,
+        tenant_id=tenant_id,
+        provider=provider_norm,
+        connection_id=finding.connection_id,
+        operation="request creation",
+    )
+
+    system_context = await service._build_system_policy_context(
+        tenant_id=tenant_id,
+        provider=provider_norm,
+        connection_id=finding.connection_id,
+    )
+    existing_request = await service.db.scalar(
+        select(RemediationRequest).where(
+            RemediationRequest.tenant_id == tenant_id,
+            RemediationRequest.finding_id == finding.id,
+            RemediationRequest.action == action,
+            RemediationRequest.status.in_(_OPEN_FINDING_REQUEST_STATUSES),
+        )
+    )
+    if isinstance(existing_request, RemediationRequest):
+        raise ValdricsException(
+            message="An open remediation request already exists for this finding.",
+            code="remediation_request_duplicate_open_finding",
+            status_code=409,
+            details={
+                "request_id": str(existing_request.id),
+                "finding_id": str(finding.id),
+                "action": action.value,
+            },
+        )
+
+    request = RemediationRequest(
+        tenant_id=tenant_id,
+        resource_id=str(finding.resource_id or ""),
+        resource_type=str(finding.resource_type or ""),
+        provider=provider_norm,
+        connection_id=finding.connection_id,
+        finding_id=finding.id,
+        finding_snapshot=build_request_finding_snapshot(finding),
+        region=str(finding.region or "global"),
+        action=action,
+        status=RemediationStatus.PENDING,
+        estimated_monthly_savings=finding.estimated_monthly_savings or Decimal("0"),
+        confidence_score=finding.confidence_score,
+        explainability_notes=finding.explainability_notes,
+        create_backup=create_backup,
+        backup_retention_days=backup_retention_days,
+        backup_cost_estimate=Decimal(str(backup_cost_estimate))
+        if backup_cost_estimate
+        else None,
+        requested_by_user_id=user_id,
+        action_parameters=service._sanitize_action_parameters(
+            parameters, system_policy_context=system_context
+        ),
+    )
+
+    service.db.add(request)
+    try:
+        await service.db.commit()
+    except IntegrityError as exc:
+        await service.db.rollback()
+        raise ValdricsException(
+            message="An open remediation request already exists for this finding.",
+            code="remediation_request_duplicate_open_finding",
+            status_code=409,
+            details={
+                "finding_id": str(finding.id),
+                "action": action.value,
+            },
+        ) from exc
+    await service.db.refresh(request)
+
+    logger.info(
+        "remediation_request_created_from_finding",
+        request_id=str(request.id),
+        finding_id=str(finding.id),
+        resource=str(request.resource_id or ""),
+        action=action.value,
+    )
+
+    return request
+
+
 async def list_pending_requests(
     service: Any,
     tenant_id: UUID,
@@ -247,18 +511,55 @@ async def list_pending_requests(
     bounded_limit = min(limit, max_page_size)
     stmt = (
         service._scoped_query(RemediationRequest, tenant_id)
+        .options(selectinload(RemediationRequest.finding))
         .where(
-            RemediationRequest.status.in_(
-                (
-                    RemediationStatus.PENDING,
-                    RemediationStatus.PENDING_APPROVAL,
-                    RemediationStatus.APPROVED,
-                    RemediationStatus.SCHEDULED,
-                    RemediationStatus.EXECUTING,
-                )
-            )
+            RemediationRequest.status.in_(_OPEN_FINDING_REQUEST_STATUSES)
         )
         .order_by(RemediationRequest.created_at.desc())
+        .offset(offset)
+        .limit(bounded_limit)
+    )
+    result = await service.db.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def list_request_history(
+    service: Any,
+    tenant_id: UUID,
+    *,
+    status: str = "completed",
+    limit: int = 20,
+    offset: int = 0,
+) -> list[RemediationRequest]:
+    """List recent completed/failed/rejected/cancelled remediation requests."""
+    normalized_status = str(status or "completed").strip().lower()
+    history_statuses_by_filter: dict[str, tuple[RemediationStatus, ...]] = {
+        "completed": (RemediationStatus.COMPLETED,),
+        "failed": (RemediationStatus.FAILED,),
+        "rejected": (RemediationStatus.REJECTED,),
+        "cancelled": (RemediationStatus.CANCELLED,),
+        "all": _HISTORY_REQUEST_STATUSES,
+    }
+    selected_statuses = history_statuses_by_filter.get(normalized_status)
+    if selected_statuses is None:
+        supported = ", ".join(sorted(history_statuses_by_filter))
+        raise ValueError(
+            f"Unsupported remediation history status '{status}'. Use one of: {supported}"
+        )
+
+    max_page_size = 200
+    bounded_limit = min(limit, max_page_size)
+    executed_at_missing = case((RemediationRequest.executed_at.is_(None), 1), else_=0)
+    stmt = (
+        service._scoped_query(RemediationRequest, tenant_id)
+        .options(selectinload(RemediationRequest.finding))
+        .where(RemediationRequest.status.in_(selected_statuses))
+        .order_by(
+            executed_at_missing.asc(),
+            RemediationRequest.executed_at.desc(),
+            RemediationRequest.updated_at.desc(),
+            RemediationRequest.created_at.desc(),
+        )
         .offset(offset)
         .limit(bounded_limit)
     )

--- a/app/modules/optimization/domain/service.py
+++ b/app/modules/optimization/domain/service.py
@@ -342,6 +342,16 @@ class ZombieService(BaseService):
             build_architectural_inefficiency_payload(all_zombies)
         )
 
+        from app.modules.optimization.domain.findings import (
+            persist_scan_findings_with_guard,
+        )
+
+        await persist_scan_findings_with_guard(
+            self,
+            tenant_id=tenant_id,
+            scan_payload=all_zombies,
+        )
+
         if analyze and not all_zombies.get("scan_timeout"):
             all_zombies["ai_analysis"] = await enqueue_zombie_analysis(
                 db=self.db,

--- a/app/modules/reporting/api/v1/savings.py
+++ b/app/modules/reporting/api/v1/savings.py
@@ -125,7 +125,8 @@ async def get_savings_proof_drilldown(
         default=None, pattern="^(aws|azure|gcp|saas|license|platform|hybrid)$"
     ),
     dimension: str = Query(
-        default="strategy_type", pattern="^(provider|strategy_type|remediation_action)$"
+        default="strategy_type",
+        pattern="^(provider|strategy_type|remediation_action|finding_category)$",
     ),
     limit: int = Query(default=50, ge=1, le=200),
     response_format: str = Query(default="json", pattern="^(json|csv)$"),
@@ -260,6 +261,8 @@ async def compute_realized_savings(
 
 class RealizedSavingsEventResponse(BaseModel):
     remediation_request_id: str
+    finding_id: str | None
+    finding_category: str | None
     provider: str
     account_id: str | None
     resource_id: str | None
@@ -330,13 +333,20 @@ async def list_realized_savings_events(
     )
     events: list[RealizedSavingsEventResponse] = []
     for event, executed_at in rows:
+        finding_id = getattr(event, "finding_id", None)
+        finding_category = getattr(event, "finding_category", None)
+        account_id = getattr(event, "account_id", None)
+        resource_id = getattr(event, "resource_id", None)
+        region = getattr(event, "region", None)
         events.append(
             RealizedSavingsEventResponse(
                 remediation_request_id=str(event.remediation_request_id),
+                finding_id=str(finding_id) if finding_id else None,
+                finding_category=str(finding_category) if finding_category else None,
                 provider=str(event.provider),
-                account_id=str(event.account_id) if event.account_id else None,
-                resource_id=str(event.resource_id) if event.resource_id else None,
-                region=str(event.region) if event.region else None,
+                account_id=str(account_id) if account_id else None,
+                resource_id=str(resource_id) if resource_id else None,
+                region=str(region) if region else None,
                 method=str(event.method),
                 executed_at=executed_at.isoformat()
                 if isinstance(executed_at, datetime)
@@ -364,6 +374,8 @@ async def list_realized_savings_events(
     if response_format == "csv":
         header = [
             "remediation_request_id",
+            "finding_id",
+            "finding_category",
             "provider",
             "account_id",
             "resource_id",

--- a/app/modules/reporting/domain/realized_savings.py
+++ b/app/modules/reporting/domain/realized_savings.py
@@ -118,6 +118,12 @@ class RealizedSavingsService:
         resource_id = str(getattr(request, "resource_id", "") or "").strip()
         if not resource_id:
             return None
+        finding_id = getattr(request, "finding_id", None)
+        finding_snapshot = getattr(request, "finding_snapshot", None)
+        finding_category: str | None = None
+        if isinstance(finding_snapshot, dict):
+            category_raw = str(finding_snapshot.get("category") or "").strip()
+            finding_category = category_raw or None
 
         executed_at = request.executed_at
         executed_day = executed_at.date()
@@ -215,6 +221,8 @@ class RealizedSavingsService:
             existing = RealizedSavingsEvent(
                 tenant_id=tenant_id,
                 remediation_request_id=request.id,
+                finding_id=finding_id,
+                finding_category=finding_category,
                 provider=str(request.provider or "").strip().lower() or "unknown",
                 account_id=account_id,
                 resource_id=resource_id,
@@ -243,6 +251,8 @@ class RealizedSavingsService:
             existing.provider = (
                 str(request.provider or "").strip().lower() or existing.provider
             )
+            existing.finding_id = finding_id
+            existing.finding_category = finding_category
             existing.account_id = account_id
             existing.resource_id = resource_id
             existing.region = str(getattr(request, "region", "") or None)

--- a/app/modules/reporting/domain/savings_proof.py
+++ b/app/modules/reporting/domain/savings_proof.py
@@ -27,6 +27,7 @@ from app.models.optimization import OptimizationStrategy, StrategyRecommendation
 from app.models.realized_savings import RealizedSavingsEvent
 from app.models.remediation import RemediationRequest, RemediationStatus
 from app.modules.reporting.domain.savings_proof_drilldown_ops import (
+    build_finding_category_buckets,
     build_remediation_action_buckets,
     build_strategy_type_buckets,
     sort_and_limit_buckets,
@@ -346,7 +347,12 @@ class SavingsProofService:
         dim = str(dimension or "").strip().lower()
         normalized_provider = provider.strip().lower() if provider else None
 
-        supported_dims = {"provider", "strategy_type", "remediation_action"}
+        supported_dims = {
+            "provider",
+            "strategy_type",
+            "remediation_action",
+            "finding_category",
+        }
         if dim not in supported_dims:
             supported = ", ".join(sorted(supported_dims))
             raise ValueError(
@@ -419,8 +425,18 @@ class SavingsProofService:
                 ensure_bucket=_ensure_bucket,
                 as_float=_as_float,
             )
-        else:
+        elif dim == "remediation_action":
             notes = await build_remediation_action_buckets(
+                db=self.db,
+                tenant_id=tenant_id,
+                normalized_provider=normalized_provider,
+                window_start=window_start,
+                window_end=window_end,
+                ensure_bucket=_ensure_bucket,
+                as_float=_as_float,
+            )
+        else:
+            notes = await build_finding_category_buckets(
                 db=self.db,
                 tenant_id=tenant_id,
                 normalized_provider=normalized_provider,

--- a/app/modules/reporting/domain/savings_proof_drilldown_ops.py
+++ b/app/modules/reporting/domain/savings_proof_drilldown_ops.py
@@ -218,6 +218,109 @@ async def build_remediation_action_buckets(
     ]
 
 
+def _finding_category_from_snapshot(snapshot: object) -> str:
+    if isinstance(snapshot, dict):
+        value = str(snapshot.get("category") or "").strip().lower()
+        if value:
+            return value
+    return "unknown"
+
+
+async def build_finding_category_buckets(
+    *,
+    db: AsyncSession,
+    tenant_id: UUID,
+    normalized_provider: str | None,
+    window_start: datetime,
+    window_end: datetime,
+    ensure_bucket: Callable[[str], dict[str, Any]],
+    as_float: Callable[[Any], float],
+) -> list[str]:
+    pending_statuses = {
+        RemediationStatus.PENDING.value,
+        RemediationStatus.PENDING_APPROVAL.value,
+        RemediationStatus.APPROVED.value,
+        RemediationStatus.SCHEDULED.value,
+        RemediationStatus.EXECUTING.value,
+    }
+
+    pending_stmt = select(RemediationRequest).where(
+        RemediationRequest.tenant_id == tenant_id,
+        RemediationRequest.status.in_(pending_statuses),
+    )
+    if normalized_provider:
+        pending_stmt = pending_stmt.where(
+            RemediationRequest.provider == normalized_provider
+        )
+    pending_requests = list((await db.execute(pending_stmt)).scalars().all())
+    for request in pending_requests:
+        key = _finding_category_from_snapshot(getattr(request, "finding_snapshot", None))
+        bucket = ensure_bucket(key)
+        bucket["pending_remediations"] += 1
+        bucket["opportunity_monthly_usd"] += as_float(
+            getattr(request, "estimated_monthly_savings", None)
+        )
+
+    completed_at = func.coalesce(
+        RemediationRequest.executed_at,
+        RemediationRequest.updated_at,
+        RemediationRequest.created_at,
+    )
+    completed_stmt = select(RemediationRequest).where(
+        RemediationRequest.tenant_id == tenant_id,
+        RemediationRequest.status == RemediationStatus.COMPLETED.value,
+        completed_at >= window_start,
+        completed_at <= window_end,
+    )
+    if normalized_provider:
+        completed_stmt = completed_stmt.where(
+            RemediationRequest.provider == normalized_provider
+        )
+    completed_requests = list((await db.execute(completed_stmt)).scalars().all())
+
+    realized_events_by_request_id: dict[UUID, RealizedSavingsEvent] = {}
+    if completed_requests:
+        event_stmt = select(RealizedSavingsEvent).where(
+            RealizedSavingsEvent.tenant_id == tenant_id,
+            RealizedSavingsEvent.remediation_request_id.in_(
+                [request.id for request in completed_requests]
+            ),
+        )
+        if normalized_provider:
+            event_stmt = event_stmt.where(
+                RealizedSavingsEvent.provider == normalized_provider
+            )
+        realized_events = list((await db.execute(event_stmt)).scalars().all())
+        realized_events_by_request_id = {
+            event.remediation_request_id: event for event in realized_events
+        }
+
+    for request in completed_requests:
+        realized_event = realized_events_by_request_id.get(request.id)
+        key = (
+            str(realized_event.finding_category or "").strip().lower()
+            if realized_event is not None
+            else ""
+        )
+        if not key:
+            key = _finding_category_from_snapshot(
+                getattr(request, "finding_snapshot", None)
+            )
+        bucket = ensure_bucket(key or "unknown")
+        bucket["completed_remediations"] += 1
+        bucket["realized_monthly_usd"] += as_float(
+            realized_event.realized_monthly_savings_usd
+            if realized_event is not None
+            else getattr(request, "estimated_monthly_savings", None)
+        )
+
+    return [
+        "Finding category drilldown is remediation provenance scoped: it reflects pending/completed remediations and realized savings evidence, not open strategy recommendations.",
+        "Unknown is used when a remediation request or realized savings event does not carry finding category metadata.",
+        "Realized uses finance-grade ledger deltas where evidence exists; otherwise it falls back to estimated monthly savings.",
+    ]
+
+
 def sort_and_limit_buckets(
     buckets_by_key: dict[str, dict[str, Any]], *, top_limit: int
 ) -> tuple[list[tuple[str, dict[str, Any]]], bool]:

--- a/app/shared/core/health.py
+++ b/app/shared/core/health.py
@@ -60,6 +60,41 @@ class HealthService:
     def __init__(self, db: AsyncSession | None = None):
         self.db = db
 
+    def _get_settings(self) -> Any:
+        return get_settings()
+
+    def _health_timeout_seconds(self, *, component: str) -> float:
+        settings_obj = self._get_settings()
+        default_timeout = getattr(settings_obj, "HEALTH_CHECK_TIMEOUT_SECONDS", 2.0)
+        external_timeout = getattr(
+            settings_obj,
+            "HEALTH_CHECK_EXTERNAL_TIMEOUT_SECONDS",
+            min(float(default_timeout or 2.0), 2.0),
+        )
+        raw_timeout = external_timeout if component == "external_services" else default_timeout
+        try:
+            timeout = float(raw_timeout)
+        except (TypeError, ValueError):
+            timeout = 2.0
+        return max(0.1, min(timeout, 10.0))
+
+    def _testing_mode(self) -> bool:
+        return bool(getattr(self._get_settings(), "TESTING", False))
+
+    async def _disabled_component_result(
+        self,
+        *,
+        message: str,
+        services: Dict[str, Any] | None = None,
+    ) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "status": "disabled",
+            "message": message,
+        }
+        if services is not None:
+            payload["services"] = services
+        return payload
+
     async def check_all(self) -> Dict[str, Any]:
         """Run system health checks and return a lifecycle-friendly payload."""
         health = await self.comprehensive_health_check()
@@ -109,7 +144,10 @@ class HealthService:
             from app.shared.core.http import get_http_client
 
             client = get_http_client()
-            response = await client.get("https://sts.amazonaws.com")
+            response = await client.get(
+                "https://sts.amazonaws.com",
+                timeout=self._health_timeout_seconds(component="external_services"),
+            )
 
             if response.status_code < 400:
                 return True, {"reachable": True}
@@ -129,6 +167,7 @@ class HealthService:
 
         Returns detailed health status for monitoring and alerting.
         """
+        testing_mode = self._testing_mode()
         component_checks = (
             (
                 "database",
@@ -140,14 +179,34 @@ class HealthService:
             (
                 "cache",
                 self._run_health_check(
-                    self._check_cache(),
+                    (
+                        self._disabled_component_result(
+                            message="Cache health checks disabled in testing",
+                        )
+                        if testing_mode
+                        else self._check_cache()
+                    ),
                     component="cache",
                 ),
             ),
             (
                 "external_services",
                 self._run_health_check(
-                    self._check_external_services(),
+                    (
+                        self._disabled_component_result(
+                            message="External service health checks disabled in testing",
+                            services={
+                                "aws_sts": {
+                                    "status": "disabled",
+                                    "message": (
+                                        "External service health checks disabled in testing"
+                                    ),
+                                }
+                            },
+                        )
+                        if testing_mode
+                        else self._check_external_services()
+                    ),
                     component="external_services",
                 ),
             ),
@@ -237,7 +296,26 @@ class HealthService:
     ) -> Dict[str, Any]:
         """Contain unexpected subcheck failures so /health remains deterministic."""
         try:
-            result = await coro
+            result = await asyncio.wait_for(
+                coro,
+                timeout=self._health_timeout_seconds(component=component),
+            )
+        except asyncio.TimeoutError:
+            fallback_status = HEALTH_FALLBACK_STATUSES.get(component, "unknown")
+            logger.error(
+                "health_check_timeout",
+                component=component,
+                fallback_status=fallback_status,
+                timeout_seconds=self._health_timeout_seconds(component=component),
+            )
+            return {
+                "status": fallback_status,
+                "error": (
+                    f"Health check timed out after "
+                    f"{self._health_timeout_seconds(component=component):.2f}s"
+                ),
+                "component": component,
+            }
         except HEALTH_RECOVERABLE_ERRORS as exc:
             fallback_status = HEALTH_FALLBACK_STATUSES.get(component, "unknown")
             logger.error(
@@ -341,7 +419,10 @@ class HealthService:
             from app.shared.core.http import get_http_client
 
             client = get_http_client()
-            response = await client.get("https://sts.amazonaws.com")
+            response = await client.get(
+                "https://sts.amazonaws.com",
+                timeout=self._health_timeout_seconds(component="external_services"),
+            )
             services_status["aws_sts"] = {
                 "status": "healthy" if response.status_code < 500 else "unhealthy",
                 "response_code": response.status_code,

--- a/app/shared/db/session.py
+++ b/app/shared/db/session.py
@@ -1,3 +1,4 @@
+import asyncio
 import inspect
 import re
 import ssl  # noqa: F401  # Retained for compatibility with focused DB test patches.
@@ -237,7 +238,21 @@ def _get_db_runtime() -> _DBRuntime:
 
 
 def reset_db_runtime() -> None:
-    """Test helper for forcing runtime re-initialization on next access."""
+    """Sync wrapper for forcing runtime re-initialization on next access."""
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        asyncio.run(dispose_db_runtime())
+        return
+
+    # Async callers should use dispose_db_runtime() directly so disposal completes
+    # before a new runtime is created.
+    logger.warning("reset_db_runtime_called_inside_running_loop_scheduling_dispose")
+    asyncio.create_task(dispose_db_runtime())
+
+
+async def dispose_db_runtime() -> None:
+    """Dispose the active async engine and clear the cached runtime."""
     global _db_runtime
     runtime = _db_runtime
     _db_runtime = None
@@ -246,7 +261,7 @@ def reset_db_runtime() -> None:
         return
 
     try:
-        runtime.engine.sync_engine.dispose()
+        await runtime.engine.dispose()
     except DB_RUNTIME_DISPOSE_ERRORS as exc:
         logger.debug("db_runtime_dispose_skipped", error=str(exc), exc_info=True)
 

--- a/app/shared/llm/zombie_analyzer.py
+++ b/app/shared/llm/zombie_analyzer.py
@@ -144,6 +144,34 @@ class ZombieAnalyzer:
         return flattened
 
     @staticmethod
+    def _finding_binding_key(resource: Dict[str, Any]) -> tuple[str, str]:
+        provider = str(resource.get("provider") or "").strip().lower()
+        resource_id = str(resource.get("resource_id") or "").strip().lower()
+        return provider, resource_id
+
+    @classmethod
+    def _enrich_analysis_resources_with_findings(
+        cls,
+        *,
+        analysis_resources: List[Dict[str, Any]],
+        flattened_detection_results: List[Dict[str, Any]],
+    ) -> None:
+        binding_index = {
+            cls._finding_binding_key(resource): resource
+            for resource in flattened_detection_results
+            if resource.get("finding_id")
+        }
+
+        for resource in analysis_resources:
+            binding = binding_index.get(cls._finding_binding_key(resource))
+            if not isinstance(binding, dict):
+                continue
+            for key in ("finding_id", "finding_status", "connection_id"):
+                value = binding.get(key)
+                if value not in (None, ""):
+                    resource[key] = value
+
+    @staticmethod
     def _resolve_output_token_ceiling(raw_limit: Any) -> int | None:
         if raw_limit is None:
             return None
@@ -374,6 +402,10 @@ class ZombieAnalyzer:
                 response_text, ZombieAnalysisResult
             )
             analysis = validated_result.model_dump()
+            self._enrich_analysis_resources_with_findings(
+                analysis_resources=analysis.get("resources", []),
+                flattened_detection_results=zombies,
+            )
             logger.info(
                 "zombie_analysis_complete",
                 resource_count=len(analysis.get("resources", [])),

--- a/dashboard/e2e/public-marketing.spec.ts
+++ b/dashboard/e2e/public-marketing.spec.ts
@@ -79,6 +79,60 @@ async function openMobileMenu(page: Parameters<typeof test>[0]['page']) {
 }
 
 test.describe('Public marketing smoke (desktop)', () => {
+	test('emits canonical and robots metadata for public and auth routes', async ({ page }) => {
+		await page.goto(BASE_URL, { waitUntil: 'domcontentloaded' });
+		await expect(page.locator('link[rel="canonical"]')).toHaveAttribute('href', `${BASE_URL}/`);
+		await expect(page.locator('meta[name="robots"]')).toHaveAttribute('content', 'index,follow');
+
+		await page.goto(`${BASE_URL}/pricing`, { waitUntil: 'domcontentloaded' });
+		await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
+			'href',
+			`${BASE_URL}/pricing`
+		);
+		await expect(page.locator('meta[name="robots"]')).toHaveAttribute('content', 'index,follow');
+
+		await page.goto(`${BASE_URL}/auth/login`, { waitUntil: 'domcontentloaded' });
+		await expect(page.locator('meta[name="robots"]')).toHaveAttribute(
+			'content',
+			'noindex,nofollow'
+		);
+		await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
+			'href',
+			`${BASE_URL}/auth/login`
+		);
+
+		for (const routeCase of [
+			{
+				path: '/status',
+				title: /System Status \| Valdrics/i,
+				description: /current service status for valdrics core platform dependencies/i
+			},
+			{
+				path: '/privacy',
+				title: /Privacy Policy \| Valdrics/i,
+				description: /privacy policy covering processing scope, retention, security controls/i
+			},
+			{
+				path: '/terms',
+				title: /Terms of Service \| Valdrics/i,
+				description: /terms of service covering account responsibilities, billing, acceptable use/i
+			}
+		]) {
+			await page.goto(`${BASE_URL}${routeCase.path}`, { waitUntil: 'domcontentloaded' });
+			await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
+				'href',
+				`${BASE_URL}${routeCase.path}`
+			);
+			await expect(page.locator('meta[name="robots"]')).toHaveAttribute('content', 'index,follow');
+			await expect(page).toHaveTitle(routeCase.title);
+			await expect(page.locator('meta[name="description"]')).toHaveAttribute(
+				'content',
+				routeCase.description
+			);
+			await expect(page.locator('script[type="application/ld+json"]').first()).toBeAttached();
+		}
+	});
+
 	test('covers landing, pricing, docs, api docs, and status navigation', async ({
 		page
 	}, testInfo) => {

--- a/dashboard/e2e/public-progressive-enhancement.spec.ts
+++ b/dashboard/e2e/public-progressive-enhancement.spec.ts
@@ -1,0 +1,53 @@
+import { expect, test } from '@playwright/test';
+
+const BASE_URL = process.env.DASHBOARD_URL || 'http://localhost:4173';
+
+test.describe('Public progressive enhancement', () => {
+	test.use({ javaScriptEnabled: false });
+
+	test('landing page exposes no-JS fallback links and readable SSR content', async ({ page }) => {
+		await page.goto(BASE_URL, { waitUntil: 'domcontentloaded' });
+
+		const banner = page.locator('[data-noscript-banner]');
+		await expect(banner).toContainText(/javascript is disabled/i);
+		await expect(page.locator('main')).toHaveCount(1);
+		await expect(page.getByRole('heading', { level: 1 }).first()).toBeVisible();
+		await expect(page.locator('link[rel="canonical"]')).toHaveAttribute('href', `${BASE_URL}/`);
+
+		await banner.getByRole('link', { name: /^resources$/i }).click();
+		await expect(page).toHaveURL(/\/resources$/);
+		await expect(page.getByRole('heading', { level: 1, name: /resources/i })).toBeVisible();
+
+		await banner.getByRole('link', { name: /^status$/i }).click();
+		await expect(page).toHaveURL(/\/status$/);
+		await expect(page.getByRole('heading', { level: 1, name: /system status/i })).toBeVisible();
+	});
+
+	test('status and legal pages retain metadata and structured data without JavaScript', async ({
+		page
+	}) => {
+		for (const routeCase of [
+			{
+				path: '/status',
+				heading: /system status/i,
+				title: /System Status \| Valdrics/i
+			},
+			{
+				path: '/privacy',
+				heading: /privacy policy/i,
+				title: /Privacy Policy \| Valdrics/i
+			},
+			{
+				path: '/terms',
+				heading: /terms of service/i,
+				title: /Terms of Service \| Valdrics/i
+			}
+		]) {
+			await page.goto(`${BASE_URL}${routeCase.path}`, { waitUntil: 'domcontentloaded' });
+			await expect(page).toHaveTitle(routeCase.title);
+			await expect(page.getByRole('heading', { level: 1, name: routeCase.heading })).toBeVisible();
+			await expect(page.locator('meta[name="robots"]')).toHaveAttribute('content', 'index,follow');
+			await expect(page.locator('script[type="application/ld+json"]').first()).toBeAttached();
+		}
+	});
+});

--- a/dashboard/src/app.utilities.css
+++ b/dashboard/src/app.utilities.css
@@ -80,6 +80,46 @@
 	outline-offset: 2px;
 }
 
+.noscript-banner {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	justify-content: space-between;
+	gap: var(--space-3);
+	padding: var(--space-3) var(--space-4);
+	border-bottom: 1px solid rgb(6 182 212 / 0.2);
+	background:
+		linear-gradient(135deg, rgb(8 47 73 / 0.95), rgb(15 23 42 / 0.96)), var(--color-ink-950);
+	color: var(--color-ink-50);
+}
+
+.noscript-banner__copy {
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--space-2);
+	align-items: baseline;
+}
+
+.noscript-banner__links {
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--space-3);
+}
+
+.noscript-banner__links a {
+	color: var(--color-accent-300);
+	font-weight: 600;
+	text-decoration: underline;
+	text-decoration-thickness: 2px;
+	text-underline-offset: 0.2em;
+}
+
+.noscript-banner__links a:focus-visible {
+	outline: 2px solid var(--color-accent-400);
+	outline-offset: 2px;
+	border-radius: var(--radius-sm);
+}
+
 /* ===== UTILITIES ===== */
 .sr-only {
 	position: absolute !important;
@@ -201,4 +241,15 @@
 	backdrop-filter: blur(10px);
 	border: 1px solid rgba(255, 255, 255, 0.08);
 	box-shadow: 0 4px 30px rgba(0, 0, 0, 0.1);
+}
+
+@media (max-width: 640px) {
+	.noscript-banner {
+		padding: var(--space-3);
+	}
+
+	.noscript-banner__copy {
+		flex-direction: column;
+		align-items: flex-start;
+	}
 }

--- a/dashboard/src/lib/components/FindingsTable.svelte
+++ b/dashboard/src/lib/components/FindingsTable.svelte
@@ -6,6 +6,7 @@
 
 	interface ZombieFinding {
 		provider: 'aws' | 'azure' | 'gcp';
+		finding_id?: string;
 		resource_id: string;
 		resource_type?: string;
 		monthly_cost?: string | number;
@@ -246,12 +247,17 @@
 									type="button"
 									class="btn btn-ghost text-xs hover:bg-accent-500/20 hover:text-accent-400"
 									onclick={() => onRemediate(finding)}
-									disabled={remediating === finding.resource_id}
+									disabled={remediating === finding.resource_id || !finding.finding_id}
+									title={!finding.finding_id
+										? 'Persisted finding binding missing. Use the latest scan output before remediation.'
+										: undefined}
 								>
 									{#if remediating === finding.resource_id}
 										<span class="animate-pulse">...</span>
 									{:else}
-										{finding.recommended_action || 'Review'}
+										{finding.finding_id
+											? finding.recommended_action || 'Review'
+											: 'Unavailable'}
 									{/if}
 								</button>
 							</div>

--- a/dashboard/src/lib/components/FindingsTable.svelte.test.ts
+++ b/dashboard/src/lib/components/FindingsTable.svelte.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/svelte';
 import FindingsTable from './FindingsTable.svelte';
 
 vi.mock('dompurify', () => ({
@@ -13,6 +13,10 @@ vi.mock('$lib/logging/client', () => ({
 		error: vi.fn()
 	}
 }));
+
+afterEach(() => {
+	cleanup();
+});
 
 describe('FindingsTable', () => {
 	it('shows growth-plan lock state when owner attribution is tier-gated', () => {
@@ -34,5 +38,26 @@ describe('FindingsTable', () => {
 
 		expect(screen.getByText('LOCKED')).toBeTruthy();
 		expect(screen.getByTitle('Owner Attribution requires Growth tier')).toBeTruthy();
+	});
+
+	it('disables remediation when persisted finding binding is missing', () => {
+		render(FindingsTable, {
+			resources: [
+				{
+					provider: 'aws',
+					resource_id: 'i-1234567890',
+					resource_type: 'instance',
+					monthly_cost: '$25',
+					confidence: 'medium',
+					risk_if_deleted: 'low',
+					explanation: 'Idle for 14 days'
+				}
+			],
+			onRemediate: vi.fn()
+		});
+
+		const button = screen.getByRole('button', { name: 'Unavailable' });
+		expect(button.hasAttribute('disabled')).toBe(true);
+		expect(button.getAttribute('title')).toContain('Persisted finding binding missing');
 	});
 });

--- a/dashboard/src/lib/components/RemediationModal.svelte
+++ b/dashboard/src/lib/components/RemediationModal.svelte
@@ -4,6 +4,7 @@
 	import { edgeApiPath } from '$lib/edgeProxy';
 
 	type RemediationFinding = {
+		finding_id?: string;
 		resource_id: string;
 		resource_type?: string;
 		provider?: string;
@@ -47,6 +48,7 @@
 	let parameters = $state<RemediationParameters>({ target_size: '' });
 
 	const action = $derived(finding ? deriveRemediationAction(finding) : '');
+	const hasFindingBinding = $derived(Boolean(finding?.finding_id));
 
 	$effect(() => {
 		if (isOpen && finding && !parameters.target_size) {
@@ -55,6 +57,12 @@
 	});
 
 	$effect(() => {
+		if (isOpen && finding && !hasFindingBinding) {
+			preview = null;
+			previewError =
+				'Persisted finding binding missing. Rerun the scan before requesting remediation.';
+			return;
+		}
 		if (isOpen && finding && !preview && !previewLoading) {
 			runPreview();
 		}
@@ -98,11 +106,6 @@
 		return 'stop_instance';
 	}
 
-	function parseMonthlyCost(value: string | number | undefined): number {
-		if (typeof value === 'number') return value;
-		return Number.parseFloat(String(value ?? '0').replace(/[^0-9.-]/g, '')) || 0;
-	}
-
 	function policyDecisionClass(decision: string | undefined): string {
 		switch ((decision || '').toLowerCase()) {
 			case 'allow':
@@ -123,6 +126,12 @@
 			previewError = 'Not authenticated.';
 			return;
 		}
+		if (!finding.finding_id) {
+			preview = null;
+			previewError =
+				'Persisted finding binding missing. Rerun the scan before requesting remediation.';
+			return;
+		}
 
 		previewLoading = true;
 		previewError = '';
@@ -138,9 +147,7 @@
 			const previewResponse = await api.post(
 				edgeApiPath('/zombies/policy-preview'),
 				{
-					resource_id: finding.resource_id,
-					resource_type: finding.resource_type || 'unknown',
-					provider: finding.provider || 'aws',
+					finding_id: finding.finding_id,
 					action,
 					parameters
 				},
@@ -173,6 +180,11 @@
 			actionError = 'Not authenticated.';
 			return;
 		}
+		if (!finding.finding_id) {
+			actionError =
+				'Persisted finding binding missing. Rerun the scan before requesting remediation.';
+			return;
+		}
 
 		submitting = true;
 		actionError = '';
@@ -187,12 +199,8 @@
 			const response = await api.post(
 				edgeApiPath('/zombies/request'),
 				{
-					resource_id: finding.resource_id,
-					resource_type: finding.resource_type || 'unknown',
-					provider: finding.provider || 'aws',
-					connection_id: finding.connection_id,
+					finding_id: finding.finding_id,
 					action,
-					estimated_savings: parseMonthlyCost(finding.monthly_cost),
 					create_backup: true,
 					parameters
 				},
@@ -293,6 +301,18 @@
 					</div>
 				{/if}
 
+				{#if !hasFindingBinding}
+					<div class="p-4 bg-warning-500/10 border border-warning-500/30 rounded-lg">
+						<p class="text-sm text-warning-400 font-semibold">
+							This row is not bound to a persisted finding yet.
+						</p>
+						<p class="text-xs text-warning-300/80 mt-1">
+							Rerun the zombie scan and use the persisted finding result before requesting
+							remediation.
+						</p>
+					</div>
+				{/if}
+
 				<!-- Policy Preview -->
 				<div class="space-y-3">
 					<h4 class="text-sm font-semibold flex items-center gap-2 text-ink-200">
@@ -370,6 +390,7 @@
 						class="btn btn-primary min-w-[140px]"
 						disabled={submitting ||
 							previewLoading ||
+							!hasFindingBinding ||
 							!!previewError ||
 							preview?.decision?.toLowerCase() === 'block'}
 						onclick={submitRequest}

--- a/dashboard/src/lib/components/RemediationModal.svelte.test.ts
+++ b/dashboard/src/lib/components/RemediationModal.svelte.test.ts
@@ -1,0 +1,110 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import RemediationModal from './RemediationModal.svelte';
+
+const { postMock } = vi.hoisted(() => ({
+	postMock: vi.fn()
+}));
+
+vi.mock('$lib/api', () => ({
+	api: {
+		post: postMock
+	}
+}));
+
+vi.mock('$lib/edgeProxy', () => ({
+	edgeApiPath: (path: string) => `/api/edge/api/v1${path}`
+}));
+
+function jsonResponse(payload: unknown, status = 200): Response {
+	return new Response(JSON.stringify(payload), {
+		status,
+		headers: { 'Content-Type': 'application/json' }
+	});
+}
+
+describe('RemediationModal', () => {
+	beforeEach(() => {
+		postMock.mockReset();
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('uses finding_id for policy preview and request creation', async () => {
+		postMock
+			.mockResolvedValueOnce(
+				jsonResponse({
+					decision: 'allow',
+					summary: 'Safe to queue',
+					tier: 'pro',
+					rule_hits: []
+				})
+			)
+			.mockResolvedValueOnce(
+				jsonResponse({
+					status: 'pending',
+					request_id: 'req-123'
+				})
+			);
+
+		render(RemediationModal, {
+			isOpen: true,
+			finding: {
+				finding_id: 'finding-123',
+				resource_id: 'i-abc123',
+				resource_type: 'ec2_instance',
+				provider: 'aws',
+				recommended_action: 'stop',
+				monthly_cost: '$22.00'
+			},
+			accessToken: 'token',
+			onClose: vi.fn()
+		});
+
+		await waitFor(() => expect(postMock).toHaveBeenCalledTimes(1));
+		expect(postMock.mock.calls[0]?.[1]).toEqual({
+			finding_id: 'finding-123',
+			action: 'stop_instance',
+			parameters: { target_size: '' }
+		});
+		expect(postMock.mock.calls[0]?.[1]).not.toHaveProperty('resource_id');
+		expect(postMock.mock.calls[0]?.[1]).not.toHaveProperty('provider');
+
+		const submitButton = screen.getByRole('button', { name: 'Approve & Queue' });
+		await waitFor(() => expect(submitButton.hasAttribute('disabled')).toBe(false));
+		await fireEvent.click(submitButton);
+
+		await waitFor(() => expect(postMock).toHaveBeenCalledTimes(2));
+		expect(postMock.mock.calls[1]?.[1]).toEqual({
+			finding_id: 'finding-123',
+			action: 'stop_instance',
+			create_backup: true,
+			parameters: { target_size: '' }
+		});
+		expect(await screen.findByText(/Request req-123 created\./i)).toBeTruthy();
+	});
+
+	it('fails closed when finding_id is missing', async () => {
+		render(RemediationModal, {
+			isOpen: true,
+			finding: {
+				resource_id: 'i-abc123',
+				resource_type: 'ec2_instance',
+				provider: 'aws',
+				recommended_action: 'stop',
+				monthly_cost: '$22.00'
+			},
+			accessToken: 'token',
+			onClose: vi.fn()
+		});
+
+		expect(
+			await screen.findByText(/Persisted finding binding missing\. Rerun the scan/i)
+		).toBeTruthy();
+		expect(postMock).not.toHaveBeenCalled();
+		const submitButton = screen.getByRole('button', { name: 'Approve & Queue' });
+		expect(submitButton.hasAttribute('disabled')).toBe(true);
+	});
+});

--- a/dashboard/src/lib/components/ZombieTable.svelte
+++ b/dashboard/src/lib/components/ZombieTable.svelte
@@ -3,6 +3,7 @@
 	import { type ZombieCollectionKey, type ZombieCollections } from '$lib/zombieCollections';
 
 	type RemediationFinding = {
+		finding_id?: string;
 		resource_id: string;
 		resource_type?: string;
 		provider?: string;
@@ -205,8 +206,12 @@
 								type="button"
 								class="btn btn-ghost text-xs"
 								onclick={() => onRemediate(row.finding)}
+								disabled={!row.finding.finding_id}
+								title={!row.finding.finding_id
+									? 'Persisted finding binding missing. Rerun the scan to remediate safely.'
+									: 'Review remediation'}
 							>
-								Review
+								{row.finding.finding_id ? 'Review' : 'Unavailable'}
 							</button>
 						</td>
 					</tr>

--- a/dashboard/src/lib/components/ZombieTable.svelte.test.ts
+++ b/dashboard/src/lib/components/ZombieTable.svelte.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import ZombieTable from './ZombieTable.svelte';
+
+describe('ZombieTable', () => {
+	it('disables review when persisted finding binding is missing', () => {
+		render(ZombieTable, {
+			zombies: {
+				idle_instances: [
+					{
+						resource_id: 'i-zombie-1',
+						resource_type: 'EC2 Instance',
+						provider: 'aws',
+						monthly_cost: '$18.00'
+					}
+				]
+			},
+			zombieCount: 1,
+			onRemediate: vi.fn()
+		});
+
+		const button = screen.getByRole('button', { name: 'Unavailable' });
+		expect(button.hasAttribute('disabled')).toBe(true);
+		expect(button.getAttribute('title')).toContain('Persisted finding binding missing');
+	});
+});

--- a/dashboard/src/routes/+layout.svelte
+++ b/dashboard/src/routes/+layout.svelte
@@ -273,6 +273,23 @@
 
 <div class="min-h-screen bg-ink-950 text-ink-100">
 	<a href="#main" class="skip-link">Skip to content</a>
+	<noscript>
+		<div class="noscript-banner" data-noscript-banner>
+			<div class="noscript-banner__copy">
+				<strong>JavaScript is disabled.</strong>
+				<span>
+					Public pages remain readable, but sign-in, live telemetry, and dashboard actions require
+					JavaScript.
+				</span>
+			</div>
+			<nav class="noscript-banner__links" aria-label="No JavaScript fallback links">
+				<a href={toAppPath('/pricing')}>Pricing</a>
+				<a href={toAppPath('/resources')}>Resources</a>
+				<a href={toAppPath('/docs')}>Docs</a>
+				<a href={toAppPath('/status')}>Status</a>
+			</nav>
+		</div>
+	</noscript>
 	{#if data.user}
 		<AppAuthenticatedShell
 			user={data.user}

--- a/dashboard/src/routes/+page.svelte
+++ b/dashboard/src/routes/+page.svelte
@@ -26,6 +26,7 @@
 	import { getDashboardPersonaContent, PUBLIC_HOME_META } from './homeDashboardContent';
 
 	type RemediationFinding = {
+		finding_id?: string;
 		resource_id: string;
 		resource_type?: string;
 		provider?: string;

--- a/dashboard/src/routes/layout/PublicSiteShell.svelte
+++ b/dashboard/src/routes/layout/PublicSiteShell.svelte
@@ -54,6 +54,8 @@
 				href={toAppPath('/')}
 				class="public-brand flex items-center gap-2"
 				aria-label="Valdrics home"
+				data-sveltekit-preload-data="hover"
+				data-sveltekit-preload-code="hover"
 			>
 				<CloudLogo provider="valdrics" size={40} emphasizeMark={true} />
 				<img
@@ -107,6 +109,8 @@
 											href={toAppPath(resourceLink.href)}
 											role="menuitem"
 											class="public-nav-dropdown-item"
+											data-sveltekit-preload-data="hover"
+											data-sveltekit-preload-code="hover"
 											onclick={closePublicResourcesMenu}
 										>
 											{resourceLink.label}
@@ -116,20 +120,44 @@
 							{/if}
 						</div>
 					{:else}
-						<a href={toAppPath(link.href)} class="public-nav-link">{link.label}</a>
+						<a
+							href={toAppPath(link.href)}
+							class="public-nav-link"
+							data-sveltekit-preload-data="hover"
+							data-sveltekit-preload-code="hover"
+						>
+							{link.label}
+						</a>
 					{/if}
 				{/each}
 			</div>
 
 			<div class="public-nav-secondary items-center gap-2">
-				<a href={toAppPath('/enterprise')} class="btn btn-secondary text-sm px-4 py-2">
+				<a
+					href={toAppPath('/enterprise')}
+					class="btn btn-secondary text-sm px-4 py-2"
+					data-sveltekit-preload-data="hover"
+					data-sveltekit-preload-code="hover"
+				>
 					Enterprise Path
 				</a>
-				<a href={toAppPath('/auth/login')} class="btn btn-primary text-sm px-4 py-2">Start Free</a>
+				<a
+					href={toAppPath('/auth/login')}
+					class="btn btn-primary text-sm px-4 py-2"
+					data-sveltekit-preload-data="hover"
+					data-sveltekit-preload-code="hover"
+				>
+					Start Free
+				</a>
 			</div>
 
 			<div class="public-nav-mobile flex items-center gap-2">
-				<a href={toAppPath('/auth/login')} class="btn btn-primary public-nav-mobile-cta">
+				<a
+					href={toAppPath('/auth/login')}
+					class="btn btn-primary public-nav-mobile-cta"
+					data-sveltekit-preload-data="hover"
+					data-sveltekit-preload-code="hover"
+				>
 					Start Free
 				</a>
 				<button
@@ -206,6 +234,8 @@
 						<a
 							href={toAppPath('/enterprise')}
 							class="btn btn-primary justify-center mb-1 w-full"
+							data-sveltekit-preload-data="hover"
+							data-sveltekit-preload-code="hover"
 							onclick={closePublicMenu}
 						>
 							Enterprise Path
@@ -213,6 +243,8 @@
 						<a
 							href={toAppPath('/auth/login')}
 							class="btn btn-secondary justify-center mb-2 w-full"
+							data-sveltekit-preload-data="hover"
+							data-sveltekit-preload-code="hover"
 							onclick={closePublicMenu}
 						>
 							Start Free
@@ -221,6 +253,8 @@
 							<a
 								href={toAppPath(link.href)}
 								class="py-3 min-h-11 flex items-center hover:text-ink-100"
+								data-sveltekit-preload-data="hover"
+								data-sveltekit-preload-code="hover"
 								onclick={closePublicMenu}
 							>
 								{link.label}
@@ -259,7 +293,14 @@
 								{link.label}
 							</a>
 						{:else}
-							<a href={toAppPath(link.href)} class="public-footer-link">{link.label}</a>
+							<a
+								href={toAppPath(link.href)}
+								class="public-footer-link"
+								data-sveltekit-preload-data="hover"
+								data-sveltekit-preload-code="hover"
+							>
+								{link.label}
+							</a>
 						{/if}
 					{/each}
 				</nav>

--- a/dashboard/src/routes/ops/OpsBacklogSection.svelte
+++ b/dashboard/src/routes/ops/OpsBacklogSection.svelte
@@ -1,8 +1,14 @@
 <script lang="ts">
-	import type { JobRecord, PendingRequest, StrategyRecommendation } from './opsTypes';
+	import type {
+		JobRecord,
+		PendingRequest,
+		RemediationHistoryItem,
+		StrategyRecommendation
+	} from './opsTypes';
 
 	let {
 		pendingRequests,
+		recentCompletions,
 		processingJobs = false,
 		jobs,
 		recommendations,
@@ -17,6 +23,7 @@
 		onApplyRecommendation
 	}: {
 		pendingRequests: PendingRequest[];
+		recentCompletions: RemediationHistoryItem[];
 		processingJobs?: boolean;
 		jobs: JobRecord[];
 		recommendations: StrategyRecommendation[];
@@ -77,6 +84,63 @@
 								>
 									Review
 								</button>
+							</td>
+						</tr>
+					{/each}
+				</tbody>
+			</table>
+		</div>
+	{/if}
+</div>
+
+<div class="card">
+	<div class="flex items-center justify-between mb-4">
+		<h2 class="text-lg font-semibold">Recent completions</h2>
+	</div>
+	{#if recentCompletions.length === 0}
+		<p class="text-ink-400 text-sm">No completed remediation history yet.</p>
+	{:else}
+		<div class="overflow-x-auto">
+			<table class="table">
+				<thead>
+					<tr>
+						<th>Resource</th>
+						<th>Action</th>
+						<th>Completed</th>
+						<th>Finding category</th>
+						<th>Finding status</th>
+						<th>Outcome</th>
+					</tr>
+				</thead>
+				<tbody>
+					{#each recentCompletions as req (req.id)}
+						<tr>
+							<td>
+								<div class="text-sm">{req.resource_type}</div>
+								<div class="text-xs text-ink-500 font-mono">{req.resource_id}</div>
+							</td>
+							<td class="capitalize">{req.action.replaceAll('_', ' ')}</td>
+							<td class="text-xs text-ink-500">{formatDate(req.executed_at || req.created_at)}</td>
+							<td class="text-xs font-mono">{req.finding_category || 'unknown'}</td>
+							<td>
+								{#if req.finding_status === 'resolved'}
+									<span class="badge badge-success text-xs">Resolved</span>
+								{:else}
+									<span class="text-xs text-ink-500 capitalize">
+										{(req.finding_status || 'unknown').replaceAll('_', ' ')}
+									</span>
+								{/if}
+							</td>
+							<td>
+								{#if req.status === 'completed'}
+									<span class="text-success-400 text-sm font-semibold">Completed</span>
+								{:else if req.execution_error}
+									<div class="text-xs text-danger-400">{req.execution_error}</div>
+								{:else}
+									<span class="text-xs text-ink-500 capitalize">
+										{req.status.replaceAll('_', ' ')}
+									</span>
+								{/if}
 							</td>
 						</tr>
 					{/each}

--- a/dashboard/src/routes/ops/OpsPageViewContent.svelte
+++ b/dashboard/src/routes/ops/OpsPageViewContent.svelte
@@ -15,6 +15,7 @@
 		JobStatus,
 		PendingRequest,
 		PolicyPreview,
+		RemediationHistoryItem,
 		StrategyRecommendation
 	} from './opsTypes';
 	import { formatDate, formatUsd, policyDecisionClass } from './opsUtils';
@@ -29,6 +30,7 @@
 	let refreshingStrategies = $state(false);
 	let actingId = $state<string | null>(null);
 	let pendingRequests = $state<PendingRequest[]>([]);
+	let remediationHistory = $state<RemediationHistoryItem[]>([]);
 	let jobStatus = $state<JobStatus | null>(null);
 	let jobs = $state<JobRecord[]>([]);
 	let recommendations = $state<StrategyRecommendation[]>([]);
@@ -61,6 +63,7 @@
 			const headers = getHeaders();
 			const results = await Promise.allSettled([
 				getWithTimeout(edgeApiPath('/zombies/pending'), headers),
+				getWithTimeout(edgeApiPath('/zombies/history'), headers),
 				getWithTimeout(edgeApiPath('/jobs/status'), headers),
 				getWithTimeout(edgeApiPath('/jobs/list?limit=20'), headers),
 				getWithTimeout(edgeApiPath('/strategies/recommendations?status=open'), headers)
@@ -72,11 +75,13 @@
 					: null;
 
 			const pendingRes = responseOrNull(0);
-			const statusRes = responseOrNull(1);
-			const jobsRes = responseOrNull(2);
-			const recsRes = responseOrNull(3);
+			const historyRes = responseOrNull(1);
+			const statusRes = responseOrNull(2);
+			const jobsRes = responseOrNull(3);
+			const recsRes = responseOrNull(4);
 
 			pendingRequests = pendingRes?.ok ? ((await pendingRes.json()).requests ?? []) : [];
+			remediationHistory = historyRes?.ok ? ((await historyRes.json()).requests ?? []) : [];
 			jobStatus = statusRes?.ok ? await statusRes.json() : null;
 			jobs = jobsRes?.ok ? await jobsRes.json() : [];
 			recommendations = recsRes?.ok ? await recsRes.json() : [];
@@ -317,11 +322,12 @@
 
 			<OpsOperationalHealthSection {data} />
 
-			<OpsBacklogSection
-				{pendingRequests}
-				{processingJobs}
-				{jobs}
-				{recommendations}
+	<OpsBacklogSection
+		{pendingRequests}
+		recentCompletions={remediationHistory}
+		{processingJobs}
+		{jobs}
+		{recommendations}
 				{refreshingStrategies}
 				{actingId}
 				{formatDate}

--- a/dashboard/src/routes/ops/ops-page.remediation.svelte.test.ts
+++ b/dashboard/src/routes/ops/ops-page.remediation.svelte.test.ts
@@ -192,4 +192,33 @@ describe('ops page unit economics interactions', () => {
 		const executeButton = within(dialog).getByRole('button', { name: 'Awaiting Approval' });
 		expect(executeButton.hasAttribute('disabled')).toBe(true);
 	});
+
+	it('shows recent completed remediations with resolved finding status', async () => {
+		setupOpsGetMocks({
+			history: [
+				{
+					id: 'd1a2b3c4-1111-2222-3333-444455556666',
+					status: 'completed',
+					resource_id: 'i-resolved-1',
+					resource_type: 'EC2 Instance',
+					action: 'terminate_instance',
+					finding_status: 'resolved',
+					finding_category: 'idle_instances',
+					executed_at: '2026-02-12T10:15:00Z',
+					created_at: '2026-02-12T10:00:00Z',
+					estimated_savings: 42
+				}
+			]
+		});
+
+		render(Page, { data: testOpsPageData });
+
+		await screen.findByText('Recent completions');
+		const resourceCell = await screen.findByText('i-resolved-1');
+		const row = resourceCell.closest('tr');
+		expect(row).toBeTruthy();
+		expect(within(row as HTMLTableRowElement).getByText('idle_instances')).toBeTruthy();
+		expect(within(row as HTMLTableRowElement).getByText('Resolved')).toBeTruthy();
+		expect(within(row as HTMLTableRowElement).getByText('Completed')).toBeTruthy();
+	});
 });

--- a/dashboard/src/routes/ops/ops-page.test.setup.ts
+++ b/dashboard/src/routes/ops/ops-page.test.setup.ts
@@ -40,6 +40,7 @@ export function jsonResponse(payload: unknown, status = 200): Response {
 
 export function setupOpsGetMocks({
 	requests = [],
+	history = [],
 	closePackage,
 	policyPreview = {
 		decision: 'allow',
@@ -49,11 +50,13 @@ export function setupOpsGetMocks({
 	}
 }: {
 	requests?: Array<Record<string, unknown>>;
+	history?: Array<Record<string, unknown>>;
 	closePackage?: Record<string, unknown>;
 	policyPreview?: Record<string, unknown>;
 } = {}) {
 	getMock.mockImplementation(async (url: string) => {
 		if (url.includes('/zombies/pending')) return jsonResponse({ requests });
+		if (url.includes('/zombies/history')) return jsonResponse({ requests: history });
 		if (url.includes('/zombies/policy-preview/')) return jsonResponse(policyPreview);
 		if (url.includes('/jobs/status')) {
 			return jsonResponse({ pending: 0, running: 0, completed: 0, failed: 0, dead_letter: 0 });

--- a/dashboard/src/routes/ops/opsTypes.ts
+++ b/dashboard/src/routes/ops/opsTypes.ts
@@ -7,12 +7,33 @@ export type PendingRequest = {
 	provider?: string;
 	region?: string;
 	connection_id?: string | null;
+	finding_id?: string | null;
+	finding_status?: string | null;
+	finding_category?: string | null;
 	estimated_savings: number;
 	scheduled_execution_at?: string | null;
 	escalation_required?: boolean;
 	escalation_reason?: string | null;
 	escalated_at?: string | null;
 	created_at: string | null;
+};
+
+export type RemediationHistoryItem = {
+	id: string;
+	status: string;
+	resource_id: string;
+	resource_type: string;
+	action: string;
+	provider?: string;
+	region?: string;
+	connection_id?: string | null;
+	finding_id?: string | null;
+	finding_status?: string | null;
+	finding_category?: string | null;
+	estimated_savings: number;
+	created_at: string | null;
+	executed_at?: string | null;
+	execution_error?: string | null;
 };
 
 export type PolicyPreview = {

--- a/dashboard/src/routes/privacy/+page.svelte
+++ b/dashboard/src/routes/privacy/+page.svelte
@@ -1,10 +1,14 @@
-<svelte:head>
-	<title>Privacy Policy | Valdrics</title>
-	<meta
-		name="description"
-		content="Valdrics privacy policy covering processing scope, retention, security controls, and data subject rights for cloud and software spend governance workflows."
-	/>
-</svelte:head>
+<script lang="ts">
+	import PublicPageMeta from '$lib/components/public/PublicPageMeta.svelte';
+</script>
+
+<PublicPageMeta
+	title="Privacy Policy"
+	description="Valdrics privacy policy covering processing scope, retention, security controls, and data subject rights for cloud and software spend governance workflows."
+	pageType="WebPage"
+	pageSection="Privacy"
+	keywords={['privacy policy', 'data retention', 'data subject rights', 'security controls']}
+/>
 
 <article class="mx-auto max-w-4xl px-6 py-12 space-y-8">
 	<header class="space-y-3">

--- a/dashboard/src/routes/privacy/privacy-page.svelte.test.ts
+++ b/dashboard/src/routes/privacy/privacy-page.svelte.test.ts
@@ -1,6 +1,15 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/svelte';
+import { readable } from 'svelte/store';
 import Page from './+page.svelte';
+
+vi.mock('$app/paths', () => ({
+	assets: ''
+}));
+
+vi.mock('$app/stores', () => ({
+	page: readable({ url: new URL('https://example.com/privacy') })
+}));
 
 describe('privacy page', () => {
 	it('renders production legal sections', () => {

--- a/dashboard/src/routes/robots.txt/robots.server.test.ts
+++ b/dashboard/src/routes/robots.txt/robots.server.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { GET } from './+server';
+
+describe('robots.txt route', () => {
+	it('disallows auth and build assets while advertising sitemap', async () => {
+		const response = await GET({
+			url: new URL('https://example.com/robots.txt')
+		} as Parameters<typeof GET>[0]);
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get('content-type')).toContain('text/plain');
+		expect(response.headers.get('cache-control')).toBe('public, max-age=3600');
+
+		const body = await response.text();
+		expect(body).toContain('User-agent: *');
+		expect(body).toContain('Disallow: /auth/');
+		expect(body).toContain('Disallow: /_app/');
+		expect(body).toContain('Sitemap: https://example.com/sitemap.xml');
+	});
+
+	it('preserves the deployed base path in the sitemap URL', async () => {
+		const response = await GET({
+			url: new URL('https://example.com/app/robots.txt')
+		} as Parameters<typeof GET>[0]);
+
+		const body = await response.text();
+		expect(body).toContain('Sitemap: https://example.com/app/sitemap.xml');
+	});
+});

--- a/dashboard/src/routes/savings/+page.svelte
+++ b/dashboard/src/routes/savings/+page.svelte
@@ -8,7 +8,11 @@
 	import { clientLogger } from '$lib/logging/client';
 	import { filenameFromContentDispositionHeader } from '$lib/utils';
 	import SavingsPageViewContent from './SavingsPageViewContent.svelte';
-	import type { SavingsProofDrilldownResponse, SavingsProofResponse } from './savingsTypes';
+	import type {
+		RealizedSavingsEvent,
+		SavingsProofDrilldownResponse,
+		SavingsProofResponse
+	} from './savingsTypes';
 
 	let { data } = $props();
 
@@ -21,10 +25,21 @@
 
 	let report = $state<SavingsProofResponse | null>(null);
 	let drilldown = $state<SavingsProofDrilldownResponse | null>(null);
-	let drilldownDimension = $state<'strategy_type' | 'remediation_action'>('strategy_type');
+	let realizedEvents = $state<RealizedSavingsEvent[]>([]);
+	let drilldownDimension = $state<'strategy_type' | 'remediation_action' | 'finding_category'>(
+		'strategy_type'
+	);
 	let provider = $state<string>('');
 	let datePreset = $state('30d');
 	let dateRange = $state({ startDate: '', endDate: '' });
+
+	function buildSavingsParams(): SvelteURLSearchParams {
+		const params = new SvelteURLSearchParams();
+		if (dateRange.startDate) params.set('start_date', dateRange.startDate);
+		if (dateRange.endDate) params.set('end_date', dateRange.endDate);
+		if (provider) params.set('provider', provider);
+		return params;
+	}
 
 	function isProPlus(tierValue: string | null | undefined): boolean {
 		return ['pro', 'enterprise'].includes((tierValue ?? '').toLowerCase());
@@ -65,12 +80,10 @@
 		error = '';
 		success = '';
 		drilldown = null;
+		realizedEvents = [];
 		try {
 			const headers = getHeaders();
-			const params = new SvelteURLSearchParams();
-			if (dateRange.startDate) params.set('start_date', dateRange.startDate);
-			if (dateRange.endDate) params.set('end_date', dateRange.endDate);
-			if (provider) params.set('provider', provider);
+			const params = buildSavingsParams();
 			params.set('response_format', 'json');
 
 			const res = await getWithTimeout(edgeApiPath(`/savings/proof?${params.toString()}`), headers);
@@ -81,7 +94,7 @@
 				);
 			}
 			report = (await res.json()) as SavingsProofResponse;
-			void loadDrilldown();
+			await Promise.all([loadDrilldown(), loadRealizedEvents()]);
 		} catch (e) {
 			clientLogger.error('Failed to load savings proof:', e);
 			error =
@@ -100,10 +113,7 @@
 		error = '';
 		try {
 			const headers = getHeaders();
-			const params = new SvelteURLSearchParams();
-			if (dateRange.startDate) params.set('start_date', dateRange.startDate);
-			if (dateRange.endDate) params.set('end_date', dateRange.endDate);
-			if (provider) params.set('provider', provider);
+			const params = buildSavingsParams();
 			params.set('dimension', drilldownDimension);
 			params.set('response_format', 'json');
 
@@ -121,6 +131,36 @@
 			error =
 				e instanceof TimeoutError
 					? 'Savings drilldown request timed out. Try again.'
+					: (e as Error).message;
+		}
+	}
+
+	async function loadRealizedEvents() {
+		if (!data.user || !data.session?.access_token) return;
+		if (!isProPlus(data.subscription?.tier)) return;
+
+		try {
+			const headers = getHeaders();
+			const params = buildSavingsParams();
+			params.set('response_format', 'json');
+			params.set('limit', '25');
+			const res = await getWithTimeout(
+				edgeApiPath(`/savings/realized/events?${params.toString()}`),
+				headers
+			);
+			if (!res.ok) {
+				const payload = await res.json().catch(() => ({}));
+				throw new Error(
+					payload.detail || payload.message || 'Failed to load realized savings evidence.'
+				);
+			}
+			realizedEvents = (await res.json()) as RealizedSavingsEvent[];
+		} catch (e) {
+			clientLogger.error('Failed to load realized savings evidence:', e);
+			realizedEvents = [];
+			error =
+				e instanceof TimeoutError
+					? 'Realized savings evidence request timed out. Try again.'
 					: (e as Error).message;
 		}
 	}
@@ -179,6 +219,7 @@
 	{success}
 	{report}
 	{drilldown}
+	{realizedEvents}
 	bind:drilldownDimension
 	bind:provider
 	bind:datePreset

--- a/dashboard/src/routes/savings/SavingsPageViewContent.svelte
+++ b/dashboard/src/routes/savings/SavingsPageViewContent.svelte
@@ -3,7 +3,11 @@
 	import AuthGate from '$lib/components/AuthGate.svelte';
 	import DateRangePicker from '$lib/components/DateRangePicker.svelte';
 	import { getUpgradePrompt } from '$lib/pricing/upgradePrompt';
-	import type { SavingsProofDrilldownResponse, SavingsProofResponse } from './savingsTypes';
+	import type {
+		RealizedSavingsEvent,
+		SavingsProofDrilldownResponse,
+		SavingsProofResponse
+	} from './savingsTypes';
 
 	interface Props {
 		data: {
@@ -18,7 +22,8 @@
 		success: string;
 		report: SavingsProofResponse | null;
 		drilldown: SavingsProofDrilldownResponse | null;
-		drilldownDimension: 'strategy_type' | 'remediation_action';
+		realizedEvents: RealizedSavingsEvent[];
+		drilldownDimension: 'strategy_type' | 'remediation_action' | 'finding_category';
 		provider: string;
 		datePreset: string;
 		dateRange: {
@@ -41,6 +46,7 @@
 		success,
 		report,
 		drilldown,
+		realizedEvents,
 		drilldownDimension = $bindable(),
 		provider = $bindable(),
 		datePreset = $bindable(),
@@ -224,6 +230,7 @@
 							>
 								<option value="strategy_type">Strategy type</option>
 								<option value="remediation_action">Remediation action</option>
+								<option value="finding_category">Finding category</option>
 							</select>
 							<button
 								type="button"
@@ -285,6 +292,61 @@
 									{/each}
 								</tbody>
 							</table>
+						</div>
+
+						<div class="mt-5 rounded-xl border border-ink-800/60 bg-ink-950/20 p-4">
+							<div class="flex items-center justify-between gap-2 mb-3 flex-wrap">
+								<div>
+									<h3 class="text-sm font-semibold">
+										Completed remediations with finance-grade realized savings evidence
+									</h3>
+									<p class="text-xs text-ink-500">
+										Finding provenance is carried from discovery through execution and realized
+										savings measurement.
+									</p>
+								</div>
+							</div>
+							{#if realizedEvents.length === 0}
+								<p class="text-sm text-ink-400">
+									No realized savings evidence events were found for this window.
+								</p>
+							{:else}
+								<div class="overflow-x-auto">
+									<table class="table">
+										<thead>
+											<tr>
+												<th>Finding category</th>
+												<th>Resource</th>
+												<th>Provider</th>
+												<th>Executed</th>
+												<th>Realized (Monthly)</th>
+												<th>Provenance</th>
+											</tr>
+										</thead>
+										<tbody>
+											{#each realizedEvents as event (event.remediation_request_id)}
+												<tr>
+													<td class="font-mono text-xs">
+														{event.finding_category || 'unknown'}
+													</td>
+													<td class="text-xs font-mono">{event.resource_id || '-'}</td>
+													<td class="text-xs">{event.provider}</td>
+													<td class="text-xs text-ink-500">
+														{formatDate(event.executed_at || event.computed_at)}
+													</td>
+													<td>{formatUsd(event.realized_monthly_savings_usd)}</td>
+													<td class="text-xs text-ink-500">
+														<div>Request {event.remediation_request_id.slice(0, 8)}...</div>
+														<div>
+															Finding {event.finding_id ? `${event.finding_id.slice(0, 8)}...` : 'n/a'}
+														</div>
+													</td>
+												</tr>
+											{/each}
+										</tbody>
+									</table>
+								</div>
+							{/if}
 						</div>
 					{/if}
 				</div>

--- a/dashboard/src/routes/savings/savings-page.svelte.test.ts
+++ b/dashboard/src/routes/savings/savings-page.svelte.test.ts
@@ -42,8 +42,58 @@ describe('savings proof page', () => {
 	});
 
 	it('renders savings proof breakdown from API', async () => {
-		getMock.mockImplementation(async () =>
-			jsonResponse({
+		getMock.mockImplementation(async (url: string) => {
+			if (url.includes('/savings/proof/drilldown')) {
+				return jsonResponse({
+					start_date: '2026-02-01',
+					end_date: '2026-02-10',
+					as_of: '2026-02-13T00:00:00Z',
+					tier: 'pro',
+					provider: null,
+					dimension: 'strategy_type',
+					opportunity_monthly_usd: 123.45,
+					realized_monthly_usd: 67.89,
+					buckets: [
+						{
+							key: 'reserved_instance',
+							opportunity_monthly_usd: 100.0,
+							realized_monthly_usd: 50.0,
+							open_recommendations: 2,
+							applied_recommendations: 1,
+							pending_remediations: 0,
+							completed_remediations: 0
+						}
+					],
+					truncated: false,
+					limit: 50,
+					notes: ['Grouped by strategy type.']
+				});
+			}
+			if (url.includes('/savings/realized/events')) {
+				return jsonResponse([
+					{
+						remediation_request_id: 'req-1',
+						finding_id: 'finding-1',
+						finding_category: 'idle_instances',
+						provider: 'aws',
+						account_id: 'acct-1',
+						resource_id: 'i-123',
+						region: 'us-east-1',
+						method: 'ledger_delta_avg_daily_v1',
+						executed_at: '2026-02-12T10:00:00Z',
+						baseline_start_date: '2026-02-01',
+						baseline_end_date: '2026-02-07',
+						measurement_start_date: '2026-02-08',
+						measurement_end_date: '2026-02-14',
+						baseline_avg_daily_cost_usd: 10,
+						measurement_avg_daily_cost_usd: 5,
+						realized_monthly_savings_usd: 150,
+						confidence_score: 0.9,
+						computed_at: '2026-02-15T00:00:00Z'
+					}
+				]);
+			}
+			return jsonResponse({
 				start_date: '2026-02-01',
 				end_date: '2026-02-10',
 				as_of: '2026-02-13T00:00:00Z',
@@ -66,8 +116,8 @@ describe('savings proof page', () => {
 					}
 				],
 				notes: ['Opportunity is a snapshot.']
-			})
-		);
+			});
+		});
 
 		const data = {
 			user: { id: 'user-id' },
@@ -78,11 +128,81 @@ describe('savings proof page', () => {
 		render(Page, { data });
 
 		await screen.findByText('Breakdown');
-		expect(screen.getByText('aws')).toBeTruthy();
+		expect(
+			screen.getByText('Completed remediations with finance-grade realized savings evidence')
+		).toBeTruthy();
+		expect(screen.getByText('idle_instances')).toBeTruthy();
+		expect(screen.getByText('i-123')).toBeTruthy();
 
 		await waitFor(() => {
 			expect(getMock).toHaveBeenCalled();
 		});
+	});
+
+	it('supports finding category drilldown', async () => {
+		getMock.mockImplementation(async (url: string) => {
+			if (url.includes('/savings/proof/drilldown')) {
+				const params = new URL(url, 'https://app.test').searchParams;
+				return jsonResponse({
+					start_date: '2026-02-01',
+					end_date: '2026-02-10',
+					as_of: '2026-02-13T00:00:00Z',
+					tier: 'pro',
+					provider: null,
+					dimension: params.get('dimension') || 'strategy_type',
+					opportunity_monthly_usd: 12,
+					realized_monthly_usd: 20,
+					buckets: [
+						{
+							key: 'idle_instances',
+							opportunity_monthly_usd: 4,
+							realized_monthly_usd: 20,
+							open_recommendations: 0,
+							applied_recommendations: 0,
+							pending_remediations: 1,
+							completed_remediations: 1
+						}
+					],
+					truncated: false,
+					limit: 50,
+					notes: ['Finding category grouped output.']
+				});
+			}
+			if (url.includes('/savings/realized/events')) {
+				return jsonResponse([]);
+			}
+			return jsonResponse({
+				start_date: '2026-02-01',
+				end_date: '2026-02-10',
+				as_of: '2026-02-13T00:00:00Z',
+				tier: 'pro',
+				opportunity_monthly_usd: 12,
+				realized_monthly_usd: 20,
+				open_recommendations: 0,
+				applied_recommendations: 0,
+				pending_remediations: 1,
+				completed_remediations: 1,
+				breakdown: [],
+				notes: []
+			});
+		});
+
+		const data = {
+			user: { id: 'user-id' },
+			session: { access_token: 'token' },
+			subscription: { tier: 'pro', status: 'active' }
+		} as unknown as PageData;
+
+		render(Page, { data });
+		await screen.findByText('Drilldown');
+		const select = await screen.findByLabelText('Drilldown dimension');
+		await waitFor(() => {
+			expect(select).toBeTruthy();
+		});
+		(select as HTMLSelectElement).value = 'finding_category';
+		select.dispatchEvent(new Event('change'));
+
+		await screen.findByText('idle_instances');
 	});
 
 	it('shows pro plan prompt for non-pro tiers without loading report data', async () => {

--- a/dashboard/src/routes/savings/savingsTypes.ts
+++ b/dashboard/src/routes/savings/savingsTypes.ts
@@ -47,3 +47,24 @@ export type SavingsProofDrilldownResponse = {
 	limit: number;
 	notes: string[];
 };
+
+export type RealizedSavingsEvent = {
+	remediation_request_id: string;
+	finding_id: string | null;
+	finding_category: string | null;
+	provider: string;
+	account_id: string | null;
+	resource_id: string | null;
+	region: string | null;
+	method: string;
+	executed_at: string | null;
+	baseline_start_date: string;
+	baseline_end_date: string;
+	measurement_start_date: string;
+	measurement_end_date: string;
+	baseline_avg_daily_cost_usd: number;
+	measurement_avg_daily_cost_usd: number;
+	realized_monthly_savings_usd: number;
+	confidence_score: number | null;
+	computed_at: string;
+};

--- a/dashboard/src/routes/sitemap.xml/+server.ts
+++ b/dashboard/src/routes/sitemap.xml/+server.ts
@@ -20,7 +20,6 @@ const PUBLIC_ENTRIES: SitemapEntry[] = [
 	{ path: '/talk-to-sales', changefreq: 'weekly', priority: 0.8 },
 	{ path: '/status', changefreq: 'daily', priority: 0.6 },
 	{ path: '/pricing', changefreq: 'monthly', priority: 0.9 },
-	{ path: '/auth/login', changefreq: 'monthly', priority: 0.7 },
 	{ path: '/terms', changefreq: 'yearly', priority: 0.4 },
 	{ path: '/privacy', changefreq: 'yearly', priority: 0.4 }
 ];

--- a/dashboard/src/routes/sitemap.xml/sitemap.server.test.ts
+++ b/dashboard/src/routes/sitemap.xml/sitemap.server.test.ts
@@ -41,6 +41,7 @@ describe('sitemap.xml route', () => {
 		expect(xml).toContain('https://example.com/enterprise');
 		expect(xml).toContain('https://example.com/talk-to-sales');
 		expect(xml).toContain('https://example.com/status');
+		expect(xml).not.toContain('https://example.com/auth/login');
 		expect(xml).toContain('<lastmod>2026-03-09T00:00:00.000Z</lastmod>');
 	});
 

--- a/dashboard/src/routes/status/+page.svelte
+++ b/dashboard/src/routes/status/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import PublicPageMeta from '$lib/components/public/PublicPageMeta.svelte';
 	import PublicMarketingPage from '$lib/components/public/PublicMarketingPage.svelte';
 
 	import type { PageData } from './$types';
@@ -21,13 +22,13 @@
 	}
 </script>
 
-<svelte:head>
-	<title>System Status | Valdrics</title>
-	<meta
-		name="description"
-		content="Current service status for Valdrics core platform dependencies and automated health checks."
-	/>
-</svelte:head>
+<PublicPageMeta
+	title="System Status"
+	description="Current service status for Valdrics core platform dependencies and automated health checks."
+	pageType="WebPage"
+	pageSection="Status"
+	keywords={['system status', 'service health', 'incident readiness', 'platform health']}
+/>
 
 <PublicMarketingPage
 	kicker="Status"

--- a/dashboard/src/routes/status/status-page.svelte.test.ts
+++ b/dashboard/src/routes/status/status-page.svelte.test.ts
@@ -1,7 +1,16 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/svelte';
+import { readable } from 'svelte/store';
 
 import Page from './+page.svelte';
+
+vi.mock('$app/paths', () => ({
+	assets: ''
+}));
+
+vi.mock('$app/stores', () => ({
+	page: readable({ url: new URL('https://example.com/status') })
+}));
 
 describe('status page', () => {
 	it('renders live service health cards', () => {

--- a/dashboard/src/routes/terms/+page.svelte
+++ b/dashboard/src/routes/terms/+page.svelte
@@ -1,10 +1,14 @@
-<svelte:head>
-	<title>Terms of Service | Valdrics</title>
-	<meta
-		name="description"
-		content="Valdrics terms of service covering account responsibilities, billing, acceptable use, confidentiality, liability, and dispute provisions."
-	/>
-</svelte:head>
+<script lang="ts">
+	import PublicPageMeta from '$lib/components/public/PublicPageMeta.svelte';
+</script>
+
+<PublicPageMeta
+	title="Terms of Service"
+	description="Valdrics terms of service covering account responsibilities, billing, acceptable use, confidentiality, liability, and dispute provisions."
+	pageType="WebPage"
+	pageSection="Legal"
+	keywords={['terms of service', 'billing terms', 'acceptable use', 'liability']}
+/>
 
 <article class="mx-auto max-w-4xl px-6 py-12 space-y-8">
 	<header class="space-y-3">

--- a/dashboard/src/routes/terms/terms-page.svelte.test.ts
+++ b/dashboard/src/routes/terms/terms-page.svelte.test.ts
@@ -1,6 +1,15 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/svelte';
+import { readable } from 'svelte/store';
 import Page from './+page.svelte';
+
+vi.mock('$app/paths', () => ({
+	assets: ''
+}));
+
+vi.mock('$app/stores', () => ({
+	page: readable({ url: new URL('https://example.com/terms') })
+}));
 
 describe('terms page', () => {
 	it('renders production service terms sections', () => {

--- a/docs/ops/all_changes_categorization_2026-03-18.md
+++ b/docs/ops/all_changes_categorization_2026-03-18.md
@@ -1,0 +1,165 @@
+# All Changes Categorization (2026-03-18)
+
+Snapshot:
+- Captured at: `2026-03-18T00:00:00Z`
+- Base commit: `c89a4e9b2386e3c7f032a5fbd4452f043fadee5d`
+- Pending paths: `105`
+- Branch at snapshot: `chore/all-changes-categorization-2026-03-18`
+
+## Track BM: Optimization, Remediation, Savings Proof, and Findings Pipeline
+Scope:
+- Group backend changes for optimization findings, remediation workflows, zombie handling, realized savings, and savings proof generation.
+- Keep the related enforcement runtime/export hooks and migration for optimization request binding in the same control path review lane.
+- Carry the matching optimization, savings, zombie, and remediation regression suites together.
+
+Paths:
+- `app/models/optimization.py`
+- `app/models/realized_savings.py`
+- `app/models/remediation.py`
+- `app/modules/enforcement/domain/export_bundle_ops.py`
+- `app/modules/enforcement/domain/service_runtime_ops.py`
+- `app/modules/optimization/api/v1/zombies.py`
+- `app/modules/optimization/domain/remediation.py`
+- `app/modules/optimization/domain/remediation_credentials.py`
+- `app/modules/optimization/domain/remediation_execute.py`
+- `app/modules/optimization/domain/remediation_iac.py`
+- `app/modules/optimization/domain/remediation_workflow.py`
+- `app/modules/optimization/domain/service.py`
+- `app/modules/reporting/api/v1/savings.py`
+- `app/modules/reporting/domain/realized_savings.py`
+- `app/modules/reporting/domain/savings_proof.py`
+- `app/modules/reporting/domain/savings_proof_drilldown_ops.py`
+- `app/shared/llm/zombie_analyzer.py`
+- `tests/api/test_endpoints_zombies_plan_policy.py`
+- `tests/api/test_endpoints_zombies_scan_requests.py`
+- `tests/governance/test_detector.py`
+- `tests/integration/optimization/test_remediation_lifecycle.py`
+- `tests/unit/api/v1/test_savings_branch_paths.py`
+- `tests/unit/enforcement/test_export_bundle_ops_regressions.py`
+- `tests/unit/modules/optimization/domain/test_remediation_credentials.py`
+- `tests/unit/optimization/test_remediation_branch_coverage.py`
+- `tests/unit/optimization/test_remediation_region_resolution.py`
+- `tests/unit/optimization/test_remediation_service_audit.py`
+- `tests/unit/optimization/test_zombie_service_audit.py`
+- `tests/unit/reporting/test_realized_savings_service_branches.py`
+- `tests/unit/reporting/test_savings_api_branches.py`
+- `tests/unit/reporting/test_savings_proof_api.py`
+- `tests/unit/services/llm/test_zombie_analyzer_logic.py`
+- `tests/unit/services/zombies/test_remediation_service.py`
+- `tests/unit/zombies/test_zombies_api_branches.py`
+- `app/modules/optimization/domain/findings.py`
+- `migrations/versions/v8w9x0y1z2a_add_optimization_findings_and_request_binding.py`
+
+Notes:
+- This is the main product-runtime backend slice for cost-actioning and savings proof behavior.
+
+## Track BN: Frontend Public Experience, Ops UX, and Savings Interfaces
+Scope:
+- Batch the public shell, landing, legal, status, sitemap, robots, and progressive enhancement updates together.
+- Keep the savings and remediation UI components with their route-level and end-to-end tests.
+- Treat the operator-facing dashboard refinements as one frontend review lane.
+
+Paths:
+- `dashboard/e2e/public-marketing.spec.ts`
+- `dashboard/src/app.utilities.css`
+- `dashboard/src/lib/components/FindingsTable.svelte`
+- `dashboard/src/lib/components/FindingsTable.svelte.test.ts`
+- `dashboard/src/lib/components/RemediationModal.svelte`
+- `dashboard/src/lib/components/ZombieTable.svelte`
+- `dashboard/src/routes/+layout.svelte`
+- `dashboard/src/routes/+page.svelte`
+- `dashboard/src/routes/layout/PublicSiteShell.svelte`
+- `dashboard/src/routes/ops/OpsBacklogSection.svelte`
+- `dashboard/src/routes/ops/OpsPageViewContent.svelte`
+- `dashboard/src/routes/ops/ops-page.remediation.svelte.test.ts`
+- `dashboard/src/routes/ops/ops-page.test.setup.ts`
+- `dashboard/src/routes/ops/opsTypes.ts`
+- `dashboard/src/routes/privacy/+page.svelte`
+- `dashboard/src/routes/privacy/privacy-page.svelte.test.ts`
+- `dashboard/src/routes/savings/+page.svelte`
+- `dashboard/src/routes/savings/SavingsPageViewContent.svelte`
+- `dashboard/src/routes/savings/savings-page.svelte.test.ts`
+- `dashboard/src/routes/savings/savingsTypes.ts`
+- `dashboard/src/routes/sitemap.xml/+server.ts`
+- `dashboard/src/routes/sitemap.xml/sitemap.server.test.ts`
+- `dashboard/src/routes/status/+page.svelte`
+- `dashboard/src/routes/status/status-page.svelte.test.ts`
+- `dashboard/src/routes/terms/+page.svelte`
+- `dashboard/src/routes/terms/terms-page.svelte.test.ts`
+- `dashboard/e2e/public-progressive-enhancement.spec.ts`
+- `dashboard/src/lib/components/RemediationModal.svelte.test.ts`
+- `dashboard/src/lib/components/ZombieTable.svelte.test.ts`
+- `dashboard/src/routes/robots.txt/robots.server.test.ts`
+
+Notes:
+- This track is intentionally frontend-heavy and spans public pages plus authenticated ops and savings screens.
+
+## Track BO: Runtime Platform, Security, and API Contract Hardening
+Scope:
+- Group app bootstrap, health, DB session, CI workflow, and security-sensitive API contract changes together.
+- Keep the associated endpoint, privilege, health, and main import coverage in the same platform review lane.
+- Separate runtime/platform hardening from feature and ops-script work so the risk profile is easier to review.
+
+Paths:
+- `.github/workflows/ci.yml`
+- `app/main.py`
+- `app/shared/core/health.py`
+- `app/shared/db/session.py`
+- `migrations/env.py`
+- `tests/api/test_api_endpoints.py`
+- `tests/api/test_endpoints_security_auth.py`
+- `tests/api/test_endpoints_validation_jobs.py`
+- `tests/conftest.py`
+- `tests/security/test_privilege_escalation.py`
+- `tests/unit/core/test_health_deep.py`
+- `tests/unit/db/test_session_branch_paths_2.py`
+- `tests/unit/test_main_coverage.py`
+
+Notes:
+- This track is the platform/runtime contract slice of the batch.
+
+## Track BP: Operational Evidence, Provenance, Finance Guardrails, and Runbooks
+Scope:
+- Consolidate evidence-generation, provenance, finance committee, key rotation, and disposition verification tooling updates.
+- Keep the runbook and ops documentation refresh in the same operational evidence review lane.
+- Carry the matching ops and supply-chain verification tests together.
+
+Paths:
+- `docs/ops/key-rotation-drill-2026-02-27.md`
+- `scripts/finance_committee_packet_assumptions_engine.py`
+- `scripts/finance_committee_packet_common.py`
+- `scripts/generate_enforcement_failure_injection_evidence.py`
+- `scripts/generate_feature_enforceability_matrix.py`
+- `scripts/generate_key_rotation_drill_evidence.py`
+- `scripts/generate_local_dev_env.py`
+- `scripts/generate_pkg_fin_policy_decisions.py`
+- `scripts/generate_provenance_manifest.py`
+- `scripts/verify_finance_guardrails_evidence.py`
+- `scripts/verify_key_rotation_drill_evidence.py`
+- `scripts/verify_valdrics_disposition_freshness.py`
+- `tests/governance/test_audit_phase_1.py`
+- `tests/unit/ops/test_generate_enforcement_failure_injection_evidence.py`
+- `tests/unit/ops/test_generate_finance_committee_packet_assumptions.py`
+- `tests/unit/ops/test_generate_local_dev_env.py`
+- `tests/unit/ops/test_key_rotation_drill_evidence_pack.py`
+- `tests/unit/ops/test_runtime_evidence_generators.py`
+- `tests/unit/ops/test_verify_finance_guardrails_evidence.py`
+- `tests/unit/ops/test_verify_key_rotation_drill_evidence.py`
+- `tests/unit/ops/test_verify_repo_root_hygiene.py`
+- `tests/unit/ops/test_verify_valdrics_disposition_freshness.py`
+- `tests/unit/supply_chain/test_feature_enforceability_matrix.py`
+- `tests/unit/supply_chain/test_supply_chain_provenance.py`
+- `docs/runbooks/aws_first_operator_flow.md`
+- `tests/unit/ops/test_generate_key_rotation_drill_evidence.py`
+
+Notes:
+- This track is operational and release-gate oriented rather than end-user feature work.
+
+## Batching Decision
+Decision:
+- Merge as one consolidated PR.
+
+Reasoning:
+- The frontend, backend, runtime, and ops evidence changes are broad, but they are part of one active worktree snapshot and are now tracked through separate review lanes.
+- Splitting this snapshot further would add PR overhead while still crossing the same remediation, savings, platform, and verification contracts.
+- The issue split preserves accountability without fragmenting the actual delivery batch.

--- a/docs/ops/key-rotation-drill-2026-02-27.md
+++ b/docs/ops/key-rotation-drill-2026-02-27.md
@@ -28,6 +28,7 @@ Secrets rotated during the drill:
 - source_rollback_validation_passed: tests/unit/enforcement/enforcement_service_cases_part04.py::test_consume_approval_token_accepts_rollback_fallback_secret
 - source_replay_protection_intact: tests/unit/enforcement/enforcement_service_cases_part03.py::test_consume_approval_token_rejects_replay
 - source_alert_pipeline_verified: tests/unit/enforcement/test_reconciliation_worker.py::test_reconciliation_worker_sends_sla_release_alert
+- source_endpoint_replay_tamper_guard: tests/unit/enforcement/enforcement_api_cases_part03.py::test_consume_approval_token_endpoint_rejects_replay_and_tamper
 - pre_rotation_tokens_accepted: true
 - post_rotation_new_tokens_accepted: true
 - post_rotation_old_tokens_rejected: true
@@ -35,6 +36,7 @@ Secrets rotated during the drill:
 - rollback_validation_passed: true
 - replay_protection_intact: true
 - alert_pipeline_verified: true
+- endpoint_replay_tamper_guard: true
 - post_drill_status: PASS
 
 ## Evidence Anchors

--- a/docs/runbooks/aws_first_operator_flow.md
+++ b/docs/runbooks/aws_first_operator_flow.md
@@ -1,0 +1,181 @@
+# AWS-First Operator Flow Runbook
+
+This runbook is the release-critical staging smoke path for the AWS-first Valdrics operator journey:
+
+`connect AWS -> scan -> create remediation from finding -> approve -> execute -> confirm resolved finding -> confirm savings proof`
+
+## Preconditions
+
+1. Staging must be on the target application build.
+2. Alembic must be at head.
+3. The staging tenant must be on a tier that includes:
+   - auto remediation
+   - policy preview
+   - savings proof
+4. Use an AWS staging account with disposable low-risk resources only.
+
+## Apply Database State
+
+Run the staging migration sequence before the smoke test:
+
+```bash
+uv run python scripts/generate_managed_migration_env.py --environment staging
+uv run python scripts/validate_migration_env.py --env-file .runtime/staging.migrate.env
+set -a && source .runtime/staging.migrate.env && uv run alembic upgrade head
+```
+
+Verify the new head is applied before proceeding.
+
+## Prepare AWS Test Account
+
+1. Ensure the AWS test account has an assumable Valdrics role and cost visibility configured.
+2. Seed one intentionally remediable low-risk resource in the account, for example:
+   - an idle EC2 instance in a non-production subnet
+3. Confirm the resource is in a region enabled for the connection.
+
+## Connect AWS
+
+1. In the Valdrics settings flow, create or verify the AWS connection.
+2. Confirm the connection status is `active`.
+3. If AWS Organizations discovery is enabled for the test account, verify the management account status is still `active` before continuing.
+
+Expected failure states:
+- `403` or feature gate failure: wrong tier or role
+- connection verify failure: invalid role trust, missing external ID, expired trust
+
+Check:
+- application logs for `aws_connection_verified`
+- Ops Center connection status
+
+## Run Zombie Scan
+
+1. Run the AWS scan from the dashboard or `GET /api/v1/zombies?region=<region>`.
+2. Confirm at least one actionable result returns a persisted `finding_id`.
+3. If AI analysis is enabled in staging, confirm any AI-enriched row still preserves the same `finding_id`.
+
+Expected failure states:
+- no `finding_id`: release blocker for this flow
+- scan job enqueued but not completed: inspect job processor health
+
+Check:
+- logs for `aws_parallel_scan_starting` and the returned scan payload containing persisted `finding_id`
+- `/api/v1/zombies/pending` remains unchanged until a request is created
+
+## Create Remediation From Finding
+
+1. Create the remediation request using the persisted `finding_id`.
+2. Confirm the request succeeds and returns `request_id`.
+3. Repeat the same request immediately and confirm duplicate open request protection returns `409`.
+
+Expected failure states:
+- `404`: stale or non-tenant finding
+- `409`: duplicate open request, expected only on replay
+- `400`: inactive or mismatched connection binding
+
+Check:
+- logs for `remediation_request_created_from_finding`
+- logs for `remediation_request_duplicate_open_finding` on replay
+
+## Approve And Execute
+
+1. Approve the request from Ops Center or `POST /api/v1/zombies/approve/{request_id}`.
+2. Execute the request.
+3. In staging only, use grace-period bypass when required for the smoke test:
+
+```bash
+POST /api/v1/zombies/execute/{request_id}?bypass_grace_period=true
+```
+
+4. Confirm the remediation completes successfully.
+
+Expected failure states:
+- `403`: missing explicit remediation approval permission
+- `400`: stale finding binding or inactive connection
+- `500`: provider execution failure
+
+Check:
+- logs for `remediation_execution_started`
+- logs for `remediation_executed`
+- `409 remediation_finding_context_mismatch` if execution fails closed on stale binding
+
+## Verify Resolved Finding In Ops Center
+
+1. Open Ops Center.
+2. Confirm the request disappears from the pending queue.
+3. Confirm it appears in **Recent completions**.
+4. Confirm the row shows:
+   - resource
+   - action
+   - completion time
+   - finding category
+   - `Resolved` finding status
+
+Release blocker:
+- completed request visible without resolved finding linkage
+
+## Verify Savings Proof
+
+1. Trigger realized savings computation for a window that includes the completed remediation:
+
+```bash
+POST /api/v1/savings/realized/compute?start_date=<window-start>&end_date=<window-end>&baseline_days=7&measurement_days=7&gap_days=1&monthly_multiplier_days=30&require_final=true
+```
+
+2. Confirm the compute response reports the remediation as either:
+   - `computed`
+   - or explicitly `skipped` for a deterministic reason such as insufficient finalized ledger data
+3. Open the Savings Proof page for the same time window.
+4. Confirm the realized evidence section includes the completed remediation.
+5. Confirm the row shows:
+   - `finding_category`
+   - `finding_id`
+   - `remediation_request_id`
+   - realized monthly savings
+6. Switch drilldown to `finding_category` and confirm the executed remediation contributes to the expected bucket.
+7. Export CSV and confirm the exported row retains:
+   - `finding_id`
+   - `finding_category`
+   - `remediation_request_id`
+   - `realized_monthly_savings_usd`
+
+Expected failure states:
+- realized event missing because ledger prerequisites are incomplete
+- provenance fields missing in JSON or CSV
+- drilldown bucket mismatch
+
+Check:
+- logs for `realized_savings_computed`
+- logs for `savings_proof_drilldown_generated`
+
+## Required Metrics And Logs
+
+Confirm these signals are present during the smoke run:
+
+- duplicate remediation request rejection count
+- finding-binding mismatch failures (`remediation_finding_context_mismatch`)
+- realized savings compute skip reasons
+- remediation history fetch errors
+- savings drilldown generation logs
+
+Minimum expected structured events:
+
+- `remediation_request_created_from_finding`
+- `remediation_request_duplicate_open_finding`
+- `remediation_executed`
+- `realized_savings_computed`
+- `savings_proof_drilldown_generated`
+
+## Exit Criteria
+
+Promotion is blocked unless all of the following pass:
+
+1. AWS connection is active and verified.
+2. Scan returns actionable results with persisted `finding_id`.
+3. Remediation request is created from `finding_id`.
+4. Duplicate open request replay is rejected with `409`.
+5. Approval and execution succeed.
+6. The finding is resolved and visible as resolved in Ops Center history.
+7. Savings Proof shows the completed remediation with provenance intact in JSON and CSV.
+
+After the staging smoke run passes, complete the broader deployment flow in
+[production_env_checklist.md](/home/daretechie/DevProject/GitHub/CloudSentinel-AI/docs/runbooks/production_env_checklist.md).

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -33,7 +33,7 @@ from app.models.background_job import BackgroundJob  # noqa: F401 # pylint: disa
 from app.modules.governance.domain.security.audit_log import AuditLog, SystemAuditLog  # noqa: F401 # pylint: disable=unused-import
 from app.models.attribution import AttributionRule, CostAllocation  # noqa: F401 # pylint: disable=unused-import
 from app.models.anomaly_marker import AnomalyMarker  # noqa: F401 # pylint: disable=unused-import
-from app.models.optimization import OptimizationStrategy, StrategyRecommendation  # noqa: F401 # pylint: disable=unused-import
+from app.models.optimization import OptimizationFinding, OptimizationStrategy, StrategyRecommendation  # noqa: F401 # pylint: disable=unused-import
 from app.models.enforcement import (  # noqa: F401 # pylint: disable=unused-import
     EnforcementApprovalRequest,
     EnforcementBudgetAllocation,

--- a/migrations/versions/v8w9x0y1z2a_add_optimization_findings_and_request_binding.py
+++ b/migrations/versions/v8w9x0y1z2a_add_optimization_findings_and_request_binding.py
@@ -1,0 +1,183 @@
+"""add optimization findings and request binding
+
+Revision ID: v8w9x0y1z2a
+Revises: u7v8w9x0y1z
+Create Date: 2026-03-17 14:20:00.000000
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision: str = "v8w9x0y1z2a"
+down_revision: str | Sequence[str] | None = "u7v8w9x0y1z"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+finding_source_enum = sa.Enum("ZOMBIE_SCAN", name="findingsource")
+finding_status_enum = sa.Enum("OPEN", "RESOLVED", name="findingstatus")
+
+
+def upgrade() -> None:
+    finding_source_enum.create(op.get_bind(), checkfirst=True)
+    finding_status_enum.create(op.get_bind(), checkfirst=True)
+
+    op.create_table(
+        "optimization_findings",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("tenant_id", sa.Uuid(), nullable=False),
+        sa.Column("source", finding_source_enum, nullable=False, server_default="ZOMBIE_SCAN"),
+        sa.Column("status", finding_status_enum, nullable=False, server_default="OPEN"),
+        sa.Column("fingerprint", sa.String(length=64), nullable=False),
+        sa.Column("provider", sa.String(length=20), nullable=False),
+        sa.Column("category", sa.String(length=100), nullable=False),
+        sa.Column("connection_id", sa.Uuid(), nullable=False),
+        sa.Column("connection_name", sa.String(length=255), nullable=True),
+        sa.Column("resource_id", sa.String(length=255), nullable=False),
+        sa.Column("resource_type", sa.String(length=100), nullable=False),
+        sa.Column("region", sa.String(length=64), nullable=False, server_default="global"),
+        sa.Column("estimated_monthly_savings", sa.Numeric(12, 2), nullable=True),
+        sa.Column("confidence_score", sa.Numeric(4, 3), nullable=True),
+        sa.Column("explainability_notes", sa.String(length=2000), nullable=True),
+        sa.Column("requires_manual_review", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("automated_action_allowed", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column("decision_gate", sa.String(length=64), nullable=True),
+        sa.Column(
+            "payload",
+            sa.JSON().with_variant(postgresql.JSONB(astext_type=sa.Text()), "postgresql"),
+            nullable=False,
+            server_default=sa.text("'{}'"),
+        ),
+        sa.Column("first_detected_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("last_detected_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("resolved_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["tenant_id"], ["tenants.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("tenant_id", "fingerprint", name="uix_optimization_findings_tenant_fingerprint"),
+    )
+    op.create_index(
+        "ix_optimization_findings_tenant_status_last_detected",
+        "optimization_findings",
+        ["tenant_id", "status", "last_detected_at"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_optimization_findings_tenant_connection_region",
+        "optimization_findings",
+        ["tenant_id", "connection_id", "region"],
+        unique=False,
+    )
+    op.create_index(op.f("ix_optimization_findings_tenant_id"), "optimization_findings", ["tenant_id"], unique=False)
+    op.create_index(op.f("ix_optimization_findings_source"), "optimization_findings", ["source"], unique=False)
+    op.create_index(op.f("ix_optimization_findings_status"), "optimization_findings", ["status"], unique=False)
+    op.create_index(op.f("ix_optimization_findings_provider"), "optimization_findings", ["provider"], unique=False)
+    op.create_index(op.f("ix_optimization_findings_category"), "optimization_findings", ["category"], unique=False)
+    op.create_index(op.f("ix_optimization_findings_connection_id"), "optimization_findings", ["connection_id"], unique=False)
+    op.create_index(op.f("ix_optimization_findings_resource_id"), "optimization_findings", ["resource_id"], unique=False)
+    op.create_index(op.f("ix_optimization_findings_last_detected_at"), "optimization_findings", ["last_detected_at"], unique=False)
+
+    op.add_column(
+        "remediation_requests",
+        sa.Column("finding_id", sa.Uuid(), nullable=True),
+    )
+    op.add_column(
+        "remediation_requests",
+        sa.Column(
+            "finding_snapshot",
+            sa.JSON().with_variant(postgresql.JSONB(astext_type=sa.Text()), "postgresql"),
+            nullable=True,
+        ),
+    )
+    op.create_index(op.f("ix_remediation_requests_finding_id"), "remediation_requests", ["finding_id"], unique=False)
+    op.create_index(
+        "uix_remediation_requests_open_finding_action",
+        "remediation_requests",
+        ["tenant_id", "finding_id", "action"],
+        unique=True,
+        sqlite_where=sa.text(
+            "finding_id IS NOT NULL AND status IN "
+            "('PENDING', 'PENDING_APPROVAL', 'APPROVED', 'SCHEDULED', 'EXECUTING')"
+        ),
+        postgresql_where=sa.text(
+            "finding_id IS NOT NULL AND status IN "
+            "('PENDING', 'PENDING_APPROVAL', 'APPROVED', 'SCHEDULED', 'EXECUTING')"
+        ),
+    )
+    op.create_foreign_key(
+        "fk_remediation_requests_finding_id_optimization_findings",
+        "remediation_requests",
+        "optimization_findings",
+        ["finding_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
+    op.add_column(
+        "realized_savings_events",
+        sa.Column("finding_id", sa.Uuid(), nullable=True),
+    )
+    op.add_column(
+        "realized_savings_events",
+        sa.Column("finding_category", sa.String(length=100), nullable=True),
+    )
+    op.create_index(op.f("ix_realized_savings_events_finding_id"), "realized_savings_events", ["finding_id"], unique=False)
+    op.create_index(op.f("ix_realized_savings_events_finding_category"), "realized_savings_events", ["finding_category"], unique=False)
+    op.create_foreign_key(
+        "fk_realized_savings_events_finding_id_optimization_findings",
+        "realized_savings_events",
+        "optimization_findings",
+        ["finding_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
+    op.alter_column("optimization_findings", "source", server_default=None)
+    op.alter_column("optimization_findings", "status", server_default=None)
+    op.alter_column("optimization_findings", "region", server_default=None)
+    op.alter_column("optimization_findings", "requires_manual_review", server_default=None)
+    op.alter_column("optimization_findings", "automated_action_allowed", server_default=None)
+    op.alter_column("optimization_findings", "payload", server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "fk_realized_savings_events_finding_id_optimization_findings",
+        "realized_savings_events",
+        type_="foreignkey",
+    )
+    op.drop_index(op.f("ix_realized_savings_events_finding_category"), table_name="realized_savings_events")
+    op.drop_index(op.f("ix_realized_savings_events_finding_id"), table_name="realized_savings_events")
+    op.drop_column("realized_savings_events", "finding_category")
+    op.drop_column("realized_savings_events", "finding_id")
+
+    op.drop_constraint(
+        "fk_remediation_requests_finding_id_optimization_findings",
+        "remediation_requests",
+        type_="foreignkey",
+    )
+    op.drop_index(
+        "uix_remediation_requests_open_finding_action",
+        table_name="remediation_requests",
+    )
+    op.drop_index(op.f("ix_remediation_requests_finding_id"), table_name="remediation_requests")
+    op.drop_column("remediation_requests", "finding_snapshot")
+    op.drop_column("remediation_requests", "finding_id")
+
+    op.drop_index(op.f("ix_optimization_findings_last_detected_at"), table_name="optimization_findings")
+    op.drop_index(op.f("ix_optimization_findings_resource_id"), table_name="optimization_findings")
+    op.drop_index(op.f("ix_optimization_findings_connection_id"), table_name="optimization_findings")
+    op.drop_index(op.f("ix_optimization_findings_category"), table_name="optimization_findings")
+    op.drop_index(op.f("ix_optimization_findings_provider"), table_name="optimization_findings")
+    op.drop_index(op.f("ix_optimization_findings_status"), table_name="optimization_findings")
+    op.drop_index(op.f("ix_optimization_findings_source"), table_name="optimization_findings")
+    op.drop_index(op.f("ix_optimization_findings_tenant_id"), table_name="optimization_findings")
+    op.drop_index("ix_optimization_findings_tenant_connection_region", table_name="optimization_findings")
+    op.drop_index("ix_optimization_findings_tenant_status_last_detected", table_name="optimization_findings")
+    op.drop_table("optimization_findings")
+
+    finding_status_enum.drop(op.get_bind(), checkfirst=True)
+    finding_source_enum.drop(op.get_bind(), checkfirst=True)

--- a/scripts/finance_committee_packet_assumptions_engine.py
+++ b/scripts/finance_committee_packet_assumptions_engine.py
@@ -40,6 +40,8 @@ def _index_rows(rows: Any, *, field: str) -> dict[str, dict[str, Any]]:
         tier = str(row.get("tier", "")).strip().lower()
         if not tier:
             continue
+        if tier in indexed:
+            raise ValueError(f"{field} contains duplicate tier: {tier}")
         indexed[tier] = row
     return indexed
 

--- a/scripts/finance_committee_packet_common.py
+++ b/scripts/finance_committee_packet_common.py
@@ -74,6 +74,8 @@ def index_by_tier(rows: list[dict[str, Any]], *, field: str) -> dict[str, dict[s
         if not isinstance(row, dict):
             raise ValueError(f"{field}[{idx}] must be an object")
         tier = parse_non_empty_str(row.get("tier"), field=f"{field}[{idx}].tier").lower()
+        if tier in indexed:
+            raise ValueError(f"{field} contains duplicate tier: {tier}")
         indexed[tier] = row
     return indexed
 

--- a/scripts/generate_enforcement_failure_injection_evidence.py
+++ b/scripts/generate_enforcement_failure_injection_evidence.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import subprocess  # nosec B404 - controlled local pytest invocation only
 import sys
 import time
@@ -107,6 +108,12 @@ def _run_scenario(scenario: FailureScenario, *, cwd: Path) -> tuple[dict[str, ob
         "-q",
         *(_validate_selector(selector) for selector in scenario.selectors),
     ]
+    subprocess_env = os.environ.copy()
+    subprocess_env.pop("DATABASE_URL", None)
+    subprocess_env.pop("DB_SSL_MODE", None)
+    subprocess_env.pop("PGSSLMODE", None)
+    subprocess_env["TESTING"] = "true"
+    subprocess_env["DEBUG"] = "false"
     started = time.perf_counter()
     result = subprocess.run(
         command,
@@ -114,6 +121,7 @@ def _run_scenario(scenario: FailureScenario, *, cwd: Path) -> tuple[dict[str, ob
         capture_output=True,
         text=True,
         check=False,
+        env=subprocess_env,
     )  # nosec B603 - pytest invocation uses static repo-local selectors
     duration_seconds = round(time.perf_counter() - started, 3)
     passed = result.returncode == 0
@@ -140,7 +148,11 @@ def generate_evidence(
     profile: str,
     cwd: Path,
 ) -> tuple[dict[str, object], bool]:
-    if executed_by.strip() == approved_by.strip():
+    normalized_executed_by = executed_by.strip()
+    normalized_approved_by = approved_by.strip()
+    if not normalized_executed_by or not normalized_approved_by:
+        raise ValueError("executed_by and approved_by must be non-empty")
+    if normalized_executed_by == normalized_approved_by:
         raise ValueError("executed_by and approved_by must be distinct")
 
     scenario_rows: list[dict[str, object]] = []
@@ -160,8 +172,8 @@ def generate_evidence(
         "runner": "staged_failure_injection",
         "execution_class": "staged",
         "captured_at": datetime.now(timezone.utc).isoformat(),
-        "executed_by": executed_by.strip(),
-        "approved_by": approved_by.strip(),
+        "executed_by": normalized_executed_by,
+        "approved_by": normalized_approved_by,
         "scenarios": scenario_rows,
         "summary": {
             "total_scenarios": total,

--- a/scripts/generate_feature_enforceability_matrix.py
+++ b/scripts/generate_feature_enforceability_matrix.py
@@ -42,12 +42,12 @@ def _feature_evidence_for_file(*, token: str, raw: str) -> bool:
 
 def _feature_runtime_gate_for_file(*, token: str, raw: str) -> bool:
     patterns = (
-        rf"requires_feature\([^\n]*{re.escape(token)}",
-        rf"is_feature_enabled\([^\n]*{re.escape(token)}",
+        rf"requires_feature\([^)]*{re.escape(token)}",
+        rf"is_feature_enabled\([^)]*{re.escape(token)}",
         rf"require_feature_or_403\([^)]*{re.escape(token)}",
         rf"require_features_or_403\([^)]*{re.escape(token)}",
     )
-    return any(re.search(pattern, raw, flags=re.DOTALL) for pattern in patterns)
+    return any(re.search(pattern, raw) for pattern in patterns)
 
 
 def collect_enforceability(*, repo_root: Path) -> dict[FeatureFlag, EnforceabilityEvidence]:

--- a/scripts/generate_key_rotation_drill_evidence.py
+++ b/scripts/generate_key_rotation_drill_evidence.py
@@ -234,6 +234,7 @@ def _build_markdown(
     field_results: dict[str, bool],
     selector_results: dict[str, bool],
     _selector_logs: dict[str, str],
+    overall_passed: bool,
 ) -> str:
     now = datetime.now(timezone.utc).replace(microsecond=0)
     drill_date = now.date().isoformat()
@@ -271,7 +272,7 @@ def _build_markdown(
         f"- replay_protection_intact: {str(field_results['replay_protection_intact']).lower()}\n"
         f"- alert_pipeline_verified: {str(field_results['alert_pipeline_verified']).lower()}\n"
         f"- endpoint_replay_tamper_guard: {str(endpoint_guard_result).lower()}\n"
-        "- post_drill_status: PASS\n\n"
+        f"- post_drill_status: {'PASS' if overall_passed else 'FAIL'}\n\n"
         "## Executed Selector Summary\n\n"
         f"- total_selectors_run: {len(_all_drill_checks())}\n"
     )
@@ -284,16 +285,7 @@ def main(argv: list[str] | None = None) -> int:
         retries=int(args.selector_retries),
     )
     failed = [key for key, passed in field_results.items() if not passed]
-    if failed and not bool(args.allow_check_failures):
-        details = "\n".join(
-            f"{selector}: {selector_logs.get(selector, '')}"
-            for selector in sorted(selector_logs)
-        )
-        raise RuntimeError(
-            "key-rotation live checks failed for: "
-            + ", ".join(sorted(failed))
-            + f"\n{details}"
-        )
+    overall_passed = not failed
 
     output_path = Path(str(args.output))
     output_path.parent.mkdir(parents=True, exist_ok=True)
@@ -302,9 +294,29 @@ def main(argv: list[str] | None = None) -> int:
             field_results=field_results,
             selector_results=selector_results,
             _selector_logs=selector_logs,
+            overall_passed=overall_passed,
         ),
         encoding="utf-8",
     )
+
+    if failed:
+        details = "\n".join(
+            f"{selector}: {selector_logs.get(selector, '')}"
+            for selector in sorted(selector_logs)
+        )
+        print(f"Generated key-rotation drill evidence: {output_path}")
+        if bool(args.allow_check_failures):
+            print(
+                "Key-rotation drill evidence captured failing selectors: "
+                + ", ".join(sorted(failed))
+            )
+            return 2
+        raise RuntimeError(
+            "key-rotation live checks failed for: "
+            + ", ".join(sorted(failed))
+            + f"\n{details}"
+        )
+
     verify_key_rotation_drill_evidence(
         drill_path=output_path,
         max_drill_age_days=float(args.max_drill_age_days),

--- a/scripts/generate_local_dev_env.py
+++ b/scripts/generate_local_dev_env.py
@@ -92,6 +92,7 @@ def generate_local_dev_env(
         template_path.read_text(encoding="utf-8").splitlines(),
         _build_overrides(seed),
     )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(rendered, encoding="utf-8")
     return output_path
 

--- a/scripts/generate_pkg_fin_policy_decisions.py
+++ b/scripts/generate_pkg_fin_policy_decisions.py
@@ -85,6 +85,8 @@ def _index_rows(rows: Any, *, key_field: str, field: str) -> dict[str, dict[str,
         key = str(row.get(key_field) or "").strip().lower()
         if not key:
             raise ValueError(f"{field}[{idx}].{key_field} must be a non-empty string")
+        if key in indexed:
+            raise ValueError(f"{field} contains duplicate {key_field}: {key}")
         indexed[key] = row
     return indexed
 

--- a/scripts/generate_provenance_manifest.py
+++ b/scripts/generate_provenance_manifest.py
@@ -34,6 +34,43 @@ def _utc_now_iso() -> str:
     return now.isoformat().replace("+00:00", "Z")
 
 
+def _normalize_repo_relative_path(
+    repo_root: Path,
+    path: Path,
+    *,
+    field: str,
+) -> Path:
+    raw = Path(path)
+    if raw.is_absolute():
+        raise ValueError(f"{field} must be relative to repo root")
+
+    resolved = (repo_root / raw).resolve()
+    try:
+        return resolved.relative_to(repo_root)
+    except ValueError as exc:
+        raise ValueError(f"{field} must stay within repo root: {raw.as_posix()}") from exc
+
+
+def _normalize_dependency_inputs(
+    repo_root: Path,
+    dependency_inputs: Sequence[Path],
+) -> tuple[Path, ...]:
+    normalized_paths: list[Path] = []
+    seen_paths: set[str] = set()
+    for idx, dependency_input in enumerate(dependency_inputs):
+        normalized = _normalize_repo_relative_path(
+            repo_root,
+            Path(dependency_input),
+            field=f"dependency_inputs[{idx}]",
+        )
+        key = normalized.as_posix()
+        if key in seen_paths:
+            raise ValueError(f"dependency_inputs contains duplicate path: {key}")
+        seen_paths.add(key)
+        normalized_paths.append(normalized)
+    return tuple(normalized_paths)
+
+
 def _resolve_file(repo_root: Path, relative_path: Path) -> Path:
     candidate = repo_root / relative_path
     if not candidate.exists() or not candidate.is_file():
@@ -56,10 +93,15 @@ def _build_sbom_entries(repo_root: Path, sbom_dir: Path | None) -> list[dict[str
     if sbom_dir is None:
         return []
 
-    absolute_sbom_dir = (repo_root / sbom_dir).resolve()
+    normalized_sbom_dir = _normalize_repo_relative_path(
+        repo_root,
+        sbom_dir,
+        field="sbom_dir",
+    )
+    absolute_sbom_dir = (repo_root / normalized_sbom_dir).resolve()
     if not absolute_sbom_dir.exists() or not absolute_sbom_dir.is_dir():
         raise FileNotFoundError(
-            f"SBOM directory does not exist: {sbom_dir.as_posix()}"
+            f"SBOM directory does not exist: {normalized_sbom_dir.as_posix()}"
         )
 
     entries: list[dict[str, Any]] = []
@@ -82,11 +124,16 @@ def generate_provenance_manifest(
     sbom_dir: Path | None,
     env: Mapping[str, str],
 ) -> dict[str, Any]:
+    resolved_repo_root = repo_root.resolve()
+    normalized_dependency_inputs = _normalize_dependency_inputs(
+        resolved_repo_root,
+        dependency_inputs,
+    )
     dependency_entries = [
-        _build_file_digest_entry(repo_root, relative_path)
-        for relative_path in dependency_inputs
+        _build_file_digest_entry(resolved_repo_root, relative_path)
+        for relative_path in normalized_dependency_inputs
     ]
-    sbom_entries = _build_sbom_entries(repo_root, sbom_dir)
+    sbom_entries = _build_sbom_entries(resolved_repo_root, sbom_dir)
 
     repository = env.get("GITHUB_REPOSITORY", "")
     run_id = env.get("GITHUB_RUN_ID", "")

--- a/scripts/verify_finance_guardrails_evidence.py
+++ b/scripts/verify_finance_guardrails_evidence.py
@@ -222,6 +222,8 @@ def verify_evidence(
         tier = str(item.get("tier") or "").strip().lower()
         if not tier:
             raise ValueError(f"tier_unit_economics[{idx}].tier must be a non-empty string")
+        if tier in seen_tiers:
+            raise ValueError(f"tier_unit_economics contains duplicate tier: {tier}")
         seen_tiers.add(tier)
 
         mrr_usd = _parse_float(

--- a/scripts/verify_key_rotation_drill_evidence.py
+++ b/scripts/verify_key_rotation_drill_evidence.py
@@ -27,6 +27,7 @@ REQUIRED_BOOL_FIELDS: tuple[str, ...] = (
     "rollback_validation_passed",
     "replay_protection_intact",
     "alert_pipeline_verified",
+    "endpoint_replay_tamper_guard",
 )
 
 REQUIRED_SOURCE_FIELDS: tuple[str, ...] = tuple(

--- a/scripts/verify_valdrics_disposition_freshness.py
+++ b/scripts/verify_valdrics_disposition_freshness.py
@@ -237,6 +237,23 @@ def verify_disposition_register(
                     f"dispositions[{idx}].control_probe_ids[{probe_idx}] "
                     f"references missing runtime probe: {probe_id}"
                 )
+        referenced_probe_results = [
+            probe_results[str(probe_id_value).strip()]
+            for probe_id_value in control_probe_ids
+        ]
+        all_referenced_probes_passed = all(
+            bool(item.get("passed")) for item in referenced_probe_results
+        )
+        if status == "documented_exception" and not all_referenced_probes_passed:
+            raise ValueError(
+                f"dispositions[{idx}] with status documented_exception must reference "
+                "only passing runtime probes"
+            )
+        if status == "planned_refactor" and all_referenced_probes_passed:
+            raise ValueError(
+                f"dispositions[{idx}] with status planned_refactor must reference at "
+                "least one failing runtime probe"
+            )
 
         review_by = _parse_iso_date(
             item.get("review_by"),

--- a/tests/api/test_api_endpoints.py
+++ b/tests/api/test_api_endpoints.py
@@ -97,10 +97,8 @@ class TestZombiesEndpoint:
         response = await ac.post(
             "/api/v1/zombies/request",
             json={
-                "resource_id": "test-123",
-                "resource_type": "volume",
+                "finding_id": "00000000-0000-0000-0000-000000000001",
                 "action": "delete_volume",
-                "estimated_savings": 10.0,
             },
         )
 

--- a/tests/api/test_endpoints_security_auth.py
+++ b/tests/api/test_endpoints_security_auth.py
@@ -198,11 +198,8 @@ class TestAuthorizationAndAuthentication:
         response = await ac.post(
             "/api/v1/zombies/request",
             json={
-                "resource_id": "test",
-                "resource_type": "ec2_instance",
+                "finding_id": str(uuid4()),
                 "action": "stop_instance",
-                "provider": "aws",
-                "estimated_savings": 50.0,
             },
         )
 
@@ -213,4 +210,3 @@ class TestAuthorizationAndAuthentication:
         ac.app.dependency_overrides.pop(get_current_user, None)
         ac.app.dependency_overrides.pop(require_tenant_access, None)
         ac.app.dependency_overrides.pop(dep, None)
-

--- a/tests/api/test_endpoints_validation_jobs.py
+++ b/tests/api/test_endpoints_validation_jobs.py
@@ -38,7 +38,7 @@ class TestInputValidation:
         ac.app.dependency_overrides[FeatureFlag.AUTO_REMEDIATION] = lambda: True
 
         # Missing required fields
-        incomplete_data = {"resource_type": "ec2_instance"}
+        incomplete_data = {"action": "stop_instance"}
 
         response = await ac.post("/api/v1/zombies/request", json=incomplete_data)
 
@@ -72,11 +72,8 @@ class TestInputValidation:
 
         # Invalid action enum value
         invalid_data = {
-            "resource_id": "i-test123",
-            "resource_type": "ec2_instance",
+            "finding_id": str(uuid4()),
             "action": "invalid_action_name",
-            "provider": "aws",
-            "estimated_savings": 50.0,
         }
 
         response = await ac.post("/api/v1/zombies/request", json=invalid_data)
@@ -183,5 +180,4 @@ class TestBackgroundJobsAPI:
         # Clean up overrides
         ac.app.dependency_overrides.pop(get_current_user, None)
         ac.app.dependency_overrides.pop(require_tenant_access, None)
-
 

--- a/tests/api/test_endpoints_zombies_plan_policy.py
+++ b/tests/api/test_endpoints_zombies_plan_policy.py
@@ -156,7 +156,7 @@ class TestZombieAPIPlanAndPolicyPreview:
             "app.modules.optimization.api.v1.zombies.RemediationService"
         ) as mock_service_cls:
             mock_service = mock_service_cls.return_value
-            mock_service.preview_policy_input = AsyncMock(return_value={
+            mock_service.preview_policy_for_finding = AsyncMock(return_value={
                 "decision": "escalate",
                 "summary": "GPU-related remediation requires explicit GPU approval override.",
                 "tier": "pro",
@@ -172,12 +172,8 @@ class TestZombieAPIPlanAndPolicyPreview:
             response = await ac.post(
                 "/api/v1/zombies/policy-preview",
                 json={
-                    "resource_id": "i-gpu-smoke",
-                    "resource_type": "GPU Compute",
+                    "finding_id": str(uuid4()),
                     "action": "terminate_instance",
-                    "provider": "aws",
-                    "confidence_score": 0.88,
-                    "explainability_notes": "gpu workload",
                 },
             )
             assert response.status_code == 200
@@ -210,10 +206,8 @@ class TestZombieAPIPlanAndPolicyPreview:
         response = await ac.post(
             "/api/v1/zombies/policy-preview",
             json={
-                "resource_id": "i-gpu-smoke",
-                "resource_type": "GPU Compute",
+                "finding_id": str(uuid4()),
                 "action": "invalid_action",
-                "provider": "aws",
             },
         )
         assert response.status_code == 400
@@ -223,5 +217,3 @@ class TestZombieAPIPlanAndPolicyPreview:
         ac.app.dependency_overrides.pop(get_current_user, None)
         ac.app.dependency_overrides.pop(require_tenant_access, None)
         ac.app.dependency_overrides.pop(FeatureFlag.POLICY_PREVIEW, None)
-
-

--- a/tests/api/test_endpoints_zombies_scan_requests.py
+++ b/tests/api/test_endpoints_zombies_scan_requests.py
@@ -1,9 +1,12 @@
 """Zombie API endpoint tests: scan, request creation, and pending listing flows."""
 
+from datetime import datetime, timezone
 import pytest
 from uuid import uuid4
 from unittest.mock import AsyncMock, MagicMock, patch
 from httpx import AsyncClient
+
+from app.models.remediation import RemediationStatus
 
 class TestZombieAPIScanAndRequests:
     """Tests for zombie scan and remediation request/list flows."""
@@ -142,11 +145,8 @@ class TestZombieAPIScanAndRequests:
     ):
         """Test successful remediation request creation."""
         request_data = {
-            "resource_id": "i-test123",
-            "resource_type": "ec2_instance",
+            "finding_id": str(uuid4()),
             "action": "stop_instance",
-            "provider": "aws",
-            "estimated_savings": 50.0,
         }
 
         # Mock authentication by overriding the app's dependency
@@ -175,7 +175,7 @@ class TestZombieAPIScanAndRequests:
             mock_service = mock_service_cls.return_value
             mock_result = MagicMock()
             mock_result.id = uuid4()
-            mock_service.create_request = AsyncMock(return_value=mock_result)
+            mock_service.create_request_from_finding = AsyncMock(return_value=mock_result)
 
             response = await ac.post("/api/v1/zombies/request", json=request_data)
 
@@ -195,11 +195,8 @@ class TestZombieAPIScanAndRequests:
     ):
         """Test remediation request creation with invalid action."""
         request_data = {
-            "resource_id": "i-test123",
-            "resource_type": "ec2_instance",
+            "finding_id": str(uuid4()),
             "action": "invalid_action",
-            "provider": "aws",
-            "estimated_savings": 50.0,
         }
 
         # Mock authentication by overriding the app's dependency
@@ -254,6 +251,11 @@ class TestZombieAPIScanAndRequests:
             "app.modules.optimization.api.v1.zombies.RemediationService"
         ) as mock_service_cls:
             mock_service = mock_service_cls.return_value
+            test_remediation_request.finding_id = uuid4()
+            test_remediation_request.finding_snapshot = {
+                "status": "open",
+                "category": "idle_instances",
+            }
             mock_service.list_pending = AsyncMock(return_value=[test_remediation_request])
 
             response = await ac.get("/api/v1/zombies/pending")
@@ -264,6 +266,8 @@ class TestZombieAPIScanAndRequests:
             assert len(data["requests"]) == 1
             assert data["requests"][0]["resource_id"] == "i-test123"
             assert data["requests"][0]["status"] == "pending"
+            assert data["requests"][0]["finding_status"] == "open"
+            assert data["requests"][0]["finding_category"] == "idle_instances"
 
         # Clean up overrides
         ac.app.dependency_overrides.pop(get_current_user, None)
@@ -326,3 +330,46 @@ class TestZombieAPIScanAndRequests:
         ac.app.dependency_overrides.pop(get_current_user, None)
         ac.app.dependency_overrides.pop(require_tenant_access, None)
 
+    @pytest.mark.asyncio
+    async def test_list_remediation_history_success(
+        self, ac: AsyncClient, test_tenant, mock_user, test_remediation_request
+    ):
+        """Test successful listing of completed remediation history."""
+        from app.shared.core.auth import get_current_user, require_tenant_access
+
+        async def mock_get_current_user():
+            return mock_user
+
+        async def mock_require_tenant_access():
+            return test_tenant.id
+
+        ac.app.dependency_overrides[get_current_user] = mock_get_current_user
+        ac.app.dependency_overrides[require_tenant_access] = mock_require_tenant_access
+
+        with patch(
+            "app.modules.optimization.api.v1.zombies.RemediationService"
+        ) as mock_service_cls:
+            mock_service = mock_service_cls.return_value
+            test_remediation_request.status = RemediationStatus.COMPLETED
+            test_remediation_request.executed_at = datetime.now(timezone.utc)
+            test_remediation_request.finding_id = uuid4()
+            test_remediation_request.finding_snapshot = {
+                "status": "resolved",
+                "category": "idle_instances",
+            }
+            mock_service.list_history = AsyncMock(return_value=[test_remediation_request])
+
+            response = await ac.get("/api/v1/zombies/history")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["history_count"] == 1
+            assert data["status"] == "completed"
+            assert len(data["requests"]) == 1
+            assert data["requests"][0]["status"] == "completed"
+            assert data["requests"][0]["finding_status"] == "resolved"
+            assert data["requests"][0]["finding_category"] == "idle_instances"
+            assert data["requests"][0]["executed_at"] is not None
+
+        ac.app.dependency_overrides.pop(get_current_user, None)
+        ac.app.dependency_overrides.pop(require_tenant_access, None)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ Provides:
 
 pytest_plugins = ("tests.unit.shared.adapters.aws_cur_test_helpers",)
 
+import asyncio
 import os
 import sys
 from pathlib import Path
@@ -172,8 +173,8 @@ tenacity.retry = mock_retry
 # ============================================================================
 
 
-@pytest_asyncio.fixture
-async def async_engine(tmp_path_factory):
+@pytest.fixture
+def async_engine(tmp_path_factory):
     """Create async SQLite engine for testing using a temporary file."""
     from sqlalchemy.ext.asyncio import create_async_engine
 
@@ -182,7 +183,7 @@ async def async_engine(tmp_path_factory):
 
     engine = create_async_engine(db_url, echo=False)
     yield engine
-    await engine.dispose()
+    asyncio.run(engine.dispose())
 
     for suffix in ("", "-journal", "-shm", "-wal"):
         Path(f"{db_path}{suffix}").unlink(missing_ok=True)
@@ -241,12 +242,58 @@ def client(app) -> Generator["TestClient", None, None]:
 @pytest_asyncio.fixture
 async def async_client(
     app,
-    db,
-    async_engine,
+    request,
 ) -> AsyncGenerator["AsyncClient", None]:
     """Async test client for FastAPI. Overrides get_db to share test session."""
     from httpx import AsyncClient, ASGITransport
     from app.shared.db.session import get_db, get_system_db
+
+    from contextlib import ExitStack
+
+    old_override = app.dependency_overrides.get(get_db)
+    old_system_override = app.dependency_overrides.get(get_system_db)
+
+    # Fast API/auth smoke tests do not need the full DB bootstrap path.
+    if "db" not in request.fixturenames:
+        from fastapi.testclient import TestClient
+
+        class _AsyncClientAdapter:
+            def __init__(self, client: TestClient, bound_app) -> None:
+                self._client = client
+                self.app = bound_app
+
+            async def get(self, *args, **kwargs):
+                return await asyncio.to_thread(self._client.get, *args, **kwargs)
+
+            async def post(self, *args, **kwargs):
+                return await asyncio.to_thread(self._client.post, *args, **kwargs)
+
+            async def delete(self, *args, **kwargs):
+                return await asyncio.to_thread(self._client.delete, *args, **kwargs)
+
+            async def options(self, *args, **kwargs):
+                return await asyncio.to_thread(self._client.options, *args, **kwargs)
+
+        mock_db = MagicMock()
+        app.dependency_overrides[get_db] = lambda: mock_db
+        app.dependency_overrides[get_system_db] = lambda: mock_db
+
+        with TestClient(app) as client:
+            yield _AsyncClientAdapter(client, app)
+
+        if old_override:
+            app.dependency_overrides[get_db] = old_override
+        else:
+            app.dependency_overrides.pop(get_db, None)
+
+        if old_system_override:
+            app.dependency_overrides[get_system_db] = old_system_override
+        else:
+            app.dependency_overrides.pop(get_system_db, None)
+        return
+
+    db = request.getfixturevalue("db")
+    async_engine = request.getfixturevalue("async_engine")
 
     # Create test global session maker
     from sqlalchemy.ext.asyncio import async_sessionmaker, AsyncSession
@@ -256,6 +303,7 @@ async def async_client(
         class_=AsyncSession,
         expire_on_commit=False,
     )
+    transport = ASGITransport(app=app)
 
     # Patch all modules that use the global async_session_maker directly
     # to ensure they use our test session maker connected to the test DB.
@@ -270,8 +318,6 @@ async def async_client(
         "app.main.async_session_maker",
     ]
 
-    from contextlib import ExitStack
-
     with ExitStack() as stack:
         for target in modules_to_patch:
             try:
@@ -280,13 +326,9 @@ async def async_client(
                 # Some modules might not be loaded yet or don't have it
                 continue
 
-        # Store old override if any
-        old_override = app.dependency_overrides.get(get_db)
-        old_system_override = app.dependency_overrides.get(get_system_db)
         app.dependency_overrides[get_db] = lambda: db
         app.dependency_overrides[get_system_db] = lambda: db
 
-        transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as ac:
             setattr(ac, "app", app)  # SEC: Attach app for dependency overrides in tests
             yield ac
@@ -303,14 +345,14 @@ async def async_client(
             app.dependency_overrides.pop(get_system_db, None)
 
 
-@pytest_asyncio.fixture
-async def ac(async_client):
+@pytest.fixture
+def ac(async_client):
     """Alias for async_client to match integration tests."""
     return async_client
 
 
-@pytest_asyncio.fixture
-async def db(db_session):
+@pytest.fixture
+def db(db_session):
     """Alias for db_session to match integration tests."""
     return db_session
 

--- a/tests/governance/test_audit_phase_1.py
+++ b/tests/governance/test_audit_phase_1.py
@@ -38,10 +38,8 @@ async def test_csrf_middleware_behavior() -> None:
         response = await ac.post(
             "/api/v1/zombies/request",
             json={
-                "resource_id": "test",
-                "resource_type": "instance",
+                "finding_id": "00000000-0000-0000-0000-000000000001",
                 "action": "delete_volume",
-                "estimated_savings": 10,
             },
         )
         # Expect 401 (no auth) - CSRF is checked after auth in FastAPI

--- a/tests/governance/test_detector.py
+++ b/tests/governance/test_detector.py
@@ -91,6 +91,10 @@ async def test_create_remediation_request(
 ) -> None:
     tenant_id = uuid4()
     user_id = uuid4()
+    connection_id = uuid4()
+    service.get_by_id = AsyncMock(  # type: ignore[method-assign]
+        return_value=MagicMock(id=connection_id, tenant_id=tenant_id, status="active")
+    )
 
     req = await service.create_request(
         tenant_id=tenant_id,
@@ -100,6 +104,7 @@ async def test_create_remediation_request(
         action=RemediationAction.DELETE_VOLUME,
         estimated_savings=20.0,
         provider="aws",
+        connection_id=connection_id,
     )
 
     assert req.status == RemediationStatus.PENDING

--- a/tests/integration/optimization/test_remediation_lifecycle.py
+++ b/tests/integration/optimization/test_remediation_lifecycle.py
@@ -1,13 +1,20 @@
 import pytest
 import boto3
 from moto import mock_aws
+from decimal import Decimal
+from datetime import datetime, timedelta, timezone
 from uuid import uuid4
 from sqlalchemy import select
 from httpx import AsyncClient
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 from app.models.tenant import Tenant, User, UserRole
 from app.models.aws_connection import AWSConnection
+from app.models.optimization import FindingStatus, OptimizationFinding
+from app.models.realized_savings import RealizedSavingsEvent
 from app.models.remediation import RemediationRequest, RemediationStatus
+from app.modules.reporting.domain.realized_savings import RealizedSavingsService
 from app.shared.core.pricing import PricingTier
 from tests.utils import create_test_token
 
@@ -145,24 +152,75 @@ async def test_remediation_lifecycle_full(
         with pytest.MonkeyPatch.context() as mp:
             mp.setattr(aioboto3.Session, "client", mock_client)
             mp.setattr(MultiTenantAWSAdapter, "get_credentials", mock_get_credentials)
+            fake_detector = SimpleNamespace(
+                provider_name="aws",
+                get_credentials=AsyncMock(
+                    return_value={
+                        "AccessKeyId": "testing",
+                        "SecretAccessKey": "testing",
+                        "SessionToken": "testing",
+                    }
+                ),
+                scan_all=AsyncMock(
+                    return_value={
+                        "idle_instances": [
+                            {
+                                "resource_id": instance_id,
+                                "resource_type": "ec2_instance",
+                                "monthly_cost": 15.5,
+                            }
+                        ]
+                    }
+                ),
+            )
+            mp.setattr(
+                "app.modules.optimization.domain.service.ZombieDetectorFactory",
+                SimpleNamespace(get_detector=lambda *_args, **_kwargs: fake_detector),
+            )
+            mp.setattr(
+                "app.modules.optimization.adapters.aws.region_discovery.RegionDiscovery.get_enabled_regions",
+                AsyncMock(return_value=["us-east-1"]),
+            )
 
             # 1. Run Scan
             response = await ac.get("/api/v1/zombies?region=us-east-1", headers=headers)
             assert response.status_code == 200
+            scan_payload = response.json()
+            finding_id = None
+            for bucket in scan_payload.values():
+                if not isinstance(bucket, list):
+                    continue
+                for item in bucket:
+                    if not isinstance(item, dict):
+                        continue
+                    if item.get("resource_id") != instance_id:
+                        continue
+                    finding_id = item.get("finding_id")
+                    if finding_id:
+                        break
+                if finding_id:
+                    break
+            assert finding_id
 
             # 2. Request Remediation
             req_payload = {
-                "resource_id": instance_id,
-                "resource_type": "EC2 Instance",
+                "finding_id": finding_id,
                 "action": "terminate_instance",
-                "provider": "aws",
-                "estimated_savings": 15.50,
             }
             response = await ac.post(
                 "/api/v1/zombies/request", json=req_payload, headers=headers
             )
             assert response.status_code == 200
             request_id = response.json()["request_id"]
+
+            duplicate_response = await ac.post(
+                "/api/v1/zombies/request", json=req_payload, headers=headers
+            )
+            assert duplicate_response.status_code == 409
+            assert (
+                duplicate_response.json()["error"]["code"]
+                == "remediation_request_duplicate_open_finding"
+            )
 
             # 3. Approve
             response = await ac.post(
@@ -197,3 +255,45 @@ async def test_remediation_lifecycle_full(
             )
             rem = result.scalar_one()
             assert rem.status == RemediationStatus.COMPLETED
+            assert rem.finding_id is not None
+            rem.executed_at = datetime.now(timezone.utc) - timedelta(days=2)
+
+            finding_result = await db.execute(
+                select(OptimizationFinding).where(
+                    OptimizationFinding.id == UUID(finding_id)
+                )
+            )
+            finding = finding_result.scalar_one()
+            assert finding.status == FindingStatus.RESOLVED
+
+            service = RealizedSavingsService(db)
+            with pytest.MonkeyPatch.context() as savings_mp:
+                savings_mp.setattr(
+                    service,
+                    "_window_cost",
+                    AsyncMock(side_effect=[(Decimal("12.00"), 1), (Decimal("3.00"), 1)]),
+                )
+                event = await service.compute_for_request(
+                    tenant_id=setup_opt_data["tenant"].id,
+                    request=rem,
+                    baseline_days=1,
+                    measurement_days=1,
+                    gap_days=0,
+                    monthly_multiplier_days=30,
+                    require_final=False,
+                )
+
+            assert event is not None
+            assert event.finding_id == rem.finding_id
+            assert event.finding_category == "idle_instances"
+            assert event.realized_monthly_savings_usd == Decimal("270.00")
+            await db.commit()
+
+            event_result = await db.execute(
+                select(RealizedSavingsEvent).where(
+                    RealizedSavingsEvent.remediation_request_id == rem.id
+                )
+            )
+            persisted_event = event_result.scalar_one()
+            assert persisted_event.finding_id == rem.finding_id
+            assert persisted_event.finding_category == "idle_instances"

--- a/tests/security/test_privilege_escalation.py
+++ b/tests/security/test_privilege_escalation.py
@@ -71,7 +71,7 @@ async def test_member_cannot_process_jobs(ac: AsyncClient):
 
 @pytest.mark.asyncio
 async def test_admin_can_process_jobs(ac: AsyncClient):
-    """Verify that an admin CAN trigger job processing."""
+    """Verify that tenant admins cannot trigger platform-global job processing."""
 
     def override_admin_a(request: Request):
         request.state.tenant_id = ADMIN_A.tenant_id
@@ -83,8 +83,7 @@ async def test_admin_can_process_jobs(ac: AsyncClient):
 
     response = await ac.post("/api/v1/jobs/process")
 
-    # Might be 200 or 500 depending on DB, but should NOT be 403
-    assert response.status_code != 403
+    assert response.status_code == 403
     app.dependency_overrides.pop(get_current_user, None)
 
 
@@ -166,9 +165,6 @@ async def test_member_cannot_enqueue_restricted_jobs(ac: AsyncClient):
 
     resp = await ac.post("/api/v1/jobs/enqueue", json=payload)
 
-    # Changed to 403 because role check (RequireRole) or endpoint validation happens before Pydantic.
-    # The endpoint explicitly raises 403 for unauthorized job types.
     assert resp.status_code == 403
-    # In Pydantic 2, the error message for Forbidden job type (literal) might be more structured
-    assert "Input should be" in resp.text or "Unauthorized job type" in resp.text
+    assert "Insufficient permissions" in resp.text
     app.dependency_overrides.pop(get_current_user, None)

--- a/tests/unit/api/v1/test_savings_branch_paths.py
+++ b/tests/unit/api/v1/test_savings_branch_paths.py
@@ -418,7 +418,10 @@ async def test_list_realized_savings_events_csv_sanitizes_formula_cells() -> Non
     )
 
     rows = list(csv.reader(csv_response.body.decode().splitlines()))
-    assert rows[1][1] == "'=AWS"
-    assert rows[1][3] == "Compute,Edge"
-    assert rows[1][5] == "'+post_action_delta"
-    assert rows[1][13] == "72.0"
+    header = rows[0]
+    values = rows[1]
+    row = dict(zip(header, values, strict=False))
+    assert row["provider"] == "'=AWS"
+    assert row["resource_id"] == "Compute,Edge"
+    assert row["method"] == "'+post_action_delta"
+    assert row["realized_monthly_savings_usd"] == "72.0"

--- a/tests/unit/core/test_health_deep.py
+++ b/tests/unit/core/test_health_deep.py
@@ -1,3 +1,4 @@
+import asyncio
 import sqlite3
 import pytest
 from types import SimpleNamespace
@@ -335,3 +336,69 @@ async def test_run_health_check_rejects_non_mapping_payload():
     assert result["status"] == "unhealthy"
     assert result["component"] == "cache"
     assert result["error"] == "Health check returned non-dict payload"
+
+
+@pytest.mark.asyncio
+async def test_run_health_check_times_out_with_component_fallback():
+    service = HealthService()
+
+    async def slow_check():
+        await asyncio.sleep(0.05)
+        return {"status": "healthy"}
+
+    with patch.object(service, "_health_timeout_seconds", return_value=0.01):
+        result = await service._run_health_check(
+            slow_check(),
+            component="external_services",
+        )
+
+    assert result["status"] == "degraded"
+    assert "timed out" in result["error"]
+    assert result["component"] == "external_services"
+
+
+@pytest.mark.asyncio
+async def test_comprehensive_health_check_disables_networked_checks_in_testing():
+    service = HealthService()
+
+    with (
+        patch.object(service, "_testing_mode", return_value=True),
+        patch.object(
+            service,
+            "_check_database",
+            return_value={"status": "up", "latency_ms": 1},
+        ),
+        patch.object(
+            service,
+            "_check_cache",
+            new=AsyncMock(side_effect=AssertionError("cache check should be skipped")),
+        ),
+        patch.object(
+            service,
+            "_check_external_services",
+            new=AsyncMock(
+                side_effect=AssertionError("external check should be skipped")
+            ),
+        ),
+        patch.object(
+            service,
+            "_check_circuit_breakers",
+            return_value={"status": "healthy"},
+        ),
+        patch.object(
+            service,
+            "_check_system_resources",
+            return_value={"status": "healthy"},
+        ),
+        patch.object(
+            service,
+            "_check_background_jobs",
+            return_value={"status": "healthy"},
+        ),
+    ):
+        result = await service.comprehensive_health_check()
+
+    assert result["status"] == "healthy"
+    assert result["checks"]["cache"]["status"] == "disabled"
+    assert result["checks"]["external_services"]["status"] == "disabled"
+    assert result["checks"]["external_services"]["services"]["aws_sts"]["status"] == "disabled"

--- a/tests/unit/db/test_session_branch_paths_2.py
+++ b/tests/unit/db/test_session_branch_paths_2.py
@@ -275,14 +275,15 @@ def test_get_db_runtime_cached_and_set_inside_lock_paths() -> None:
 
 
 def test_reset_db_runtime_dispose_exception_logged() -> None:
-    dispose = MagicMock(side_effect=RuntimeError("dispose failed"))
-    runtime = SimpleNamespace(engine=SimpleNamespace(sync_engine=SimpleNamespace(dispose=dispose)))
+    dispose = AsyncMock(side_effect=RuntimeError("dispose failed"))
+    runtime = SimpleNamespace(engine=SimpleNamespace(dispose=dispose))
     session_mod._db_runtime = runtime
 
     with patch("app.shared.db.session.logger") as mock_logger:
         session_mod.reset_db_runtime()
 
     assert session_mod._db_runtime is None
+    dispose.assert_awaited_once()
     mock_logger.debug.assert_called_once()
 
 

--- a/tests/unit/enforcement/test_export_bundle_ops_regressions.py
+++ b/tests/unit/enforcement/test_export_bundle_ops_regressions.py
@@ -78,18 +78,23 @@ async def test_build_export_bundle_collapses_computed_context_lineage_across_gen
         normalize_policy_document_schema_version_fn=lambda value: value or "unknown",
         normalize_policy_document_sha256_fn=lambda value: value or "0" * 64,
         computed_context_snapshot_fn=lambda payload: dict(payload or {}),
+        parse_iso_datetime_fn=lambda value: (
+            datetime.fromisoformat(value)
+            if isinstance(value, str)
+            else value
+        ),
         json_default_fn=lambda value: value.isoformat()
         if isinstance(value, datetime)
         else str(value),
         render_decisions_csv_fn=lambda _rows: "decisions",
         render_approvals_csv_fn=lambda _rows: "approvals",
         export_events_counter=export_events_counter,
-        utcnow_fn=lambda: datetime(2026, 3, 14, 12, 0, tzinfo=timezone.utc),
     )
 
     assert len(bundle["computed_context_lineage"]) == 1
     assert bundle["computed_context_lineage"][0]["decision_count"] == 2
     assert bundle["computed_context_lineage"][0]["generated_at"] == snapshot_one["generated_at"]
+    assert bundle["generated_at"] == datetime.fromisoformat(snapshot_two["generated_at"])
 
 
 def test_build_signed_export_manifest_payload_signs_generated_at() -> None:

--- a/tests/unit/modules/optimization/domain/test_remediation_credentials.py
+++ b/tests/unit/modules/optimization/domain/test_remediation_credentials.py
@@ -27,14 +27,9 @@ class _FakeStatement:
     def __init__(self, model: object) -> None:
         self.model = model
         self.wheres: list[object] = []
-        self.orders: list[object] = []
 
     def where(self, condition: object) -> "_FakeStatement":
         self.wheres.append(condition)
-        return self
-
-    def order_by(self, *clauses: object) -> "_FakeStatement":
-        self.orders.extend(clauses)
         return self
 
 
@@ -145,71 +140,67 @@ async def test_resolve_connection_credentials_returns_fallback_when_model_missin
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    ("connection_id", "expected", "uses_ordering"),
-    [
-        (None, {"fallback": "cred"}, True),
-        ("conn-1", {}, False),
-    ],
-)
-async def test_resolve_connection_credentials_missing_connection_result_shape(
-    connection_id: str | None,
-    expected: dict[str, object],
-    uses_ordering: bool,
-) -> None:
+async def test_resolve_connection_credentials_requires_explicit_connection_binding() -> None:
     result, service, statements = await _invoke(
         provider="aws",
         connection=None,
-        connection_id=connection_id,
-        model=_make_model(status=True, last_verified_at=True),
+        connection_id=None,
+        model=_make_model(status=True),
     )
 
-    assert result == expected
+    assert result == {}
+    service.db.execute.assert_not_called()
+    service._scalar_one_or_none.assert_not_awaited()
+    assert statements == []
+
+
+@pytest.mark.asyncio
+async def test_resolve_connection_credentials_scopes_exact_connection_lookup() -> None:
+    result, service, statements = await _invoke(
+        provider="aws",
+        connection=None,
+        connection_id="conn-1",
+        model=_make_model(status=True, last_verified_at=False),
+    )
+
+    assert result == {}
     service.db.execute.assert_awaited_once()
     service._scalar_one_or_none.assert_awaited_once_with("db-result")
     stmt = statements[0]
-    if uses_ordering:
-        assert ("eq", "status", "active") in stmt.wheres
-        assert ("desc", "last_verified_at") in stmt.orders
-        assert ("desc", "id") in stmt.orders
-    else:
-        assert ("eq", "id", "conn-1") in stmt.wheres
-        assert stmt.orders == []
+    assert ("eq", "tenant_id", "tenant-1") in stmt.wheres
+    assert ("eq", "id", "conn-1") in stmt.wheres
 
 
 @pytest.mark.asyncio
-async def test_resolve_connection_credentials_uses_is_active_branch_without_last_verified() -> None:
-    result, _service, statements = await _invoke(
+async def test_resolve_connection_credentials_returns_empty_for_inactive_exact_connection() -> None:
+    inactive_connection = SimpleNamespace(
+        id="aws-inactive",
+        role_arn="arn:aws:iam::1:role/test",
+        external_id="ext",
+        status="error",
+    )
+    result, _service, _statements = await _invoke(
         provider="aws",
-        connection=None,
-        model=_make_model(status=False, is_active=True, last_verified_at=False),
+        connection=inactive_connection,
+        connection_id="aws-inactive",
     )
 
-    assert result == {"fallback": "cred"}
-    stmt = statements[0]
-    assert ("is", "is_active", True) in stmt.wheres
-    assert stmt.orders == [("desc", "id")]
-
-
-@pytest.mark.asyncio
-async def test_resolve_connection_credentials_skips_status_filters_when_model_has_no_status_flags() -> None:
-    result, _service, statements = await _invoke(
-        provider="aws",
-        connection=None,
-        model=_make_model(status=False, is_active=False, last_verified_at=False),
-    )
-
-    assert result == {"fallback": "cred"}
-    stmt = statements[0]
-    assert ("eq", "status", "active") not in stmt.wheres
-    assert all(cond[:2] != ("is", "is_active") for cond in stmt.wheres if isinstance(cond, tuple))
-    assert stmt.orders == [("desc", "id")]
+    assert result == {}
 
 
 @pytest.mark.asyncio
 async def test_resolve_connection_credentials_aws_success_and_missing_fields() -> None:
-    ok_connection = SimpleNamespace(id="aws-1", role_arn="arn:aws:iam::1:role/test", external_id="ext")
-    result, _service, _statements = await _invoke(provider="aws", connection=ok_connection)
+    ok_connection = SimpleNamespace(
+        id="aws-1",
+        role_arn="arn:aws:iam::1:role/test",
+        external_id="ext",
+        status="active",
+    )
+    result, _service, _statements = await _invoke(
+        provider="aws",
+        connection=ok_connection,
+        connection_id="aws-1",
+    )
     assert result == {
         "role_arn": "arn:aws:iam::1:role/test",
         "external_id": "ext",
@@ -234,8 +225,13 @@ async def test_resolve_connection_credentials_azure_success_and_missing_fields()
         client_id="client",
         client_secret="secret",
         subscription_id="sub",
+        is_active=True,
     )
-    result, _service, _statements = await _invoke(provider="azure", connection=ok_connection)
+    result, _service, _statements = await _invoke(
+        provider="azure",
+        connection=ok_connection,
+        connection_id="az-1",
+    )
     assert result == {
         "tenant_id": "tenant",
         "client_id": "client",
@@ -265,8 +261,13 @@ async def test_resolve_connection_credentials_gcp_dict_payload_and_blank_string_
     dict_connection = SimpleNamespace(
         id="gcp-1",
         service_account_json={"type": "service_account", "project_id": "proj"},
+        is_active=True,
     )
-    result, _service, _statements = await _invoke(provider="gcp", connection=dict_connection)
+    result, _service, _statements = await _invoke(
+        provider="gcp",
+        connection=dict_connection,
+        connection_id="gcp-1",
+    )
     assert result == {
         "type": "service_account",
         "project_id": "proj",
@@ -274,9 +275,17 @@ async def test_resolve_connection_credentials_gcp_dict_payload_and_blank_string_
         "region": "us-test-1",
     }
 
-    blank_connection = SimpleNamespace(id="gcp-2", service_account_json="   ")
-    result_blank, _service, _statements = await _invoke(provider="gcp", connection=blank_connection)
-    assert result_blank == {"fallback": "cred"}
+    blank_connection = SimpleNamespace(
+        id="gcp-2",
+        service_account_json="   ",
+        is_active=True,
+    )
+    result_blank, _service, _statements = await _invoke(
+        provider="gcp",
+        connection=blank_connection,
+        connection_id="gcp-2",
+    )
+    assert result_blank == {}
 
 
 @pytest.mark.asyncio
@@ -284,27 +293,48 @@ async def test_resolve_connection_credentials_gcp_json_string_dict_and_nondict()
     json_dict_connection = SimpleNamespace(
         id="gcp-3",
         service_account_json=json.dumps({"client_email": "bot@example.com"}),
+        is_active=True,
     )
-    result, _service, _statements = await _invoke(provider="gcp", connection=json_dict_connection)
+    result, _service, _statements = await _invoke(
+        provider="gcp",
+        connection=json_dict_connection,
+        connection_id="gcp-3",
+    )
     assert result == {
         "client_email": "bot@example.com",
         "connection_id": "gcp-3",
         "region": "us-test-1",
     }
 
-    json_list_connection = SimpleNamespace(id="gcp-4", service_account_json='["not-a-dict"]')
-    result_list, _service, _statements = await _invoke(provider="gcp", connection=json_list_connection)
-    assert result_list == {"fallback": "cred"}
+    json_list_connection = SimpleNamespace(
+        id="gcp-4",
+        service_account_json='["not-a-dict"]',
+        is_active=True,
+    )
+    result_list, _service, _statements = await _invoke(
+        provider="gcp",
+        connection=json_list_connection,
+        connection_id="gcp-4",
+    )
+    assert result_list == {}
 
 
 @pytest.mark.asyncio
 async def test_resolve_connection_credentials_gcp_invalid_json_logs_warning() -> None:
-    bad_connection = SimpleNamespace(id="gcp-5", service_account_json="{bad-json")
+    bad_connection = SimpleNamespace(
+        id="gcp-5",
+        service_account_json="{bad-json",
+        is_active=True,
+    )
 
     with patch.object(module.logger, "warning") as warning:
-        result, _service, _statements = await _invoke(provider="gcp", connection=bad_connection)
+        result, _service, _statements = await _invoke(
+            provider="gcp",
+            connection=bad_connection,
+            connection_id="gcp-5",
+        )
 
-    assert result == {"fallback": "cred"}
+    assert result == {}
     warning.assert_called_once()
     assert warning.call_args.args[0] == "remediation_invalid_gcp_service_account_json"
 
@@ -331,12 +361,17 @@ async def test_resolve_connection_credentials_connector_providers(
         auth_method="api_key",
         api_key="key",
         api_secret="secret",
+        is_active=True,
         connector_config={"enabled": True} if provider != "license" else "not-a-dict",
         spend_feed=["a", "b"],
         license_feed=["lic-a"] if provider != "license" else {"unexpected": True},
     )
 
-    result, _service, _statements = await _invoke(provider=provider, connection=connection)
+    result, _service, _statements = await _invoke(
+        provider=provider,
+        connection=connection,
+        connection_id=f"{provider}-1",
+    )
 
     assert result["vendor"] == f"{provider}-vendor"
     assert result["auth_method"] == "api_key"
@@ -357,7 +392,7 @@ async def test_resolve_connection_credentials_connector_providers(
 
 
 @pytest.mark.asyncio
-async def test_resolve_connection_credentials_unknown_provider_returns_fallback_after_lookup() -> None:
+async def test_resolve_connection_credentials_unknown_provider_requires_binding() -> None:
     connection = SimpleNamespace(id="mystery-1")
     fallback = {"x": "y"}
     result, _service, _statements = await _invoke(
@@ -366,4 +401,4 @@ async def test_resolve_connection_credentials_unknown_provider_returns_fallback_
         connection=connection,
         fallback=fallback,
     )
-    assert result == fallback
+    assert result == {}

--- a/tests/unit/ops/test_generate_enforcement_failure_injection_evidence.py
+++ b/tests/unit/ops/test_generate_enforcement_failure_injection_evidence.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -14,6 +16,17 @@ def test_generate_evidence_requires_separation_of_duties(tmp_path: Path) -> None
             output=tmp_path / "artifact.json",
             executed_by="same@valdrics.local",
             approved_by="same@valdrics.local",
+            profile="enforcement_failure_injection",
+            cwd=tmp_path,
+        )
+
+
+def test_generate_evidence_requires_non_empty_identities(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="must be non-empty"):
+        generator.generate_evidence(
+            output=tmp_path / "artifact.json",
+            executed_by="   ",
+            approved_by="approver@valdrics.local",
             profile="enforcement_failure_injection",
             cwd=tmp_path,
         )
@@ -100,3 +113,37 @@ def test_main_exit_code_follows_overall_result(
         ]
     )
     assert exit_code == 0
+
+
+def test_run_scenario_uses_isolated_pytest_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_run(*args: object, **kwargs: object) -> MagicMock:
+        captured["env"] = kwargs.get("env")
+        completed = MagicMock()
+        completed.returncode = 0
+        completed.stdout = "ok"
+        completed.stderr = ""
+        return completed
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql+asyncpg://prod.example/app")
+    monkeypatch.setenv("DB_SSL_MODE", "require")
+    monkeypatch.setenv("PGSSLMODE", "require")
+    monkeypatch.setattr(generator.subprocess, "run", _fake_run)
+
+    scenario = generator.FailureScenario(
+        scenario_id="FI-TEST",
+        checks=("isolated env",),
+        selectors=("tests/unit/enforcement/test_enforcement_api.py::test_gate_failsafe_timeout_and_error_modes",),
+    )
+    payload, passed = generator._run_scenario(scenario, cwd=Path("."))
+
+    assert passed is True
+    assert payload["status"] == "pass"
+    env = captured["env"]
+    assert isinstance(env, dict)
+    assert "DATABASE_URL" not in env
+    assert "DB_SSL_MODE" not in env
+    assert "PGSSLMODE" not in env
+    assert env["TESTING"] == "true"
+    assert env["DEBUG"] == "false"

--- a/tests/unit/ops/test_generate_finance_committee_packet_assumptions.py
+++ b/tests/unit/ops/test_generate_finance_committee_packet_assumptions.py
@@ -73,3 +73,14 @@ def test_derive_assumptions_inputs_rejects_invalid_subscription_rows() -> None:
         match=r"telemetry\.tier_subscription_snapshot\[0\] must be an object",
     ):
         derive_assumptions_inputs(telemetry=telemetry)
+
+
+def test_derive_assumptions_inputs_rejects_duplicate_tier_rows() -> None:
+    telemetry = _telemetry_payload()
+    first_row = dict(telemetry["tier_subscription_snapshot"][0])
+    telemetry["tier_subscription_snapshot"] = [
+        *telemetry["tier_subscription_snapshot"],
+        first_row,
+    ]
+    with pytest.raises(ValueError, match="duplicate tier: starter"):
+        derive_assumptions_inputs(telemetry=telemetry)

--- a/tests/unit/ops/test_generate_key_rotation_drill_evidence.py
+++ b/tests/unit/ops/test_generate_key_rotation_drill_evidence.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import scripts.generate_key_rotation_drill_evidence as drill_generator
+
+
+def _failing_execution() -> tuple[dict[str, bool], dict[str, bool], dict[str, str]]:
+    field_results = {
+        check.key: True for check in drill_generator._all_drill_checks()
+    }
+    field_results["pre_rotation_tokens_accepted"] = False
+
+    selector_results = {
+        check.selector: field_results[check.key]
+        for check in drill_generator._all_drill_checks()
+    }
+    selector_logs = {
+        check.selector: (
+            f"{check.key} failed"
+            if not field_results[check.key]
+            else f"{check.key} ok"
+        )
+        for check in drill_generator._all_drill_checks()
+    }
+    return field_results, selector_results, selector_logs
+
+
+def test_main_allow_check_failures_emits_fail_artifact_and_skips_verifier(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    output = tmp_path / "key_rotation_drill.md"
+    monkeypatch.setattr(drill_generator, "_execute_checks", lambda **_: _failing_execution())
+
+    verifier_called = False
+
+    def _unexpected_verify(**_: object) -> int:
+        nonlocal verifier_called
+        verifier_called = True
+        raise AssertionError("verifier should be skipped for failing allow_check_failures output")
+
+    monkeypatch.setattr(
+        drill_generator,
+        "verify_key_rotation_drill_evidence",
+        _unexpected_verify,
+    )
+
+    exit_code = drill_generator.main(
+        [
+            "--output",
+            str(output),
+            "--allow-check-failures",
+        ]
+    )
+
+    text = output.read_text(encoding="utf-8")
+    assert exit_code == 2
+    assert verifier_called is False
+    assert "- pre_rotation_tokens_accepted: false" in text
+    assert "- post_drill_status: FAIL" in text
+
+
+def test_main_writes_fail_artifact_before_raising_when_failures_not_allowed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    output = tmp_path / "key_rotation_drill.md"
+    monkeypatch.setattr(drill_generator, "_execute_checks", lambda **_: _failing_execution())
+    monkeypatch.setattr(
+        drill_generator,
+        "verify_key_rotation_drill_evidence",
+        lambda **_: (_ for _ in ()).throw(AssertionError("verifier should not run")),
+    )
+
+    with pytest.raises(RuntimeError, match="key-rotation live checks failed for"):
+        drill_generator.main(
+            [
+                "--output",
+                str(output),
+            ]
+        )
+
+    text = output.read_text(encoding="utf-8")
+    assert "- pre_rotation_tokens_accepted: false" in text
+    assert "- post_drill_status: FAIL" in text

--- a/tests/unit/ops/test_generate_local_dev_env.py
+++ b/tests/unit/ops/test_generate_local_dev_env.py
@@ -134,3 +134,14 @@ def test_generate_local_dev_env_is_shell_source_safe_for_json_values(tmp_path: P
     )
 
     assert sourced.stdout == '["http://localhost:5173","http://localhost:5174"]'
+
+
+def test_generate_local_dev_env_creates_parent_directories(tmp_path: Path) -> None:
+    template = tmp_path / ".env.example"
+    output = tmp_path / "nested" / "local" / ".env.dev"
+    _write(template, "CSRF_SECRET_KEY=\nENCRYPTION_KEY=\n")
+
+    result = generate_local_dev_env(template_path=template, output_path=output, seed="seed-4")
+
+    assert result == output
+    assert output.exists()

--- a/tests/unit/ops/test_key_rotation_drill_evidence_pack.py
+++ b/tests/unit/ops/test_key_rotation_drill_evidence_pack.py
@@ -20,12 +20,15 @@ def test_key_rotation_drill_pack_has_required_evidence_markers() -> None:
         "source_pre_rotation_tokens_accepted:",
         "source_post_rotation_new_tokens_accepted:",
         "source_rollback_validation_passed:",
+        "source_endpoint_replay_tamper_guard:",
         "fallback_verification_passed: true",
         "rollback_validation_passed: true",
+        "endpoint_replay_tamper_guard: true",
         "post_drill_status: PASS",
         "test_consume_approval_token_accepts_primary_secret",
         "test_consume_approval_token_accepts_new_primary_secret_after_rotation",
         "test_consume_approval_token_accepts_rollback_fallback_secret",
+        "test_consume_approval_token_endpoint_rejects_replay_and_tamper",
     )
     for snippet in required_snippets:
         assert snippet in raw

--- a/tests/unit/ops/test_runtime_evidence_generators.py
+++ b/tests/unit/ops/test_runtime_evidence_generators.py
@@ -17,6 +17,7 @@ from scripts.generate_key_rotation_drill_evidence import (
     main as generate_key_rotation_drill_evidence_main,
 )
 from scripts.generate_pkg_fin_policy_decisions import (
+    _build_payload as build_pkg_fin_policy_payload,
     main as generate_pkg_fin_policy_decisions_main,
 )
 from scripts.generate_pricing_benchmark_register import (
@@ -26,6 +27,7 @@ from scripts.generate_valdrics_disposition_register import (
     main as generate_valdrics_disposition_register_main,
 )
 from scripts.pkg_fin_policy_decisions_constants import REQUIRED_DECISION_BACKLOG_IDS
+from scripts.pkg_fin_policy_decisions_constants import REQUIRED_TIERS
 from scripts.verify_finance_telemetry_snapshot import verify_snapshot
 from scripts.verify_key_rotation_drill_evidence import verify_key_rotation_drill_evidence
 from scripts.verify_pkg_fin_policy_decisions import verify_evidence
@@ -93,6 +95,44 @@ def test_generate_pkg_fin_policy_decisions_emits_verifiable_artifact(
         for item in payload["decision_backlog"]["decision_items"]
     }
     assert decision_ids == set(REQUIRED_DECISION_BACKLOG_IDS)
+
+
+def test_generate_pkg_fin_policy_decisions_rejects_duplicate_tier_rows() -> None:
+    tiers = sorted(REQUIRED_TIERS)
+    telemetry_payload = {
+        "window": {
+            "start": "2026-01-01",
+            "end": "2026-01-31",
+            "label": "2026-01",
+        },
+        "pricing_reference": {
+            tier: {"annual_monthly_factor": 1.0}
+            for tier in tiers
+        },
+        "tier_revenue_inputs": [
+            {"tier": tier, "gross_mrr_usd": 1000.0}
+            for tier in tiers
+        ]
+        + [{"tier": tiers[0], "gross_mrr_usd": 1500.0}],
+        "tier_llm_usage": [
+            {"tier": tier, "total_cost_usd": 100.0}
+            for tier in tiers
+        ],
+        "tier_subscription_snapshot": [
+            {"tier": tier, "active_subscriptions": 10}
+            for tier in tiers
+        ],
+    }
+
+    try:
+        build_pkg_fin_policy_payload(
+            telemetry_payload=telemetry_payload,
+            months_observed=2,
+        )
+    except ValueError as exc:
+        assert "duplicate tier" in str(exc)
+    else:
+        raise AssertionError("expected duplicate tier rows to be rejected")
 
 
 def test_generate_finance_committee_assumptions_integrates_with_packet_generation(

--- a/tests/unit/ops/test_verify_finance_guardrails_evidence.py
+++ b/tests/unit/ops/test_verify_finance_guardrails_evidence.py
@@ -136,6 +136,18 @@ def test_verify_finance_guardrails_rejects_missing_required_tier(tmp_path: Path)
         verify_evidence(evidence_path=path)
 
 
+def test_verify_finance_guardrails_rejects_duplicate_tier(tmp_path: Path) -> None:
+    payload = _valid_payload()
+    payload["tier_unit_economics"] = [
+        *payload["tier_unit_economics"],
+        dict(payload["tier_unit_economics"][0]),
+    ]
+    path = tmp_path / "finance.json"
+    _write(path, payload)
+    with pytest.raises(ValueError, match="duplicate tier: starter"):
+        verify_evidence(evidence_path=path)
+
+
 def test_verify_finance_guardrails_rejects_too_old_artifact(tmp_path: Path) -> None:
     path = tmp_path / "finance.json"
     _write(path, _valid_payload())

--- a/tests/unit/ops/test_verify_key_rotation_drill_evidence.py
+++ b/tests/unit/ops/test_verify_key_rotation_drill_evidence.py
@@ -29,6 +29,7 @@ def _valid_doc(*, executed_at_utc: str = "2026-02-27T08:10:00Z") -> str:
 - source_rollback_validation_passed: tests/unit/enforcement/enforcement_service_cases_part04.py::test_consume_approval_token_accepts_rollback_fallback_secret
 - source_replay_protection_intact: tests/unit/enforcement/enforcement_service_cases_part03.py::test_consume_approval_token_rejects_replay
 - source_alert_pipeline_verified: tests/unit/enforcement/test_reconciliation_worker.py::test_reconciliation_worker_sends_sla_release_alert
+- source_endpoint_replay_tamper_guard: tests/unit/enforcement/enforcement_api_cases_part03.py::test_consume_approval_token_endpoint_rejects_replay_and_tamper
 - pre_rotation_tokens_accepted: true
 - post_rotation_new_tokens_accepted: true
 - post_rotation_old_tokens_rejected: true
@@ -36,6 +37,7 @@ def _valid_doc(*, executed_at_utc: str = "2026-02-27T08:10:00Z") -> str:
 - rollback_validation_passed: true
 - replay_protection_intact: true
 - alert_pipeline_verified: true
+- endpoint_replay_tamper_guard: true
 - post_drill_status: PASS
 """
 

--- a/tests/unit/ops/test_verify_repo_root_hygiene.py
+++ b/tests/unit/ops/test_verify_repo_root_hygiene.py
@@ -37,6 +37,6 @@ def test_main_returns_one_when_prohibited_files_exist(tmp_path: Path) -> None:
 def test_pytest_async_engine_uses_temp_directory_fixture() -> None:
     conftest_text = Path("tests/conftest.py").read_text(encoding="utf-8")
 
-    assert 'async def async_engine(tmp_path_factory):' in conftest_text
+    assert 'def async_engine(tmp_path_factory):' in conftest_text
     assert 'build_sqlite_test_database_path(tmp_path_factory.mktemp("sqlite-db"))' in conftest_text
     assert 'db_file = f"test_{uuid4().hex}.sqlite"' not in conftest_text

--- a/tests/unit/ops/test_verify_valdrics_disposition_freshness.py
+++ b/tests/unit/ops/test_verify_valdrics_disposition_freshness.py
@@ -24,8 +24,8 @@ RUNTIME_PROBE_RESULTS = [
     {
         "probe_id": "module_size_budget",
         "command": "python scripts/verify_python_module_size_budget.py --enforcement-mode strict",
-        "passed": True,
-        "output_excerpt": "ok",
+        "passed": False,
+        "output_excerpt": "size budget exceeded",
     },
     {
         "probe_id": "dependency_locking",
@@ -64,19 +64,26 @@ def _write(path: Path, payload: dict[str, object]) -> None:
 
 
 def _valid_payload() -> dict[str, object]:
+    probe_pass_by_id = {
+        str(item["probe_id"]): bool(item["passed"])
+        for item in RUNTIME_PROBE_RESULTS
+    }
     dispositions: list[dict[str, object]] = []
     for finding_id in DEFAULT_REQUIRED_FINDING_IDS:
+        control_probe_ids = CONTROL_PROBES_BY_FINDING[finding_id]
+        all_control_probes_passed = all(
+            probe_pass_by_id.get(probe_id, False) for probe_id in control_probe_ids
+        )
         item: dict[str, object] = {
             "finding_id": finding_id,
-            "status": "documented_exception",
+            "status": "documented_exception" if all_control_probes_passed else "planned_refactor",
             "owner": "platform-owner@valdrics.io",
             "review_by": "2026-03-31",
             "rationale": f"{finding_id} disposition rationale recorded for release gate.",
             "exit_criteria": f"{finding_id} closure criteria tracked in remediation backlog.",
-            "control_probe_ids": CONTROL_PROBES_BY_FINDING[finding_id],
+            "control_probe_ids": control_probe_ids,
         }
-        if finding_id in {"VAL-ADAPT-001", "VAL-ADAPT-002+"}:
-            item["status"] = "planned_refactor"
+        if item["status"] == "planned_refactor":
             item["backlog_ref"] = "VAL-ADAPT-002+"
         dispositions.append(item)
 
@@ -165,6 +172,41 @@ def test_verify_valdrics_disposition_freshness_rejects_missing_runtime_probe_res
     _write(path, payload)
 
     with pytest.raises(ValueError, match="runtime_probe_results must be a non-empty array"):
+        verify_disposition_register(
+            register_path=path,
+            max_artifact_age_days=45.0,
+            max_review_window_days=120.0,
+            as_of=AS_OF_UTC,
+        )
+
+
+def test_verify_valdrics_disposition_freshness_rejects_documented_exception_with_failed_probe(
+    tmp_path: Path,
+) -> None:
+    payload = _valid_payload()
+    payload["dispositions"][2]["status"] = "documented_exception"
+    payload["runtime_probe_results"][3]["passed"] = False
+    path = tmp_path / "valdrics-disposition.json"
+    _write(path, payload)
+
+    with pytest.raises(ValueError, match="documented_exception must reference only passing"):
+        verify_disposition_register(
+            register_path=path,
+            max_artifact_age_days=45.0,
+            max_review_window_days=120.0,
+            as_of=AS_OF_UTC,
+        )
+
+
+def test_verify_valdrics_disposition_freshness_rejects_planned_refactor_without_failed_probe(
+    tmp_path: Path,
+) -> None:
+    payload = _valid_payload()
+    payload["runtime_probe_results"][1]["passed"] = True
+    path = tmp_path / "valdrics-disposition.json"
+    _write(path, payload)
+
+    with pytest.raises(ValueError, match="planned_refactor must reference at least one failing"):
         verify_disposition_register(
             register_path=path,
             max_artifact_age_days=45.0,

--- a/tests/unit/optimization/test_remediation_branch_coverage.py
+++ b/tests/unit/optimization/test_remediation_branch_coverage.py
@@ -240,6 +240,7 @@ async def test_generate_iac_plan_provider_paths_and_bulk(
         bulk = await service.bulk_generate_iac_plan([req], uuid4())
         assert "Bulk IaC Remediation Plan" in bulk
         assert "Generated:" in bulk
+        assert "\n----------------------------------------\n# Valdrics GitOps Remediation Plan" in bulk
 
 
 @pytest.mark.asyncio
@@ -271,6 +272,7 @@ async def test_bulk_generate_iac_plan_resolves_tier_once(
         bulk = await service.bulk_generate_iac_plan([req1, req2], uuid4())
 
     assert "Bulk IaC Remediation Plan" in bulk
+    assert bulk.count("# Valdrics GitOps Remediation Plan") == 2
     mock_tier_lookup.assert_awaited_once()
 
 

--- a/tests/unit/optimization/test_remediation_region_resolution.py
+++ b/tests/unit/optimization/test_remediation_region_resolution.py
@@ -10,6 +10,7 @@ from app.modules.optimization.domain.remediation import (
     RemediationAction,
     RemediationService,
 )
+from app.shared.core.exceptions import ValdricsException
 
 
 def _db_stub() -> MagicMock:
@@ -110,13 +111,23 @@ async def test_preview_policy_input_aws_uses_scoped_connection_region_when_hint_
 async def test_create_request_non_aws_forces_global_region() -> None:
     tenant_id = uuid4()
     user_id = uuid4()
+    connection_id = uuid4()
     db = _db_stub()
     service = RemediationService(db=db, region="us-east-1")
+    service.get_by_id = AsyncMock(  # type: ignore[method-assign]
+        return_value=SimpleNamespace(id=connection_id, is_active=True)
+    )
 
-    with patch.object(
-        service,
-        "_build_system_policy_context",
-        new=AsyncMock(return_value={}),
+    with (
+        patch(
+            "app.modules.optimization.domain.remediation.get_connection_model",
+            return_value=object(),
+        ),
+        patch.object(
+            service,
+            "_build_system_policy_context",
+            new=AsyncMock(return_value={}),
+        ),
     ):
         request = await service.create_request(
             tenant_id=tenant_id,
@@ -126,9 +137,30 @@ async def test_create_request_non_aws_forces_global_region() -> None:
             action=RemediationAction.STOP_INSTANCE,
             estimated_savings=7.5,
             provider="azure",
+            connection_id=connection_id,
         )
 
     assert request.region == "global"
+
+
+@pytest.mark.asyncio
+async def test_preview_policy_input_requires_explicit_connection_binding() -> None:
+    tenant_id = uuid4()
+    user_id = uuid4()
+    db = _db_stub()
+    service = RemediationService(db=db, region="global")
+
+    with pytest.raises(ValdricsException) as exc_info:
+        await service.preview_policy_input(
+            tenant_id=tenant_id,
+            user_id=user_id,
+            resource_id="i-456",
+            resource_type="GPU Compute",
+            action=RemediationAction.TERMINATE_INSTANCE,
+            provider="aws",
+        )
+
+    assert getattr(exc_info.value, "code", None) == "remediation_connection_required"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/optimization/test_remediation_service_audit.py
+++ b/tests/unit/optimization/test_remediation_service_audit.py
@@ -36,9 +36,10 @@ def user_id():
 @pytest.mark.asyncio
 async def test_create_remediation_request(mock_db, tenant_id, user_id):
     service = RemediationService(mock_db)
-
-    # Mock connection check bypass or return None
-    mock_db.execute.return_value.scalar_one_or_none.return_value = None
+    connection_id = uuid4()
+    service.get_by_id = AsyncMock(
+        return_value=MagicMock(id=connection_id, tenant_id=tenant_id, status="active")
+    )
 
     request = await service.create_request(
         tenant_id=tenant_id,
@@ -48,6 +49,7 @@ async def test_create_remediation_request(mock_db, tenant_id, user_id):
         action=RemediationAction.DELETE_VOLUME,
         estimated_savings=15.5,
         provider="aws",
+        connection_id=connection_id,
     )
 
     assert request.tenant_id == tenant_id
@@ -63,6 +65,10 @@ async def test_create_request_overwrites_user_supplied_system_policy_context(
     mock_db, tenant_id, user_id
 ):
     service = RemediationService(mock_db)
+    connection_id = uuid4()
+    service.get_by_id = AsyncMock(
+        return_value=MagicMock(id=connection_id, tenant_id=tenant_id, status="active")
+    )
 
     with patch.object(
         service,
@@ -82,6 +88,7 @@ async def test_create_request_overwrites_user_supplied_system_policy_context(
             action=RemediationAction.DELETE_VOLUME,
             estimated_savings=15.5,
             provider="aws",
+            connection_id=connection_id,
             parameters={
                 "keep_this": "yes",
                 "_system_policy_context": {"is_production": False, "source": "user"},
@@ -393,7 +400,7 @@ async def test_generate_iac_plan_free_tier(mock_db, tenant_id):
 
 
 @pytest.mark.asyncio
-async def test_resolve_credentials_azure_uses_active_connection_when_id_missing(
+async def test_resolve_credentials_azure_requires_explicit_connection_binding(
     mock_db, tenant_id
 ):
     service = RemediationService(mock_db, credentials={"fallback": "x"})
@@ -405,24 +412,13 @@ async def test_resolve_credentials_azure_uses_active_connection_when_id_missing(
     )
     req.connection_id = None
 
-    azure_conn = MagicMock()
-    azure_conn.azure_tenant_id = "tenant-123"
-    azure_conn.client_id = "client-123"
-    azure_conn.client_secret = "secret-123"
-    azure_conn.subscription_id = "sub-123"
-
-    mock_res = MagicMock()
-    mock_res.scalar_one_or_none.return_value = azure_conn
-    mock_db.execute.return_value = mock_res
-
     creds = await service._resolve_credentials(req)
-    assert creds["tenant_id"] == "tenant-123"
-    assert creds["client_id"] == "client-123"
-    assert "fallback" not in creds
+    assert creds == {}
+    mock_db.execute.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_resolve_credentials_saas_falls_back_when_no_connection_id(
+async def test_resolve_credentials_saas_requires_explicit_connection_binding(
     mock_db, tenant_id
 ):
     service = RemediationService(mock_db, credentials={"fallback_token": "abc"})
@@ -434,12 +430,9 @@ async def test_resolve_credentials_saas_falls_back_when_no_connection_id(
     )
     req.connection_id = None
 
-    mock_res = MagicMock()
-    mock_res.scalar_one_or_none.return_value = None
-    mock_db.execute.return_value = mock_res
-
     creds = await service._resolve_credentials(req)
-    assert creds == {"fallback_token": "abc"}
+    assert creds == {}
+    mock_db.execute.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/optimization/test_zombie_service_audit.py
+++ b/tests/unit/optimization/test_zombie_service_audit.py
@@ -11,7 +11,9 @@ from app.shared.core.pricing import PricingTier
 
 @pytest.fixture
 def mock_db():
-    return AsyncMock()
+    db = AsyncMock()
+    db.add = MagicMock()
+    return db
 
 
 @pytest.fixture
@@ -103,6 +105,81 @@ async def test_scan_for_tenant_success(mock_db, tenant_id):
     assert result["waste_rightsizing"]["summary"]["total_recommendations"] == 1
     assert result["architectural_inefficiency"]["deterministic"] is True
     mock_notify.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_scan_for_tenant_attaches_persisted_finding_ids(mock_db, tenant_id):
+    service = ZombieService(mock_db)
+
+    conn = MagicMock(spec=AWSConnection)
+    conn.id = uuid4()
+    conn.tenant_id = tenant_id
+    conn.name = "Prod-AWS"
+    conn.provider = "aws"
+    conn.region = "us-east-1"
+    conn.aws_account_id = "123456789012"
+    conn.role_arn = "arn:aws:iam::123456789012:role/Valdrics"
+    conn.external_id = "external-id"
+    conn.cur_bucket_name = "cur-bucket"
+    conn.cur_report_name = "cur-report"
+    conn.cur_prefix = "cur-prefix"
+
+    mock_detector = AsyncMock()
+    mock_detector.provider_name = "aws"
+    mock_detector.get_credentials = AsyncMock(
+        return_value={"AccessKeyId": "AKIA_TEST", "SecretAccessKey": "SECRET_TEST"}
+    )
+    mock_detector.scan_all.return_value = {
+        "unattached_volumes": [{"resource_id": "vol-1", "monthly_cost": 10.0}]
+    }
+
+    mock_rd = MagicMock()
+    mock_rd.get_enabled_regions = AsyncMock(return_value=["us-east-1"])
+
+    async def execute_side_effect(stmt: object) -> MagicMock:
+        query = str(stmt).lower()
+        result = MagicMock()
+        result.scalars.return_value.all.return_value = []
+        if "aws_connections" in query:
+            result.scalars.return_value.all.return_value = [conn]
+        return result
+
+    mock_db.execute.side_effect = execute_side_effect
+
+    def fake_get_detector(*_args, **_kwargs):
+        return mock_detector
+
+    async def fake_persist(*_args, **kwargs):
+        kwargs["scan_payload"]["unattached_volumes"][0]["finding_id"] = "finding-123"
+        kwargs["scan_payload"]["unattached_volumes"][0]["finding_status"] = "open"
+
+    with (
+        patch(
+            "app.modules.optimization.domain.service.ZombieDetectorFactory",
+            new=SimpleNamespace(get_detector=fake_get_detector),
+        ),
+        patch(
+            "app.modules.optimization.adapters.aws.region_discovery.RegionDiscovery",
+            return_value=mock_rd,
+        ),
+        patch(
+            "app.shared.core.pricing.get_tenant_tier",
+            return_value=PricingTier.STARTER,
+        ),
+        patch("app.shared.core.ops_metrics.SCAN_LATENCY"),
+        patch(
+            "app.shared.core.notifications.NotificationDispatcher.notify_zombies"
+        ),
+        patch(
+            "app.modules.optimization.domain.findings.persist_scan_findings_with_guard",
+            new=AsyncMock(side_effect=fake_persist),
+        ) as mock_persist,
+    ):
+        result = await service.scan_for_tenant(tenant_id)
+
+    assert result["unattached_volumes"][0]["finding_id"] == "finding-123"
+    assert result["unattached_volumes"][0]["finding_status"] == "open"
+    mock_persist.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/reporting/test_realized_savings_service_branches.py
+++ b/tests/unit/reporting/test_realized_savings_service_branches.py
@@ -23,7 +23,12 @@ def _request(
     executed_at: datetime | None = None,
     connection_id=None,
     resource_id: str = "i-123",
+    finding_id=None,
+    finding_category: str | None = None,
 ):
+    snapshot = None
+    if finding_category is not None:
+        snapshot = {"category": finding_category}
     return SimpleNamespace(
         id=uuid4(),
         tenant_id=tenant_id,
@@ -31,6 +36,8 @@ def _request(
         executed_at=executed_at,
         connection_id=connection_id,
         resource_id=resource_id,
+        finding_id=finding_id,
+        finding_snapshot=snapshot,
         provider="aws",
         region="us-east-1",
         updated_at=executed_at,
@@ -174,14 +181,19 @@ async def test_compute_for_request_skips_future_measurement_or_incomplete_window
 async def test_compute_for_request_updates_existing_event_and_clamps_negative_delta() -> None:
     tenant_id = uuid4()
     account_id = uuid4()
+    finding_id = uuid4()
     request = _request(
         tenant_id=tenant_id,
         executed_at=datetime.now(timezone.utc) - timedelta(days=40),
         connection_id=account_id,
+        finding_id=finding_id,
+        finding_category="idle_instances",
     )
 
     existing = SimpleNamespace(
         provider="old",
+        finding_id=None,
+        finding_category=None,
         account_id=None,
         resource_id=None,
         region=None,
@@ -225,6 +237,8 @@ async def test_compute_for_request_updates_existing_event_and_clamps_negative_de
 
     assert result is existing
     assert existing.provider == "aws"
+    assert existing.finding_id == finding_id
+    assert existing.finding_category == "idle_instances"
     assert existing.account_id == account_id
     assert existing.realized_avg_daily_savings_usd == Decimal("0")
     assert existing.realized_monthly_savings_usd == Decimal("0")
@@ -237,10 +251,13 @@ async def test_compute_for_request_updates_existing_event_and_clamps_negative_de
 async def test_compute_for_request_creates_new_event_when_missing() -> None:
     tenant_id = uuid4()
     account_id = uuid4()
+    finding_id = uuid4()
     request = _request(
         tenant_id=tenant_id,
         executed_at=datetime.now(timezone.utc) - timedelta(days=40),
         connection_id=account_id,
+        finding_id=finding_id,
+        finding_category="unattached_volumes",
     )
 
     db = MagicMock()
@@ -263,6 +280,8 @@ async def test_compute_for_request_creates_new_event_when_missing() -> None:
         )
 
     assert isinstance(result, RealizedSavingsEvent)
+    assert result.finding_id == finding_id
+    assert result.finding_category == "unattached_volumes"
     assert result.realized_avg_daily_savings_usd == Decimal("15")
     assert result.realized_monthly_savings_usd == Decimal("450")
     db.add.assert_called_once_with(result)

--- a/tests/unit/reporting/test_savings_api_branches.py
+++ b/tests/unit/reporting/test_savings_api_branches.py
@@ -265,6 +265,8 @@ async def test_list_realized_savings_events_json_and_csv_paths() -> None:
 
     event_one = SimpleNamespace(
         remediation_request_id=uuid4(),
+        finding_id=uuid4(),
+        finding_category="idle_instances",
         provider="aws",
         account_id=uuid4(),
         resource_id="i-123",
@@ -282,6 +284,8 @@ async def test_list_realized_savings_events_json_and_csv_paths() -> None:
     )
     event_two = SimpleNamespace(
         remediation_request_id=uuid4(),
+        finding_id=None,
+        finding_category=None,
         provider="aws",
         account_id=None,
         resource_id=None,
@@ -315,6 +319,7 @@ async def test_list_realized_savings_events_json_and_csv_paths() -> None:
     )
     assert len(events) == 2
     assert events[0].provider == "aws"
+    assert events[0].finding_category == "idle_instances"
     assert events[1].executed_at is None
 
     response = await list_realized_savings_events(
@@ -329,3 +334,6 @@ async def test_list_realized_savings_events_json_and_csv_paths() -> None:
     assert isinstance(response, Response)
     assert response.media_type == "text/csv"
     assert "realized_monthly_savings_usd" in response.body.decode()
+    assert "finding_category" in response.body.decode()
+    assert str(event_one.remediation_request_id) in response.body.decode()
+    assert str(event_one.finding_id) in response.body.decode()

--- a/tests/unit/reporting/test_savings_proof_api.py
+++ b/tests/unit/reporting/test_savings_proof_api.py
@@ -195,6 +195,7 @@ async def test_savings_proof_drilldown_strategy_type_and_remediation_action(
         action=RemediationAction.DELETE_VOLUME,
         status=RemediationStatus.PENDING,
         estimated_monthly_savings=Decimal("2.00"),
+        finding_snapshot={"category": "unattached_volumes"},
         requested_by_user_id=admin.id,
     )
     db.add(pending_delete)
@@ -208,6 +209,7 @@ async def test_savings_proof_drilldown_strategy_type_and_remediation_action(
         action=RemediationAction.STOP_INSTANCE,
         status=RemediationStatus.APPROVED,
         estimated_monthly_savings=Decimal("4.00"),
+        finding_snapshot={"category": "idle_instances"},
         requested_by_user_id=admin.id,
     )
     db.add(pending_stop)
@@ -221,6 +223,7 @@ async def test_savings_proof_drilldown_strategy_type_and_remediation_action(
         action=RemediationAction.TERMINATE_INSTANCE,
         status=RemediationStatus.COMPLETED,
         estimated_monthly_savings=Decimal("3.00"),
+        finding_snapshot={"category": "idle_instances"},
         requested_by_user_id=admin.id,
         executed_at=datetime.now(timezone.utc) - timedelta(days=2),
     )
@@ -231,6 +234,8 @@ async def test_savings_proof_drilldown_strategy_type_and_remediation_action(
     evidence = RealizedSavingsEvent(
         tenant_id=tenant_id,
         remediation_request_id=completed_rem.id,
+        finding_id=uuid.uuid4(),
+        finding_category="idle_instances",
         provider="aws",
         account_id=None,
         resource_id=completed_rem.resource_id,
@@ -288,3 +293,19 @@ async def test_savings_proof_drilldown_strategy_type_and_remediation_action(
 
     assert payload["opportunity_monthly_usd"] == 6.0
     assert payload["realized_monthly_usd"] == 20.0
+
+    res = await ac.get(
+        "/api/v1/savings/proof/drilldown?dimension=finding_category", headers=headers
+    )
+    assert res.status_code == 200
+    payload = res.json()
+    assert payload["dimension"] == "finding_category"
+    idle = next(item for item in payload["buckets"] if item["key"] == "idle_instances")
+    unattached = next(
+        item for item in payload["buckets"] if item["key"] == "unattached_volumes"
+    )
+    assert idle["pending_remediations"] == 1
+    assert idle["completed_remediations"] == 1
+    assert idle["realized_monthly_usd"] == 20.0
+    assert unattached["pending_remediations"] == 1
+    assert unattached["opportunity_monthly_usd"] == 2.0

--- a/tests/unit/services/llm/test_zombie_analyzer_logic.py
+++ b/tests/unit/services/llm/test_zombie_analyzer_logic.py
@@ -162,6 +162,56 @@ async def test_analyze_usage_tracking(mock_llm, mock_db):
 
 
 @pytest.mark.asyncio
+async def test_analyze_rebinds_persisted_finding_metadata(mock_llm):
+    analyzer = ZombieAnalyzer(mock_llm)
+    detection_results = {
+        "idle_instances": [
+            {
+                "resource_id": "i-123",
+                "resource_type": "ec2_instance",
+                "provider": "aws",
+                "finding_id": "finding-123",
+                "finding_status": "open",
+                "connection_id": "conn-123",
+            }
+        ]
+    }
+    mock_response = MagicMock()
+    mock_response.content = json.dumps(
+        {
+            "summary": "Bound finding preserved",
+            "total_monthly_savings": "$15.00",
+            "resources": [
+                {
+                    "resource_id": "i-123",
+                    "resource_type": "ec2_instance",
+                    "provider": "aws",
+                    "explanation": "Idle",
+                    "confidence": "high",
+                    "confidence_score": 0.95,
+                    "confidence_reason": "No CPU activity",
+                    "recommended_action": "stop_instance",
+                    "monthly_cost": "$15.00",
+                    "risk_if_deleted": "low",
+                    "risk_explanation": "Can restart later",
+                }
+            ],
+            "general_recommendations": [],
+        }
+    )
+    with patch("langchain_core.prompts.ChatPromptTemplate.__or__") as mock_or:
+        mock_chain = AsyncMock()
+        mock_chain.ainvoke.return_value = mock_response
+        mock_or.return_value = mock_chain
+
+        result = await analyzer.analyze(detection_results)
+
+    assert result["resources"][0]["finding_id"] == "finding-123"
+    assert result["resources"][0]["finding_status"] == "open"
+    assert result["resources"][0]["connection_id"] == "conn-123"
+
+
+@pytest.mark.asyncio
 async def test_analyze_json_parse_error_fallback(mock_llm):
     """Test fallback behavior when LLM returns invalid JSON."""
     analyzer = ZombieAnalyzer(mock_llm)

--- a/tests/unit/services/zombies/test_remediation_service.py
+++ b/tests/unit/services/zombies/test_remediation_service.py
@@ -11,7 +11,8 @@ from app.models.remediation import (
     RemediationAction,
 )
 from app.models.aws_connection import AWSConnection
-from app.shared.core.exceptions import ResourceNotFoundError
+from app.models.optimization import FindingSource, FindingStatus, OptimizationFinding
+from app.shared.core.exceptions import ResourceNotFoundError, ValdricsException
 from app.modules.optimization.domain.actions.base import ExecutionResult, ExecutionStatus
 # Import all models to prevent mapper errors during Mock usage
 
@@ -45,6 +46,7 @@ async def test_create_request_success(remediation_service, db_session):
     mock_conn = MagicMock(spec=AWSConnection)
     mock_conn.id = connection_id
     mock_conn.tenant_id = tenant_id
+    mock_conn.status = "active"
 
     mock_res = MagicMock()
     mock_res.scalar_one_or_none.return_value = mock_conn
@@ -76,9 +78,7 @@ async def test_create_request_unauthorized_connection(remediation_service, db_se
     mock_res.scalar_one_or_none.return_value = None
     db_session.execute.return_value = mock_res
 
-    with pytest.raises(
-        ValueError, match="Unauthorized: Connection does not belong to tenant"
-    ):
+    with pytest.raises(ResourceNotFoundError, match="Connection .* not found"):
         await remediation_service.create_request(
             tenant_id=tenant_id,
             user_id=uuid4(),
@@ -115,6 +115,245 @@ async def test_create_request_does_not_swallow_base_exceptions(
             provider="aws",
             connection_id=connection_id,
         )
+
+
+@pytest.mark.asyncio
+async def test_create_request_requires_explicit_connection_binding(
+    remediation_service, db_session
+):
+    with pytest.raises(ValdricsException) as exc_info:
+        await remediation_service.create_request(
+            tenant_id=uuid4(),
+            user_id=uuid4(),
+            resource_id="vol-1",
+            resource_type="ebs_volume",
+            action=RemediationAction.DELETE_VOLUME,
+            estimated_savings=10.0,
+            provider="aws",
+        )
+
+    assert getattr(exc_info.value, "code", None) == "remediation_connection_required"
+    db_session.add.assert_not_called()
+    db_session.commit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_create_request_from_finding_binds_immutable_context(
+    remediation_service, db_session
+):
+    tenant_id = uuid4()
+    user_id = uuid4()
+    finding_id = uuid4()
+    connection_id = uuid4()
+    finding = OptimizationFinding(
+        id=finding_id,
+        tenant_id=tenant_id,
+        source=FindingSource.ZOMBIE_SCAN,
+        status=FindingStatus.OPEN,
+        fingerprint="f" * 64,
+        provider="aws",
+        category="unattached_volumes",
+        connection_id=connection_id,
+        connection_name="Prod AWS",
+        resource_id="vol-123",
+        resource_type="ebs_volume",
+        region="us-east-1",
+        estimated_monthly_savings=Decimal("50.0"),
+        confidence_score=Decimal("0.95"),
+        explainability_notes="Volume has been unattached for 30 days.",
+        requires_manual_review=False,
+        automated_action_allowed=True,
+        decision_gate=None,
+        payload={"resource_id": "vol-123"},
+    )
+
+    async def _get_by_id(model, entity_id, scope_tenant_id):
+        if model is OptimizationFinding:
+            assert entity_id == finding_id
+            assert scope_tenant_id == tenant_id
+            return finding
+        return MagicMock(id=connection_id, tenant_id=tenant_id, status="active")
+
+    remediation_service.get_by_id = AsyncMock(side_effect=_get_by_id)
+    remediation_service._build_system_policy_context = AsyncMock(
+        return_value={"source": "finding"}
+    )
+
+    request = await remediation_service.create_request_from_finding(
+        tenant_id=tenant_id,
+        user_id=user_id,
+        finding_id=finding_id,
+        action=RemediationAction.DELETE_VOLUME,
+        create_backup=True,
+    )
+
+    assert request.finding_id == finding_id
+    assert request.resource_id == "vol-123"
+    assert request.connection_id == connection_id
+    assert request.provider == "aws"
+    assert request.finding_snapshot["finding_id"] == str(finding_id)
+    assert request.finding_snapshot["category"] == "unattached_volumes"
+    assert request.estimated_monthly_savings == Decimal("50.0")
+    assert request.status == RemediationStatus.PENDING
+    db_session.add.assert_called_once()
+    db_session.commit.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_create_request_rejects_inactive_connection(remediation_service, db_session):
+    tenant_id = uuid4()
+    connection_id = uuid4()
+    remediation_service.get_by_id = AsyncMock(
+        return_value=MagicMock(id=connection_id, tenant_id=tenant_id, status="error")
+    )
+
+    with pytest.raises(ValdricsException) as exc_info:
+        await remediation_service.create_request(
+            tenant_id=tenant_id,
+            user_id=uuid4(),
+            resource_id="vol-1",
+            resource_type="ebs_volume",
+            action=RemediationAction.DELETE_VOLUME,
+            estimated_savings=10.0,
+            provider="aws",
+            connection_id=connection_id,
+        )
+
+    assert getattr(exc_info.value, "code", None) == "remediation_connection_inactive"
+    db_session.add.assert_not_called()
+    db_session.commit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_create_request_from_finding_rejects_duplicate_open_request(
+    remediation_service, db_session
+):
+    tenant_id = uuid4()
+    user_id = uuid4()
+    finding_id = uuid4()
+    connection_id = uuid4()
+    finding = OptimizationFinding(
+        id=finding_id,
+        tenant_id=tenant_id,
+        source=FindingSource.ZOMBIE_SCAN,
+        status=FindingStatus.OPEN,
+        fingerprint="d" * 64,
+        provider="aws",
+        category="unattached_volumes",
+        connection_id=connection_id,
+        connection_name="Prod AWS",
+        resource_id="vol-dup",
+        resource_type="ebs_volume",
+        region="us-east-1",
+        estimated_monthly_savings=Decimal("11.0"),
+        confidence_score=Decimal("0.91"),
+        explainability_notes="Duplicate request guard.",
+        requires_manual_review=False,
+        automated_action_allowed=True,
+        decision_gate=None,
+        payload={"resource_id": "vol-dup"},
+    )
+
+    async def _get_by_id(model, entity_id, scope_tenant_id):
+        if model is OptimizationFinding:
+            assert entity_id == finding_id
+            assert scope_tenant_id == tenant_id
+            return finding
+        return MagicMock(id=connection_id, tenant_id=tenant_id, status="active")
+
+    db_session.scalar = AsyncMock(
+        return_value=RemediationRequest(
+            id=uuid4(),
+            tenant_id=tenant_id,
+            resource_id="vol-dup",
+            resource_type="ebs_volume",
+            provider="aws",
+            connection_id=connection_id,
+            region="us-east-1",
+            action=RemediationAction.DELETE_VOLUME,
+            status=RemediationStatus.PENDING,
+            requested_by_user_id=uuid4(),
+        )
+    )
+    remediation_service.get_by_id = AsyncMock(side_effect=_get_by_id)
+    remediation_service._build_system_policy_context = AsyncMock(
+        return_value={"source": "finding"}
+    )
+
+    with pytest.raises(ValdricsException) as exc_info:
+        await remediation_service.create_request_from_finding(
+            tenant_id=tenant_id,
+            user_id=user_id,
+            finding_id=finding_id,
+            action=RemediationAction.DELETE_VOLUME,
+        )
+
+    assert getattr(exc_info.value, "code", None) == (
+        "remediation_request_duplicate_open_finding"
+    )
+    db_session.add.assert_not_called()
+    db_session.commit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_preview_policy_for_finding_uses_bound_finding_context(
+    remediation_service, db_session
+):
+    tenant_id = uuid4()
+    user_id = uuid4()
+    finding_id = uuid4()
+    connection_id = uuid4()
+    finding = OptimizationFinding(
+        id=finding_id,
+        tenant_id=tenant_id,
+        source=FindingSource.ZOMBIE_SCAN,
+        status=FindingStatus.OPEN,
+        fingerprint="a" * 64,
+        provider="aws",
+        category="idle_instances",
+        connection_id=connection_id,
+        connection_name="Prod AWS",
+        resource_id="i-123",
+        resource_type="ec2_instance",
+        region="us-east-1",
+        estimated_monthly_savings=Decimal("20.0"),
+        confidence_score=Decimal("0.88"),
+        explainability_notes="Idle instance detected.",
+        requires_manual_review=False,
+        automated_action_allowed=True,
+        decision_gate=None,
+        payload={"resource_id": "i-123"},
+    )
+
+    async def _get_by_id(model, entity_id, scope_tenant_id):
+        if model is OptimizationFinding:
+            assert entity_id == finding_id
+            assert scope_tenant_id == tenant_id
+            return finding
+        return MagicMock(id=connection_id, tenant_id=tenant_id, status="active")
+
+    remediation_service.get_by_id = AsyncMock(side_effect=_get_by_id)
+    remediation_service._build_system_policy_context = AsyncMock(
+        return_value={"source": "finding"}
+    )
+    remediation_service.preview_policy = AsyncMock(
+        return_value={"decision": "allow", "summary": "ok", "tier": "pro", "rule_hits": [], "config": {}}
+    )
+
+    result = await remediation_service.preview_policy_for_finding(
+        tenant_id=tenant_id,
+        user_id=user_id,
+        finding_id=finding_id,
+        action=RemediationAction.STOP_INSTANCE,
+        review_notes="validate first",
+    )
+
+    preview_request = remediation_service.preview_policy.await_args.args[0]
+    assert preview_request.finding_id == finding_id
+    assert preview_request.resource_id == "i-123"
+    assert preview_request.connection_id == connection_id
+    assert preview_request.finding_snapshot["fingerprint"] == "a" * 64
+    assert result["decision"] == "allow"
 
 
 @pytest.mark.asyncio
@@ -474,7 +713,151 @@ async def test_execute_backup_failure_aborts(remediation_service, db_session):
             request_id, tenant_id, bypass_grace_period=True
         )
         assert res.status == RemediationStatus.FAILED
-        assert "BACKUP_FAILED" in res.execution_error
+
+
+@pytest.mark.asyncio
+async def test_execute_fails_closed_when_finding_binding_mismatches(
+    remediation_service, db_session
+):
+    request_id = uuid4()
+    tenant_id = uuid4()
+    req = MagicMock(spec=RemediationRequest)
+    req.id = request_id
+    req.tenant_id = tenant_id
+    req.status = RemediationStatus.APPROVED
+    req.resource_id = "vol-actual"
+    req.resource_type = "ebs_volume"
+    req.action = RemediationAction.DELETE_VOLUME
+    req.create_backup = False
+    req.reviewed_by_user_id = uuid4()
+    req.estimated_monthly_savings = Decimal("15.0")
+    req.provider = "aws"
+    req.connection_id = uuid4()
+    req.finding_id = uuid4()
+    req.finding_snapshot = {
+        "provider": "aws",
+        "connection_id": str(req.connection_id),
+        "region": "us-east-1",
+        "resource_id": "vol-expected",
+        "resource_type": "ebs_volume",
+        "fingerprint": "b" * 64,
+    }
+    req.region = "us-east-1"
+    req.action_parameters = {}
+
+    mock_res = MagicMock()
+    mock_res.scalar_one_or_none.return_value = req
+    db_session.execute.return_value = mock_res
+
+    with (
+        patch(
+            "app.modules.optimization.domain.remediation.AuditLogger.log",
+            new=AsyncMock(),
+        ) as mock_audit_log,
+        patch(
+            "app.modules.optimization.domain.remediation.SafetyGuardrailService"
+        ) as mock_safety,
+    ):
+        mock_safety.return_value.check_all_guards = AsyncMock()
+        result = await remediation_service.execute(
+            request_id, tenant_id, bypass_grace_period=True
+        )
+
+    assert result.status == RemediationStatus.FAILED
+    assert "bound finding context" in (result.execution_error or "")
+    mock_safety.return_value.check_all_guards.assert_not_awaited()
+    assert mock_audit_log.await_count >= 1
+
+
+@pytest.mark.asyncio
+async def test_execute_resolves_bound_finding_on_success(remediation_service, db_session):
+    request_id = uuid4()
+    tenant_id = uuid4()
+    connection_id = uuid4()
+    finding_id = uuid4()
+    finding = OptimizationFinding(
+        id=finding_id,
+        tenant_id=tenant_id,
+        source=FindingSource.ZOMBIE_SCAN,
+        status=FindingStatus.OPEN,
+        fingerprint="c" * 64,
+        provider="aws",
+        category="idle_instances",
+        connection_id=connection_id,
+        connection_name="Prod AWS",
+        resource_id="i-123",
+        resource_type="ec2_instance",
+        region="us-east-1",
+        estimated_monthly_savings=Decimal("20.0"),
+        confidence_score=Decimal("0.88"),
+        explainability_notes="Idle instance detected.",
+        requires_manual_review=False,
+        automated_action_allowed=True,
+        decision_gate=None,
+        payload={"resource_id": "i-123"},
+    )
+    req = MagicMock(spec=RemediationRequest)
+    req.id = request_id
+    req.tenant_id = tenant_id
+    req.status = RemediationStatus.APPROVED
+    req.resource_id = "i-123"
+    req.resource_type = "ec2_instance"
+    req.action = RemediationAction.STOP_INSTANCE
+    req.create_backup = False
+    req.reviewed_by_user_id = uuid4()
+    req.estimated_monthly_savings = Decimal("20.0")
+    req.provider = "aws"
+    req.connection_id = connection_id
+    req.finding_id = finding_id
+    req.finding_snapshot = {
+        "provider": "aws",
+        "connection_id": str(connection_id),
+        "region": "us-east-1",
+        "resource_id": "i-123",
+        "resource_type": "ec2_instance",
+        "fingerprint": "c" * 64,
+    }
+    req.region = "us-east-1"
+    req.action_parameters = {}
+
+    mock_res = MagicMock()
+    mock_res.scalar_one_or_none.return_value = req
+    db_session.execute.return_value = mock_res
+    remediation_service.get_by_id = AsyncMock(return_value=finding)
+    remediation_service._resolve_credentials = AsyncMock(
+        return_value={"region": "us-east-1"}
+    )
+
+    with (
+        patch(
+            "app.modules.optimization.domain.remediation.RemediationActionFactory.get_strategy"
+        ) as mock_get_strategy,
+        patch(
+            "app.modules.optimization.domain.remediation.AuditLogger.log",
+            new=AsyncMock(),
+        ),
+        patch(
+            "app.modules.optimization.domain.remediation.SafetyGuardrailService"
+        ) as mock_safety,
+    ):
+        mock_safety.return_value.check_all_guards = AsyncMock()
+        mock_strategy = MagicMock()
+        mock_strategy.execute = AsyncMock(
+            return_value=ExecutionResult(
+                status=ExecutionStatus.SUCCESS,
+                resource_id="i-123",
+                action_taken=RemediationAction.STOP_INSTANCE.value,
+            )
+        )
+        mock_get_strategy.return_value = mock_strategy
+
+        result = await remediation_service.execute(
+            request_id, tenant_id, bypass_grace_period=True
+        )
+
+    assert result.status == RemediationStatus.COMPLETED
+    assert finding.status == FindingStatus.RESOLVED
+    assert finding.resolved_at is not None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/supply_chain/test_feature_enforceability_matrix.py
+++ b/tests/unit/supply_chain/test_feature_enforceability_matrix.py
@@ -5,7 +5,10 @@ from pathlib import Path
 
 import pytest
 
-from scripts.generate_feature_enforceability_matrix import generate_matrix
+from scripts.generate_feature_enforceability_matrix import (
+    _feature_runtime_gate_for_file,
+    generate_matrix,
+)
 from scripts.verify_feature_enforceability_matrix import verify_matrix
 
 
@@ -34,3 +37,22 @@ def test_verify_feature_enforceability_matrix_rejects_missing_paid_feature(
 
     with pytest.raises(ValueError, match="missing paid-tier features"):
         verify_matrix(artifact_path=out, repo_root=REPO_ROOT)
+
+
+def test_feature_runtime_gate_detection_handles_multiline_calls() -> None:
+    raw = """
+from app.shared.core.dependencies import requires_feature
+from app.shared.core.pricing import FeatureFlag
+
+Depends(
+    requires_feature(
+        FeatureFlag.COMPLIANCE_EXPORTS,
+        required_role="admin",
+    )
+)
+"""
+
+    assert _feature_runtime_gate_for_file(
+        token="FeatureFlag.COMPLIANCE_EXPORTS",
+        raw=raw,
+    )

--- a/tests/unit/supply_chain/test_supply_chain_provenance.py
+++ b/tests/unit/supply_chain/test_supply_chain_provenance.py
@@ -94,3 +94,50 @@ def test_generate_provenance_manifest_is_json_serializable(tmp_path: Path) -> No
 
     encoded = json.dumps(manifest, sort_keys=True)
     assert "dependency_inputs" in encoded
+
+
+def test_generate_provenance_manifest_rejects_duplicate_dependency_inputs(
+    tmp_path: Path,
+) -> None:
+    _write(tmp_path / "pyproject.toml", "[project]\nname='x'\n")
+
+    with pytest.raises(ValueError, match="duplicate path"):
+        generate_provenance_manifest(
+            repo_root=tmp_path,
+            dependency_inputs=(Path("pyproject.toml"), Path("./pyproject.toml")),
+            sbom_dir=None,
+            env={},
+        )
+
+
+def test_generate_provenance_manifest_rejects_dependency_inputs_outside_repo_root(
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir(parents=True, exist_ok=True)
+    _write(tmp_path / "outside.txt", "top-secret\n")
+
+    with pytest.raises(ValueError, match="must stay within repo root"):
+        generate_provenance_manifest(
+            repo_root=repo_root,
+            dependency_inputs=(Path("../outside.txt"),),
+            sbom_dir=None,
+            env={},
+        )
+
+
+def test_generate_provenance_manifest_rejects_sbom_dir_outside_repo_root(
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir(parents=True, exist_ok=True)
+    _write(repo_root / "pyproject.toml", "[project]\nname='x'\n")
+    _write(tmp_path / "external-sbom/python.json", '{"bomFormat":"CycloneDX"}\n')
+
+    with pytest.raises(ValueError, match="sbom_dir must stay within repo root"):
+        generate_provenance_manifest(
+            repo_root=repo_root,
+            dependency_inputs=(Path("pyproject.toml"),),
+            sbom_dir=Path("../external-sbom"),
+            env={},
+        )

--- a/tests/unit/test_main_coverage.py
+++ b/tests/unit/test_main_coverage.py
@@ -54,7 +54,7 @@ async def test_lifespan_flow(mock_lifespan_deps):
 
     with (
         patch("app.main.should_bootstrap_local_sqlite", return_value=False),
-        patch("app.main.reset_db_runtime"),
+        patch("app.main.dispose_db_runtime", new_callable=AsyncMock),
     ):
         async with lifespan(app):
             mock_lifespan_deps["makedirs"].assert_called_with(
@@ -79,7 +79,7 @@ async def test_lifespan_skips_scheduler_when_disabled(mock_lifespan_deps):
 
         with (
             patch("app.main.should_bootstrap_local_sqlite", return_value=False),
-            patch("app.main.reset_db_runtime"),
+            patch("app.main.dispose_db_runtime", new_callable=AsyncMock),
         ):
             async with lifespan(app):
                 pass
@@ -94,7 +94,7 @@ async def test_lifespan_bootstraps_local_sqlite_when_enabled(mock_lifespan_deps)
     with (
         patch("app.main.should_bootstrap_local_sqlite", return_value=True),
         patch("app.main.bootstrap_local_sqlite_schema", new_callable=AsyncMock) as bootstrap,
-        patch("app.main.reset_db_runtime"),
+        patch("app.main.dispose_db_runtime", new_callable=AsyncMock),
     ):
         async with lifespan(app):
             pass

--- a/tests/unit/zombies/test_zombies_api_branches.py
+++ b/tests/unit/zombies/test_zombies_api_branches.py
@@ -78,10 +78,8 @@ async def test_preview_remediation_policy_payload_invalid_action() -> None:
     )
 
     payload = zombies.PolicyPreviewCreate(
-        resource_id="i-gpu-123",
-        resource_type="GPU Compute",
+        finding_id=uuid4(),
         action="invalid_action",
-        provider="aws",
     )
 
     with pytest.raises(ValdricsException, match="Invalid action"):
@@ -96,7 +94,7 @@ async def test_preview_remediation_policy_payload_invalid_action() -> None:
 @pytest.mark.asyncio
 async def test_preview_remediation_policy_payload_success() -> None:
     tenant_id = uuid4()
-    connection_id = uuid4()
+    finding_id = uuid4()
     db = AsyncMock()
     user = CurrentUser(
         id=uuid4(),
@@ -107,13 +105,8 @@ async def test_preview_remediation_policy_payload_success() -> None:
     )
 
     payload = zombies.PolicyPreviewCreate(
-        resource_id="i-gpu-123",
-        resource_type="GPU Compute",
+        finding_id=finding_id,
         action="terminate_instance",
-        provider="aws",
-        connection_id=connection_id,
-        confidence_score=0.88,
-        explainability_notes="gpu node from dev experiment",
         review_notes="manual validation",
     )
 
@@ -121,7 +114,7 @@ async def test_preview_remediation_policy_payload_success() -> None:
         "app.modules.optimization.api.v1.zombies.RemediationService"
     ) as service_cls:
         service = service_cls.return_value
-        service.preview_policy_input = AsyncMock(
+        service.preview_policy_for_finding = AsyncMock(
             return_value={
                 "decision": "escalate",
                 "summary": "GPU-related remediation requires explicit GPU approval override.",
@@ -145,11 +138,38 @@ async def test_preview_remediation_policy_payload_success() -> None:
 
         assert response.decision == "escalate"
         assert response.tier == "pro"
-        service.preview_policy_input.assert_awaited_once()
-        assert (
-            service.preview_policy_input.await_args.kwargs["connection_id"]
-            == connection_id
-        )
+        service.preview_policy_for_finding.assert_awaited_once()
+        assert service.preview_policy_for_finding.await_args.kwargs["finding_id"] == finding_id
+
+
+@pytest.mark.asyncio
+async def test_list_remediation_history_translates_invalid_status() -> None:
+    tenant_id = uuid4()
+    db = AsyncMock()
+    user = CurrentUser(
+        id=uuid4(),
+        email="member@example.com",
+        tenant_id=tenant_id,
+        role=UserRole.MEMBER,
+        tier=PricingTier.PRO,
+    )
+
+    with patch(
+        "app.modules.optimization.api.v1.zombies.RemediationService"
+    ) as service_cls:
+        service = service_cls.return_value
+        service.list_history = AsyncMock(side_effect=ValueError("bad status"))
+
+        with pytest.raises(ValdricsException) as exc_info:
+            await zombies.list_remediation_history(
+                tenant_id=tenant_id,
+                user=user,
+                db=db,
+                status="completed",
+            )
+
+    assert exc_info.value.code == "remediation_history_invalid_status"
+    assert exc_info.value.status_code == 400
 
 
 @pytest.mark.asyncio
@@ -690,18 +710,15 @@ async def test_create_remediation_request_default_region_hint_is_global() -> Non
     created = MagicMock()
     created.id = uuid4()
     payload = zombies.RemediationRequestCreate(
-        resource_id="vm-123",
-        resource_type="VM Instance",
+        finding_id=uuid4(),
         action="stop_instance",
-        provider="azure",
-        estimated_savings=25.5,
     )
 
     with patch(
         "app.modules.optimization.api.v1.zombies.RemediationService"
     ) as service_cls:
         service = service_cls.return_value
-        service.create_request = AsyncMock(return_value=created)
+        service.create_request_from_finding = AsyncMock(return_value=created)
 
         result = await zombies.create_remediation_request(
             request=payload,
@@ -712,3 +729,73 @@ async def test_create_remediation_request_default_region_hint_is_global() -> Non
 
     service_cls.assert_called_once_with(db=db, region="global")
     assert result["status"] == "pending"
+
+
+@pytest.mark.asyncio
+async def test_create_remediation_request_normalizes_value_error_from_service() -> None:
+    tenant_id = uuid4()
+    db = AsyncMock()
+    user = CurrentUser(
+        id=uuid4(),
+        email="admin@example.com",
+        tenant_id=tenant_id,
+        role=UserRole.ADMIN,
+        tier=PricingTier.PRO,
+    )
+    payload = zombies.RemediationRequestCreate(
+        finding_id=uuid4(),
+        action="stop_instance",
+    )
+
+    with patch(
+        "app.modules.optimization.api.v1.zombies.RemediationService"
+    ) as service_cls:
+        service = service_cls.return_value
+        service.create_request_from_finding = AsyncMock(
+            side_effect=ValueError("invalid binding")
+        )
+
+        with pytest.raises(ValdricsException) as exc_info:
+            await zombies.create_remediation_request(
+                request=payload,
+                tenant_id=tenant_id,
+                user=user,
+                db=db,
+            )
+
+    assert exc_info.value.code == "remediation_request_invalid"
+
+
+@pytest.mark.asyncio
+async def test_preview_remediation_policy_payload_normalizes_value_error_from_service() -> None:
+    tenant_id = uuid4()
+    db = AsyncMock()
+    user = CurrentUser(
+        id=uuid4(),
+        email="admin@example.com",
+        tenant_id=tenant_id,
+        role=UserRole.ADMIN,
+        tier=PricingTier.PRO,
+    )
+    payload = zombies.PolicyPreviewCreate(
+        finding_id=uuid4(),
+        action="terminate_instance",
+    )
+
+    with patch(
+        "app.modules.optimization.api.v1.zombies.RemediationService"
+    ) as service_cls:
+        service = service_cls.return_value
+        service.preview_policy_for_finding = AsyncMock(
+            side_effect=ValueError("invalid preview")
+        )
+
+        with pytest.raises(ValdricsException) as exc_info:
+            await zombies.preview_remediation_policy_payload(
+                payload=payload,
+                tenant_id=tenant_id,
+                user=user,
+                db=db,
+            )
+
+    assert exc_info.value.code == "remediation_policy_preview_invalid"


### PR DESCRIPTION
## Summary
- categorize the full 2026-03-18 pending batch in `docs/ops/all_changes_categorization_2026-03-18.md`
- consolidate optimization/remediation backend work, public and ops dashboard updates, runtime/security hardening, and operational evidence tooling into one tracked merge batch
- close the four track issues created for the review lanes

## Tracks
- closes #307
- closes #308
- closes #309
- closes #310

## Notes
- local categorization snapshot covered `105` changed paths and produced `4` non-overlapping review tracks
- no fresh full local test suite was run in this batching turn before opening the PR
