### PR TITLE
chore: categorize and consolidate all pending changes (2026-03-23)

### DIFF
--- a/dashboard/scripts/capture-dashboard-hero-still.ts
+++ b/dashboard/scripts/capture-dashboard-hero-still.ts
@@ -1,0 +1,52 @@
+import { mkdir } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { chromium } from 'playwright';
+
+import { BASE_URL, enableAuthenticatedSession } from '../e2e/support/e2eAuth';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const outputPath = resolve(
+	process.env.HERO_STILL_OUTPUT_PATH || resolve(__dirname, '../static/landing-dashboard-still.jpg')
+);
+const routePath = process.env.HERO_STILL_ROUTE || '/dashboard';
+const viewportWidth = Number(process.env.HERO_STILL_VIEWPORT_WIDTH || '1440');
+const viewportHeight = Number(process.env.HERO_STILL_VIEWPORT_HEIGHT || '960');
+
+const browser = await chromium.launch({
+	headless: true
+});
+
+try {
+	const context = await browser.newContext({
+		viewport: { width: viewportWidth, height: viewportHeight },
+		deviceScaleFactor: 1
+	});
+
+	await enableAuthenticatedSession(context);
+
+	const page = await context.newPage();
+	await page.emulateMedia({ reducedMotion: 'reduce' });
+	await page.goto(new URL(routePath, BASE_URL).toString(), {
+		waitUntil: 'domcontentloaded'
+	});
+	await page.waitForLoadState('networkidle');
+	await page.getByRole('heading', { level: 1, name: /dashboard/i }).waitFor({
+		state: 'visible',
+		timeout: 30_000
+	});
+	await page.waitForTimeout(400);
+
+	await mkdir(dirname(outputPath), { recursive: true });
+	await page.screenshot({
+		path: outputPath,
+		type: 'jpeg',
+		quality: 84,
+		fullPage: false,
+		animations: 'disabled',
+		caret: 'hide'
+	});
+} finally {
+	await browser.close();
+}

--- a/dashboard/src/lib/components/LandingHero.svelte
+++ b/dashboard/src/lib/components/LandingHero.svelte
@@ -41,7 +41,6 @@
 	import { getReducedMotionPreference } from '$lib/landing/reducedMotion';
 	import { BUYER_ROLE_VIEWS, HERO_ROLE_CONTEXT } from '$lib/landing/heroContent';
 	import LandingHeroView from '$lib/components/landing/LandingHeroView.svelte';
-	import './LandingHero.css';
 	const DEFAULT_SIGNAL_SNAPSHOT = REALTIME_SIGNAL_SNAPSHOTS[0];
 	const ONE_PAGER_HREF = `${base}/resources/valdrics-enterprise-one-pager.md`,
 		RESOURCES_PATH = `${base}/resources`;

--- a/dashboard/src/lib/components/LandingHero.svelte.test.ts
+++ b/dashboard/src/lib/components/LandingHero.svelte.test.ts
@@ -65,7 +65,9 @@ describe('LandingHero', () => {
 
 		expect(screen.queryByText(/prelaunch, with honest public review surfaces/i)).toBeNull();
 		expect(screen.getAllByRole('link', { name: /about \/ team/i }).length).toBeGreaterThan(0);
-		expect(screen.getByRole('link', { name: /open enterprise path/i })).toBeTruthy();
+		const enterpriseReviewLinks = screen.getAllByRole('link', { name: /^enterprise review$/i });
+		expect(enterpriseReviewLinks.length).toBeGreaterThan(0);
+		expect(enterpriseReviewLinks[0]?.getAttribute('href') || '').toContain('/enterprise?');
 
 		await fireEvent.click(
 			screen.getAllByRole('link', { name: /start free workspace|book executive briefing/i })[0]!

--- a/dashboard/src/lib/components/landing/LandingCurrencyToggle.svelte
+++ b/dashboard/src/lib/components/landing/LandingCurrencyToggle.svelte
@@ -58,7 +58,7 @@
 	</div>
 	{#if showUsdToggle}
 		<p class="landing-currency-toggle__note">
-			Local display uses indicative FX for comparison. Toggle USD to view the base-model values.
+			Local currency uses indicative FX. Switch to USD to compare.
 		</p>
 	{/if}
 </div>

--- a/dashboard/src/lib/components/landing/LandingHeroCopy.svelte
+++ b/dashboard/src/lib/components/landing/LandingHeroCopy.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { ABOVE_FOLD_TRUST_RAIL } from '$lib/landing/heroContent';
+	import './LandingMarketingShared.css';
 
 	const heroTrustRail = ABOVE_FOLD_TRUST_RAIL.slice(0, 3);
 

--- a/dashboard/src/lib/components/landing/LandingHeroView.public.css
+++ b/dashboard/src/lib/components/landing/LandingHeroView.public.css
@@ -207,7 +207,8 @@
 	box-shadow: 0 16px 34px rgb(15 23 42 / 0.05);
 }
 
-.landing-public-mockup {
+.landing-public-mockup,
+.landing-public-product-still {
 	display: grid;
 	gap: 0;
 	overflow: hidden;
@@ -215,7 +216,8 @@
 	position: relative;
 }
 
-.landing-public-mockup::after {
+.landing-public-mockup::after,
+.landing-public-product-still::after {
 	content: '';
 	position: absolute;
 	inset: auto auto 1rem 1rem;
@@ -226,6 +228,10 @@
 	filter: blur(10px);
 	pointer-events: none;
 	animation: landingPublicHaloPulse 8s ease-in-out infinite;
+}
+
+.landing-public-product-still {
+	gap: 0;
 }
 
 .landing-public-windowbar {
@@ -311,6 +317,70 @@
 	grid-template-columns: minmax(13rem, 15rem) minmax(0, 1fr);
 	gap: 1rem;
 	padding: 1rem;
+}
+
+.landing-public-still-frame {
+	display: grid;
+	gap: 0.6rem;
+	padding: 1rem 1rem 0.85rem;
+	margin: 0;
+}
+
+.landing-public-still-image {
+	display: block;
+	width: 100%;
+	height: auto;
+	border-radius: 1rem;
+	border: 1px solid rgb(8 126 164 / 0.1);
+	box-shadow: 0 22px 44px rgb(15 23 42 / 0.1);
+	background: rgb(240 245 248);
+}
+
+.landing-public-still-caption {
+	margin: 0;
+	font-size: 0.83rem;
+	line-height: 1.45;
+	color: var(--color-ink-500);
+}
+
+.landing-public-still-notes {
+	display: grid;
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+	gap: 0.75rem;
+	padding: 0 1rem 1rem;
+}
+
+.landing-public-still-note {
+	display: grid;
+	gap: 0.24rem;
+	padding: 0.85rem 0.9rem;
+	border: 1px solid rgb(8 126 164 / 0.08);
+	border-radius: 0.95rem;
+	background: rgb(246 250 252 / 0.96);
+	box-shadow: 0 12px 26px rgb(15 23 42 / 0.04);
+}
+
+.landing-public-still-note span,
+.landing-public-still-note small {
+	color: var(--color-ink-500);
+}
+
+.landing-public-still-note span {
+	font-size: 0.72rem;
+	font-weight: 800;
+	letter-spacing: 0.1em;
+	text-transform: uppercase;
+}
+
+.landing-public-still-note strong {
+	font-size: 0.98rem;
+	line-height: 1.35;
+	color: var(--color-ink-950);
+}
+
+.landing-public-still-note small {
+	font-size: 0.82rem;
+	line-height: 1.45;
 }
 
 .landing-public-mockup-rail {
@@ -793,6 +863,7 @@
 }
 
 .landing-public-mockup,
+.landing-public-product-still,
 .landing-public-proof-item,
 .landing-public-pillar-card,
 .landing-public-plan-card,
@@ -801,7 +872,8 @@
 	animation: landingPublicRise 680ms var(--ease-out) both;
 }
 
-.landing-public-mockup {
+.landing-public-mockup,
+.landing-public-product-still {
 	animation-delay: 140ms;
 }
 
@@ -824,6 +896,7 @@
 }
 
 .landing-public-mockup:hover,
+.landing-public-product-still:hover,
 .landing-public-pillar-card:hover,
 .landing-public-plan-card:hover,
 .landing-public-trust-card:hover,
@@ -853,7 +926,8 @@
 	.landing-public-annotation-row,
 	.landing-public-record-stats,
 	.landing-public-kpi-strip,
-	.landing-public-drawer-grid {
+	.landing-public-drawer-grid,
+	.landing-public-still-notes {
 		grid-template-columns: 1fr;
 	}
 
@@ -874,6 +948,7 @@
 	}
 
 	.landing-public-mockup,
+	.landing-public-product-still,
 	.landing-public-pillar-card,
 	.landing-public-plan-card,
 	.landing-public-trust-card,
@@ -883,13 +958,16 @@
 		border-radius: 1.15rem;
 	}
 
-	.landing-public-mockup {
+	.landing-public-mockup,
+	.landing-public-product-still {
 		padding: 0;
 	}
 
 	.landing-public-windowbar,
 	.landing-public-mockup-body,
-	.landing-public-annotation-row {
+	.landing-public-annotation-row,
+	.landing-public-still-frame,
+	.landing-public-still-notes {
 		padding-left: 0.85rem;
 		padding-right: 0.85rem;
 	}
@@ -1029,7 +1107,8 @@
 	animation-delay: 280ms;
 }
 
-.landing-motion-cinematic .landing-public-mockup {
+.landing-motion-cinematic .landing-public-mockup,
+.landing-motion-cinematic .landing-public-product-still {
 	animation:
 		landingPublicRise 680ms var(--ease-out) both,
 		landingPublicPreviewFloat 7s ease-in-out 820ms infinite;
@@ -1224,7 +1303,23 @@
 	color: rgb(103 232 249);
 }
 
+.public-site-shell[data-public-theme='dark'] .landing-public-still-caption,
+.public-site-shell[data-public-theme='dark'] .landing-public-still-note span,
+.public-site-shell[data-public-theme='dark'] .landing-public-still-note small {
+	color: var(--color-ink-400);
+}
+
+.public-site-shell[data-public-theme='dark'] .landing-public-still-note {
+	border-color: rgb(255 255 255 / 0.1);
+	background: rgb(255 255 255 / 0.04);
+}
+
+.public-site-shell[data-public-theme='dark'] .landing-public-still-note strong {
+	color: var(--color-ink-100);
+}
+
 .public-site-shell[data-public-theme='dark'] .landing-public-mockup:hover,
+.public-site-shell[data-public-theme='dark'] .landing-public-product-still:hover,
 .public-site-shell[data-public-theme='dark'] .landing-public-pillar-card:hover,
 .public-site-shell[data-public-theme='dark'] .landing-public-plan-card:hover,
 .public-site-shell[data-public-theme='dark'] .landing-public-trust-card:hover,
@@ -1239,12 +1334,13 @@
 	.landing-public-pillar-card,
 	.landing-public-plan-card,
 	.landing-public-trust-card,
-	.landing-public-band,
-	.landing-public-hero::before,
-	.landing-public-hero::after,
-	.landing-public-hero-orb,
-	.landing-public-hero-ring,
-	.landing-public-mockup::after {
+		.landing-public-band,
+		.landing-public-hero::before,
+		.landing-public-hero::after,
+		.landing-public-hero-orb,
+		.landing-public-hero-ring,
+		.landing-public-mockup::after,
+		.landing-public-product-still::after {
 		animation: none !important;
 		opacity: 1;
 		transform: none;

--- a/dashboard/src/lib/components/landing/LandingHeroView.svelte
+++ b/dashboard/src/lib/components/landing/LandingHeroView.svelte
@@ -10,6 +10,7 @@
 	import LandingRoiSimulator from '$lib/components/landing/LandingRoiSimulator.svelte';
 	import LandingCookieConsent from '$lib/components/landing/LandingCookieConsent.svelte';
 	import LandingExitIntentPrompt from '$lib/components/landing/LandingExitIntentPrompt.svelte';
+	import './LandingMarketingShared.css';
 	import './LandingHeroView.public.css';
 
 	const productPillars = [
@@ -73,7 +74,7 @@
 		}).format(date);
 	}
 
-	let hoveredLaneId = $state<SignalLaneId | null>(null);
+	const dashboardStillSrc = `${base}/landing-dashboard-still.jpg`;
 
 	let {
 		motionProfile,
@@ -179,17 +180,13 @@
 		showBackToTop: boolean;
 	} = $props();
 
-	let interactiveSignalLane = $derived(
-		activeSnapshot.lanes.find((lane) => lane.id === hoveredLaneId) ?? activeSignalLane
-	);
 	let highlightedWasteUsd = $derived(
-		interactiveSignalLane.wasteUsd ??
+		activeSignalLane.wasteUsd ??
 			activeSnapshot.lanes.find((lane) => typeof lane.wasteUsd === 'number')?.wasteUsd ??
 			12400
 	);
-	let highlightedSources = $derived(activeSnapshot.sources.slice(0, 3));
-	let highlightedActionLabel = $derived(interactiveSignalLane.actionLabel ?? 'Assign owner');
-	let laneSeverityTone = $derived(interactiveSignalLane.severity ?? 'healthy');
+	let highlightedActionLabel = $derived(activeSignalLane.actionLabel ?? 'Assign owner');
+	let laneSeverityTone = $derived(activeSignalLane.severity ?? 'healthy');
 </script>
 
 <div
@@ -228,8 +225,8 @@
 				/>
 
 				<aside
-					class="landing-public-surface landing-public-mockup"
-					aria-label="Product decision mockup"
+					class="landing-public-surface landing-public-product-still"
+					aria-label="Real product dashboard screenshot"
 				>
 					<div class="landing-public-windowbar">
 						<div class="landing-public-window-dots" aria-hidden="true">
@@ -237,152 +234,46 @@
 							<span></span>
 							<span></span>
 						</div>
-						<p class="landing-public-window-title">Valdrics workspace · {activeSnapshot.label}</p>
+						<p class="landing-public-window-title">
+							Valdrics dashboard · {activeSnapshot.label}
+						</p>
 						<p class={`landing-public-window-status is-${laneSeverityTone}`}>
-							{interactiveSignalLane.status}
+							{activeSignalLane.status}
 						</p>
 					</div>
 
-					<div class="landing-public-mockup-body">
-						<div class="landing-public-mockup-rail">
-							<p class="landing-public-eyebrow">What the first workflow looks like</p>
-							<ol class="landing-public-step-list">
-								{#each activeSnapshot.lanes as lane, index (lane.id)}
-									<li class:active={interactiveSignalLane.id === lane.id}>
-										<button
-											type="button"
-											class="landing-public-step-trigger"
-											aria-pressed={interactiveSignalLane.id === lane.id}
-											aria-label={`Inspect ${publicLaneTitles[lane.id] ?? lane.title}`}
-											onmouseenter={() => (hoveredLaneId = lane.id)}
-											onfocus={() => (hoveredLaneId = lane.id)}
-											onmouseleave={() => (hoveredLaneId = null)}
-											onblur={() => (hoveredLaneId = null)}
-											onclick={() =>
-												(hoveredLaneId = interactiveSignalLane.id === lane.id ? null : lane.id)}
-										>
-											<span>0{index + 1}</span>
-											<div>
-												<strong>{publicLaneTitles[lane.id] ?? lane.title}</strong>
-												<p>{lane.metric}</p>
-											</div>
-										</button>
-									</li>
-								{/each}
-							</ol>
-						</div>
+					<figure class="landing-public-still-frame">
+						<img
+							class="landing-public-still-image"
+							src={dashboardStillSrc}
+							alt="Real Valdrics dashboard showing savings metrics, active findings, and owner-routed actions."
+							width="1440"
+							height="960"
+							loading="eager"
+							decoding="async"
+							fetchpriority="high"
+						/>
+						<figcaption class="landing-public-still-caption">
+							Real workspace still from the signed-in dashboard.
+						</figcaption>
+					</figure>
 
-						<div class="landing-public-mockup-main">
-							<div class="landing-public-record-card">
-								<div class="landing-public-record-head">
-									<div>
-										<p class="landing-public-proof-label">Active decision record</p>
-										<h2 class="landing-public-preview-title">{activeSnapshot.headline}</h2>
-										<p class="landing-public-preview-copy">{activeSnapshot.decisionSummary}</p>
-									</div>
-									<div class="landing-public-record-pill">
-										{publicLaneTitles[interactiveSignalLane.id] ?? interactiveSignalLane.title}
-									</div>
-								</div>
-
-								<div class="landing-public-record-stats">
-									<article>
-										<span>Decision record</span>
-										<strong>{activeSnapshot.traceId}</strong>
-									</article>
-									<article>
-										<span>Captured</span>
-										<strong>{formatCapturedAt(activeSnapshot.capturedAt)}</strong>
-									</article>
-									<article>
-										<span>Spend at risk</span>
-										<strong>{formatUsd(highlightedWasteUsd, currencyCode)}</strong>
-									</article>
-									<article>
-										<span>Next action</span>
-										<strong>{highlightedActionLabel}</strong>
-									</article>
-								</div>
-							</div>
-
-							<div class="landing-public-kpi-strip" aria-label="Workspace summary">
-								<article class="landing-public-kpi-card">
-									<span>Owners aligned</span>
-									<strong>Finance + Engineering</strong>
-									<small>One shared record instead of handoff threads.</small>
-								</article>
-								<article class="landing-public-kpi-card">
-									<span>Approval queue</span>
-									<strong>{activeSnapshot.lanes.length} tracked stages</strong>
-									<small>Checks and approvals stay visible in one view.</small>
-								</article>
-								<article class="landing-public-kpi-card">
-									<span>Evidence ready</span>
-									<strong>{activeSnapshot.sources.length} linked inputs</strong>
-									<small>Exports and proof stay attached to the decision.</small>
-								</article>
-							</div>
-
-							<div class="landing-public-drawer-grid">
-								<article class="landing-public-drawer">
-									<p class="landing-public-proof-label">Approval queue</p>
-									<div class="landing-public-queue-list">
-										{#each activeSnapshot.lanes as lane, index (lane.id)}
-											<div class="landing-public-queue-row">
-												<span class="landing-public-queue-index">0{index + 1}</span>
-												<div class="landing-public-queue-copy">
-													<strong>{publicLaneTitles[lane.id] ?? lane.title}</strong>
-													<small>{lane.status}</small>
-												</div>
-												<span class={`landing-public-queue-pill is-${lane.severity}`}>
-													{lane.metric}
-												</span>
-											</div>
-										{/each}
-									</div>
-									<div class="landing-public-drawer-foot">
-										<span>Current stage</span>
-										<strong
-											>{publicLaneTitles[interactiveSignalLane.id] ??
-												interactiveSignalLane.title}</strong
-										>
-									</div>
-								</article>
-
-								<article class="landing-public-drawer">
-									<p class="landing-public-proof-label">Evidence linked</p>
-									<div class="landing-public-evidence-list" aria-label="Linked sources">
-										{#each highlightedSources as source (source)}
-											<div class="landing-public-evidence-row">
-												<strong>{source}</strong>
-												<small>Attached to {activeSnapshot.traceId}</small>
-											</div>
-										{/each}
-									</div>
-									<div class="landing-public-drawer-foot">
-										<span>Why teams care</span>
-										<strong>Context, owner, and proof stay in one review screen.</strong>
-									</div>
-								</article>
-							</div>
-						</div>
-					</div>
-
-					<div class="landing-public-annotation-row" aria-label="Product mockup annotations">
-						<div class="landing-public-annotation">
-							<span>Context</span>
-							<strong>Signal, source, and cost impact stay attached before review starts.</strong>
-						</div>
-						<div class="landing-public-annotation">
-							<span>Control</span>
-							<strong>Checks, approval, and execution path stay visible on the same record.</strong>
-						</div>
-						<div class="landing-public-annotation">
-							<span>Proof</span>
-							<strong
-								>Outcome and savings narrative are ready for finance or procurement reuse.</strong
-							>
-						</div>
+					<div class="landing-public-still-notes" aria-label="Why this screenshot matters">
+						<article class="landing-public-still-note">
+							<span>Decision record</span>
+							<strong>{activeSnapshot.traceId}</strong>
+							<small>{formatCapturedAt(activeSnapshot.capturedAt)}</small>
+						</article>
+						<article class="landing-public-still-note">
+							<span>Current stage</span>
+							<strong>{publicLaneTitles[activeSignalLane.id] ?? activeSignalLane.title}</strong>
+							<small>{highlightedActionLabel}</small>
+						</article>
+						<article class="landing-public-still-note">
+							<span>Linked proof</span>
+							<strong>{activeSnapshot.sources.length} attached inputs</strong>
+							<small>{formatUsd(highlightedWasteUsd, currencyCode)} at risk tracked</small>
+						</article>
 					</div>
 				</aside>
 			</div>
@@ -397,8 +288,8 @@
 					<strong>Owner, approval, and proof stay on one operating record</strong>
 				</article>
 				<article class="landing-public-surface landing-public-proof-item" role="listitem">
-					<p class="landing-public-proof-label">Buyer readiness</p>
-					<strong>Pricing, proof, docs, and company details stay public before a call</strong>
+					<p class="landing-public-proof-label">Open materials</p>
+					<strong>Pricing, proof, docs, and company details are public</strong>
 				</article>
 			</div>
 		</div>
@@ -434,13 +325,11 @@
 				<div class="landing-public-impact-grid">
 					<div>
 						<span>Current stage</span>
-						<strong
-							>{publicLaneTitles[interactiveSignalLane.id] ?? interactiveSignalLane.title}</strong
-						>
+						<strong>{publicLaneTitles[activeSignalLane.id] ?? activeSignalLane.title}</strong>
 					</div>
 					<div>
 						<span>Action path</span>
-						<strong>{interactiveSignalLane.actionLabel ?? 'Assigned before review'}</strong>
+						<strong>{activeSignalLane.actionLabel ?? 'Assigned before review'}</strong>
 					</div>
 					<div>
 						<span>Linked sources</span>
@@ -515,11 +404,11 @@
 			</div>
 			<div class="landing-public-band landing-public-band--compact">
 				<div>
-					<p class="landing-public-eyebrow">Need more detail?</p>
-					<h3>Published list pricing stays in USD for clean comparison</h3>
+					<p class="landing-public-eyebrow">Full pricing</p>
+					<h3>Prices shown in USD.</h3>
 					<p>
-						Use the pricing page for full comparison. Move into the enterprise lane only when
-						security, procurement, or deployment requirements need a separate process.
+						Use the pricing page for full plan details. Contact enterprise for security,
+						procurement, or deployment requirements.
 					</p>
 				</div>
 				<div class="landing-public-band-actions">
@@ -547,10 +436,7 @@
 			<div class="landing-public-section-head">
 				<p class="landing-public-eyebrow">Trust</p>
 				<h2>Review the company before you talk to us</h2>
-				<p>
-					Before a buyer books a call, they should be able to review the company, the proof pack,
-					and the enterprise path without hitting a wall of internal product language.
-				</p>
+				<p>Review the company, proof pack, and technical materials before you book a call.</p>
 			</div>
 			<div class="landing-public-trust-grid">
 				<article class="landing-public-surface landing-public-trust-card">
@@ -586,18 +472,18 @@
 					</div>
 				</article>
 				<article class="landing-public-surface landing-public-trust-card">
-					<p class="landing-public-proof-label">Enterprise lane</p>
-					<h3>Use the formal review path only when it is needed</h3>
+					<p class="landing-public-proof-label">Enterprise review</p>
+					<h3>Use enterprise review when it is needed</h3>
 					<p>
-						Security, privacy, residency, and procurement questions can move into a dedicated lane
-						without forcing every buyer into it from the start.
+						Security, privacy, residency, and procurement questions can be handled separately
+						without slowing down a basic evaluation.
 					</p>
 					<div class="landing-public-link-list">
 						<a
 							href={trustEnterpriseHref}
 							onclick={() => onTrackCta('cta_click', 'trust', 'enterprise')}
 						>
-							Open Enterprise Path
+							Enterprise Review
 						</a>
 						<a
 							href={requestValidationBriefingHref}

--- a/dashboard/src/lib/components/landing/LandingMarketingShared.css
+++ b/dashboard/src/lib/components/landing/LandingMarketingShared.css
@@ -1,0 +1,593 @@
+.landing-copy {
+	display: grid;
+	width: 100%;
+	row-gap: 0.6rem;
+	justify-items: stretch;
+	text-align: center;
+}
+
+@media (min-width: 1100px) {
+	.landing-copy {
+		max-width: 39rem;
+		margin-right: auto;
+		justify-items: start;
+		text-align: left;
+	}
+}
+
+.landing-kicker {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	justify-content: center;
+	gap: 0.55rem;
+}
+
+@media (min-width: 1100px) {
+	.landing-kicker {
+		justify-content: flex-start;
+	}
+}
+
+.landing-kicker .badge {
+	line-height: 1.25;
+}
+
+.landing-kicker-text {
+	color: var(--color-ink-700);
+	font-size: 0.95rem;
+	font-weight: 600;
+	letter-spacing: 0.01em;
+	text-wrap: balance;
+}
+
+.landing-title {
+	margin: 0.2rem auto 0;
+	max-width: 11.5ch;
+	font-family: 'Fraunces', 'Iowan Old Style', 'Palatino Linotype', Palatino, serif;
+	font-size: clamp(2.4rem, 5vw, 4.35rem);
+	font-weight: 700;
+	letter-spacing: -0.055em;
+	line-height: 0.94;
+	color: var(--color-ink-950);
+	text-wrap: balance;
+}
+
+@media (min-width: 1100px) {
+	.landing-title {
+		margin-left: 0;
+		max-width: 10.8ch;
+	}
+}
+
+.landing-subtitle {
+	margin: 0;
+	max-width: 34rem;
+	color: var(--color-ink-700);
+	font-size: clamp(1.02rem, 2vw, 1.18rem);
+	font-weight: 520;
+	line-height: 1.56;
+	text-wrap: balance;
+}
+
+@media (min-width: 1100px) {
+	.landing-subtitle {
+		max-width: 31rem;
+	}
+}
+
+.landing-cta {
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: center;
+	gap: 0.75rem;
+	margin-top: 0.55rem;
+	width: 100%;
+}
+
+@media (min-width: 1100px) {
+	.landing-cta {
+		justify-content: flex-start;
+	}
+}
+
+.landing-cta-primary,
+.landing-cta-secondary {
+	min-width: 12rem;
+}
+
+.landing-cta-primary {
+	box-shadow: 0 16px 30px rgb(8 126 164 / 0.18);
+}
+
+.landing-cta-secondary {
+	border-color: rgb(8 126 164 / 0.14);
+	background: rgb(255 255 255 / 0.82);
+	color: var(--color-ink-900);
+	box-shadow: inset 0 0 0 1px rgb(255 255 255 / 0.55);
+}
+
+.landing-cta-secondary:hover {
+	border-color: rgb(8 126 164 / 0.22);
+	background: rgb(255 255 255 / 0.94);
+}
+
+.landing-copy-points {
+	display: grid;
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+	gap: 0.75rem;
+	width: 100%;
+	margin-top: 0.35rem;
+}
+
+.landing-copy-point {
+	display: grid;
+	gap: 0.28rem;
+	padding: 0.9rem 0.95rem;
+	border: 1px solid rgb(8 126 164 / 0.08);
+	border-radius: 1rem;
+	background: rgb(255 255 255 / 0.72);
+	box-shadow: 0 14px 32px rgb(15 23 42 / 0.04);
+}
+
+.landing-copy-point-title {
+	margin: 0;
+	font-size: 0.78rem;
+	font-weight: 800;
+	letter-spacing: 0.08em;
+	text-transform: uppercase;
+	color: rgb(8 126 164);
+}
+
+.landing-copy-point-detail {
+	margin: 0;
+	color: var(--color-ink-700);
+	font-size: 0.93rem;
+	line-height: 1.48;
+}
+
+@media (max-width: 767px) {
+	.landing-cta {
+		flex-direction: column;
+		align-items: stretch;
+	}
+
+	.landing-cta a {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 100%;
+	}
+
+	.landing-copy-points {
+		grid-template-columns: 1fr;
+	}
+}
+
+.landing-section-head {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: end;
+	justify-content: space-between;
+	gap: 0.9rem 1rem;
+	max-width: 68rem;
+	margin: 0 auto 1rem;
+}
+
+.landing-h2 {
+	margin: 0;
+	font-family: 'Fraunces', 'Iowan Old Style', 'Palatino Linotype', Palatino, serif;
+	font-size: clamp(1.95rem, 3vw, 2.7rem);
+	font-weight: 700;
+	letter-spacing: -0.04em;
+	line-height: 1.02;
+	color: var(--color-ink-950);
+}
+
+.landing-section-sub {
+	margin: 0.55rem 0 0;
+	max-width: 42rem;
+	color: var(--color-ink-600);
+	font-size: 1.02rem;
+	line-height: 1.6;
+}
+
+@media (max-width: 767px) {
+	.landing-section-head {
+		align-items: start;
+	}
+}
+
+.landing-proof-k {
+	margin: 0;
+	font-size: 0.76rem;
+	font-weight: 800;
+	letter-spacing: 0.1em;
+	text-transform: uppercase;
+	color: rgb(8 126 164);
+}
+
+.landing-cta-link {
+	display: inline-flex;
+	margin-top: 0.2rem;
+	font-size: 0.92rem;
+	font-weight: 700;
+	color: rgb(8 126 164);
+	text-decoration: underline;
+	text-decoration-thickness: 1px;
+	text-underline-offset: 2px;
+}
+
+.landing-cta-link:hover {
+	color: rgb(14 165 233);
+}
+
+.landing-cta-link:focus-visible {
+	outline: 2px solid var(--color-accent-500);
+	outline-offset: 2px;
+	border-radius: 4px;
+}
+
+.landing-currency-toggle {
+	display: grid;
+	gap: 0.35rem;
+	justify-items: start;
+	text-align: left;
+}
+
+.landing-currency-toggle__label {
+	font-size: 0.74rem;
+	font-weight: 800;
+	letter-spacing: 0.08em;
+	text-transform: uppercase;
+	color: var(--color-ink-500);
+}
+
+.landing-currency-toggle__controls {
+	display: inline-flex;
+	flex-wrap: wrap;
+	gap: 0.45rem;
+	padding: 0.22rem;
+	border-radius: 999px;
+	border: 1px solid rgb(8 126 164 / 0.14);
+	background: rgb(255 255 255 / 0.92);
+}
+
+.landing-currency-toggle__controls button {
+	min-height: 2.2rem;
+	padding: 0.52rem 0.8rem;
+	border: 0;
+	border-radius: 999px;
+	background: transparent;
+	color: var(--color-ink-700);
+	font-size: 0.86rem;
+	font-weight: 700;
+	transition:
+		background-color var(--duration-fast) var(--ease-out),
+		color var(--duration-fast) var(--ease-out),
+		box-shadow var(--duration-fast) var(--ease-out);
+}
+
+.landing-currency-toggle__controls button.active {
+	background: linear-gradient(135deg, var(--color-brand-600) 0%, var(--color-brand-700) 100%);
+	color: var(--color-ink-50);
+	box-shadow: 0 10px 20px rgb(16 159 210 / 0.22);
+}
+
+.landing-currency-toggle__controls button:focus-visible {
+	outline: 2px solid var(--color-accent-500);
+	outline-offset: 2px;
+}
+
+.landing-currency-toggle__note {
+	margin: 0;
+	max-width: 20rem;
+	font-size: 0.82rem;
+	line-height: 1.45;
+	color: var(--color-ink-500);
+}
+
+@media (max-width: 767px) {
+	.landing-currency-toggle {
+		width: 100%;
+	}
+
+	.landing-currency-toggle__controls {
+		width: 100%;
+	}
+
+	.landing-currency-toggle__controls button {
+		flex: 1 1 auto;
+		justify-content: center;
+	}
+}
+
+.landing-roi-grid,
+.landing-sim-grid {
+	display: grid;
+	grid-template-columns: 1fr;
+	gap: 1rem;
+}
+
+@media (min-width: 1024px) {
+	.landing-roi-grid {
+		grid-template-columns: 1.05fr 0.95fr;
+	}
+
+	.landing-sim-grid {
+		grid-template-columns: 1fr 1fr;
+	}
+}
+
+.landing-roi-controls,
+.landing-sim-controls {
+	display: grid;
+	gap: 0.95rem;
+}
+
+.landing-roi-results,
+.landing-sim-results {
+	display: grid;
+	gap: 1rem;
+}
+
+.landing-roi-control {
+	border: 1px solid rgb(8 126 164 / 0.1);
+	border-radius: 1rem;
+	padding: 0.82rem 0.88rem;
+	background: rgb(243 248 250 / 0.94);
+}
+
+.landing-roi-grid-2 {
+	display: grid;
+	gap: 0.75rem;
+}
+
+@media (min-width: 768px) {
+	.landing-roi-grid-2 {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+}
+
+.landing-roi-label {
+	display: block;
+	font-size: 0.84rem;
+	font-weight: 700;
+	color: rgb(8 126 164);
+}
+
+.landing-roi-meta {
+	margin-top: 0.25rem;
+	font-size: 0.95rem;
+	font-weight: 700;
+	color: var(--color-ink-800);
+}
+
+.landing-roi-control input[type='range'] {
+	width: 100%;
+	margin-top: 0.5rem;
+	accent-color: var(--color-accent-500);
+}
+
+.landing-roi-metrics,
+.landing-sim-metrics {
+	display: grid;
+	grid-template-columns: 1fr;
+	gap: 0.75rem;
+}
+
+@media (min-width: 768px) {
+	.landing-roi-metrics,
+	.landing-sim-metrics {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+}
+
+.landing-roi-metric,
+.landing-sim-metric {
+	border: 1px solid rgb(8 126 164 / 0.08);
+	border-radius: 1rem;
+	padding: 0.85rem 0.9rem;
+	background: rgb(243 248 250 / 0.92);
+}
+
+.landing-roi-metric p,
+.landing-sim-metric p {
+	margin: 0;
+	font-size: 0.78rem;
+	font-weight: 800;
+	letter-spacing: 0.08em;
+	text-transform: uppercase;
+	color: var(--color-ink-500);
+}
+
+.landing-roi-metric strong,
+.landing-sim-metric strong {
+	display: block;
+	margin-top: 0.34rem;
+	font-size: 1.08rem;
+	color: var(--color-ink-950);
+}
+
+.landing-roi-metric strong.is-positive {
+	color: var(--color-success-500);
+}
+
+.landing-roi-metric strong.is-negative {
+	color: var(--color-danger-500);
+}
+
+.landing-sim-metric span {
+	display: block;
+	margin-top: 0.32rem;
+	font-size: 0.9rem;
+	line-height: 1.45;
+	color: var(--color-ink-600);
+}
+
+.landing-sim-metric.is-highlight {
+	padding: 1rem;
+	background: linear-gradient(180deg, rgb(255 255 255 / 0.96), rgb(239 247 249 / 0.98));
+}
+
+.landing-sim-metric.is-highlight strong {
+	font-size: clamp(1.85rem, 4vw, 2.7rem);
+	line-height: 1;
+	letter-spacing: -0.05em;
+}
+
+.landing-sim-metric.is-primary strong {
+	color: rgb(8 126 164);
+}
+
+.landing-sim-metric.is-context {
+	grid-column: 1 / -1;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 0.8rem;
+}
+
+.landing-sim-chart {
+	display: grid;
+	gap: 0.65rem;
+}
+
+.landing-sim-bar-row {
+	display: grid;
+	grid-template-columns: 8.5rem minmax(0, 1fr) 6rem;
+	gap: 0.65rem;
+	align-items: center;
+}
+
+@media (max-width: 640px) {
+	.landing-sim-bar-row {
+		grid-template-columns: 1fr;
+		gap: 0.35rem;
+	}
+}
+
+.landing-sim-bar-label {
+	font-size: 0.84rem;
+	font-weight: 700;
+	color: var(--color-ink-700);
+}
+
+.landing-sim-bar-value {
+	text-align: right;
+	font-size: 0.98rem;
+	font-weight: 800;
+	color: var(--color-ink-950);
+}
+
+.landing-roi-cta {
+	display: grid;
+	gap: 0.6rem;
+}
+
+.landing-roi-note {
+	margin: 0;
+	font-size: 0.88rem;
+	line-height: 1.5;
+	color: var(--color-ink-600);
+}
+
+.landing-sim-bar-meter,
+.landing-roi-snapshot-meter {
+	width: 100%;
+	height: 0.72rem;
+	border: none;
+	border-radius: 9999px;
+	overflow: hidden;
+	background: rgb(8 126 164 / 0.08);
+}
+
+.landing-roi-snapshot-meter {
+	height: 0.42rem;
+}
+
+.landing-sim-bar-meter::-webkit-progress-bar,
+.landing-roi-snapshot-meter::-webkit-progress-bar {
+	background: rgb(8 126 164 / 0.08);
+	border-radius: 9999px;
+}
+
+.landing-sim-bar-meter::-webkit-progress-value,
+.landing-roi-snapshot-meter::-webkit-progress-value,
+.landing-sim-bar-meter::-moz-progress-bar,
+.landing-roi-snapshot-meter::-moz-progress-bar {
+	border-radius: 9999px;
+}
+
+.landing-sim-bar-meter--reactive::-webkit-progress-value,
+.landing-roi-snapshot-meter--reactive::-webkit-progress-value,
+.landing-sim-bar-meter--reactive::-moz-progress-bar,
+.landing-roi-snapshot-meter--reactive::-moz-progress-bar {
+	background: linear-gradient(90deg, rgb(244 63 94 / 0.85), rgb(251 113 133 / 0.9));
+}
+
+.landing-sim-bar-meter--governed::-webkit-progress-value,
+.landing-roi-snapshot-meter--governed::-webkit-progress-value,
+.landing-sim-bar-meter--governed::-moz-progress-bar,
+.landing-roi-snapshot-meter--governed::-moz-progress-bar {
+	background: linear-gradient(90deg, rgb(8 126 164 / 0.92), rgb(16 185 129 / 0.88));
+}
+
+.public-site-shell[data-public-theme='dark'] .landing-kicker-text {
+	color: var(--color-ink-300);
+}
+
+.public-site-shell[data-public-theme='dark'] .landing-title {
+	color: var(--color-ink-50);
+}
+
+.public-site-shell[data-public-theme='dark'] .landing-subtitle,
+.public-site-shell[data-public-theme='dark'] .landing-copy-point-detail,
+.public-site-shell[data-public-theme='dark'] .landing-roi-note,
+.public-site-shell[data-public-theme='dark'] .landing-sim-metric span {
+	color: var(--color-ink-300);
+}
+
+.public-site-shell[data-public-theme='dark'] .landing-copy-point,
+.public-site-shell[data-public-theme='dark'] .landing-roi-control,
+.public-site-shell[data-public-theme='dark'] .landing-roi-metric,
+.public-site-shell[data-public-theme='dark'] .landing-sim-metric {
+	border-color: rgb(255 255 255 / 0.08);
+	background: rgb(255 255 255 / 0.04);
+}
+
+.public-site-shell[data-public-theme='dark'] .landing-cta-secondary {
+	border-color: rgb(255 255 255 / 0.14);
+	background: rgb(255 255 255 / 0.05);
+	color: var(--color-ink-100);
+}
+
+.public-site-shell[data-public-theme='dark'] .landing-cta-secondary:hover {
+	border-color: rgb(255 255 255 / 0.24);
+	background: rgb(255 255 255 / 0.1);
+}
+
+.public-site-shell[data-public-theme='dark'] .landing-section-sub,
+.public-site-shell[data-public-theme='dark'] .landing-currency-toggle__note {
+	color: var(--color-ink-400);
+}
+
+.public-site-shell[data-public-theme='dark'] .landing-h2,
+.public-site-shell[data-public-theme='dark'] .landing-roi-metric strong,
+.public-site-shell[data-public-theme='dark'] .landing-sim-metric strong,
+.public-site-shell[data-public-theme='dark'] .landing-sim-bar-value {
+	color: var(--color-ink-50);
+}
+
+.public-site-shell[data-public-theme='dark'] .landing-currency-toggle__label {
+	color: var(--color-ink-400);
+}
+
+.public-site-shell[data-public-theme='dark'] .landing-currency-toggle__controls {
+	border-color: rgb(255 255 255 / 0.12);
+	background: rgb(255 255 255 / 0.04);
+}
+
+.public-site-shell[data-public-theme='dark'] .landing-currency-toggle__controls button {
+	color: var(--color-ink-300);
+}

--- a/dashboard/src/lib/components/landing/LandingPlansSection.svelte
+++ b/dashboard/src/lib/components/landing/LandingPlansSection.svelte
@@ -107,8 +107,8 @@
 			Know the team footprint before signup or procurement
 		</h3>
 		<p class="landing-p">
-			Start with one controlled workflow in a workspace. Use the enterprise path only when audit,
-			procurement, or rollout governance needs a formal diligence lane.
+			Start with one controlled workflow in a workspace. Use enterprise review only when audit,
+			procurement, or rollout governance needs a separate process.
 		</p>
 
 		<div class="landing-rollout-grid">
@@ -144,7 +144,7 @@
 				class="btn btn-secondary"
 				onclick={() => onTrackCta('cta_click', 'plans', 'enterprise_review')}
 			>
-				Open Enterprise Path
+				Enterprise Review
 			</a>
 		</div>
 	</section>

--- a/dashboard/src/lib/components/landing/LandingRoiCalculator.svelte
+++ b/dashboard/src/lib/components/landing/LandingRoiCalculator.svelte
@@ -2,6 +2,7 @@
 	import type { LandingCurrencyCode } from '$lib/landing/currencyPreference';
 	import LandingCurrencyToggle from '$lib/components/landing/LandingCurrencyToggle.svelte';
 	import { type LandingRoiInputs, type LandingRoiResult } from '$lib/landing/roiCalculator';
+	import './LandingMarketingShared.css';
 
 	let {
 		roiInputs,

--- a/dashboard/src/lib/components/landing/LandingRoiSimulator.svelte
+++ b/dashboard/src/lib/components/landing/LandingRoiSimulator.svelte
@@ -2,6 +2,7 @@
 	import { base } from '$app/paths';
 	import type { LandingCurrencyCode } from '$lib/landing/currencyPreference';
 	import LandingCurrencyToggle from '$lib/components/landing/LandingCurrencyToggle.svelte';
+	import './LandingMarketingShared.css';
 
 	let {
 		normalizedScenarioWasteWithoutPct,

--- a/dashboard/src/lib/components/landing/LandingTrustSection.svelte
+++ b/dashboard/src/lib/components/landing/LandingTrustSection.svelte
@@ -51,7 +51,7 @@
 		<h2 class="landing-h2">Proof, review surfaces, and rollout clarity</h2>
 		<p class="landing-section-sub">
 			Public proof should reduce uncertainty without inventing customer evidence. Valdrics exposes
-			buyer-safe materials for security, rollout, procurement, and executive review.
+			clear materials for security, rollout, procurement, and executive review.
 		</p>
 	</div>
 
@@ -123,9 +123,8 @@
 			<p class="landing-proof-k">Enterprise validation lane</p>
 			<h3 class="landing-h3">Use the formal path only when diligence actually needs it</h3>
 			<p class="landing-p">
-				Self-serve teams can start in the workspace path. Procurement, architecture review, and
-				security review can move into a dedicated enterprise lane without restarting the
-				conversation.
+				Self-serve teams can start in the workspace. Procurement, architecture review, and security
+				review can move into enterprise review without restarting the conversation.
 			</p>
 			<div class="landing-lead-actions">
 				<a
@@ -133,7 +132,7 @@
 					class="btn btn-primary w-fit pulse-glow"
 					onclick={() => onTrackCta('enterprise_review')}
 				>
-					Open Enterprise Path
+					Enterprise Review
 				</a>
 				<a
 					href={requestValidationBriefingHref}

--- a/dashboard/src/lib/content/publicCompany.ts
+++ b/dashboard/src/lib/content/publicCompany.ts
@@ -25,7 +25,7 @@ export const PUBLIC_DEPLOYMENT_RESIDENCY_FACTS: readonly DeploymentResidencyFact
 	{
 		question: 'What does the public site commit to on data residency today?',
 		answer:
-			'Current public materials do not commit to a region-specific residency promise. Deployment-region and residency-specific requirements are handled through the enterprise review path.',
+			'Current public materials do not commit to a region-specific residency promise. Deployment-region and residency-specific requirements are handled during enterprise review.',
 		status: 'enterprise'
 	},
 	{
@@ -37,7 +37,7 @@ export const PUBLIC_DEPLOYMENT_RESIDENCY_FACTS: readonly DeploymentResidencyFact
 	{
 		question: 'How are region-specific requests handled?',
 		answer:
-			'Region-specific hosting, residency constraints, and procurement conditions are handled as scoped diligence items in the enterprise validation lane.',
+			'Region-specific hosting, residency constraints, and procurement conditions are handled as scoped items during enterprise review.',
 		status: 'enterprise'
 	}
 ]);
@@ -54,9 +54,9 @@ export const PUBLIC_REVIEW_CHANNELS = Object.freeze([
 		note: 'Technical validation, onboarding, owner routing, and export-ready operating guidance.'
 	},
 	{
-		label: 'Enterprise Path',
+		label: 'Enterprise Review',
 		href: '/enterprise',
-		note: 'Formal diligence lane for procurement, architecture review, and rollout governance.'
+		note: 'Procurement, architecture review, and rollout governance.'
 	},
 	{
 		label: 'Talk to Sales',

--- a/dashboard/src/lib/content/publicContent.docs.ts
+++ b/dashboard/src/lib/content/publicContent.docs.ts
@@ -67,7 +67,7 @@ export const RAW_PUBLIC_CONTENT_DOCS = [
 			{
 				title: 'Use the first connection to prove trust, not breadth',
 				body: [
-					'The first connection should answer the buyer-safe questions early: what access is required, what context becomes visible, and what proof survives after action.',
+					'The first connection should answer the basic questions early: what access is required, what context becomes visible, and what proof survives after action.',
 					'Starting small reduces integration risk and gives security and platform teams a real review surface.'
 				],
 				bullets: [
@@ -109,7 +109,7 @@ export const RAW_PUBLIC_CONTENT_DOCS = [
 		readingMinutes: 6,
 		audiences: ['engineering', 'finance', 'platform'],
 		primaryCta: { label: 'See the Decision Loop', href: '/#product' },
-		secondaryCta: { label: 'Open Enterprise Path', href: '/enterprise' },
+		secondaryCta: { label: 'Enterprise Review', href: '/enterprise' },
 		sections: [
 			{
 				title: 'Why routing matters',

--- a/dashboard/src/lib/content/publicContent.insights.ts
+++ b/dashboard/src/lib/content/publicContent.insights.ts
@@ -108,7 +108,7 @@ export const RAW_PUBLIC_CONTENT_INSIGHTS = [
 		readingMinutes: 6,
 		audiences: ['engineering', 'finance', 'procurement'],
 		primaryCta: { label: 'See the Decision Loop', href: '/#product' },
-		secondaryCta: { label: 'Open Enterprise Path', href: '/enterprise' },
+		secondaryCta: { label: 'Enterprise Review', href: '/enterprise' },
 		sections: [
 			{
 				title: 'Where the commercial story changes',

--- a/dashboard/src/lib/content/publicContent.proof.ts
+++ b/dashboard/src/lib/content/publicContent.proof.ts
@@ -4,7 +4,7 @@ export const RAW_PUBLIC_CONTENT_PROOF = [
 		slug: 'deployment-and-data-residency',
 		title: 'Deployment and Data Residency Review',
 		summary:
-			'Review what the public site commits to today on deployment posture and how residency-specific requirements are handled in the enterprise lane.',
+			'Review what the public site commits to today on deployment posture and how residency-specific requirements are handled during enterprise review.',
 		kicker: 'Proof Pack',
 		seoTitle: 'Deployment and Data Residency Review',
 		seoDescription:
@@ -13,19 +13,19 @@ export const RAW_PUBLIC_CONTENT_PROOF = [
 		stage: 'validate',
 		readingMinutes: 4,
 		audiences: ['security', 'procurement', 'executive'],
-		primaryCta: { label: 'Open Enterprise Path', href: '/enterprise' },
+		primaryCta: { label: 'Enterprise Review', href: '/enterprise' },
 		secondaryCta: { label: 'Talk to Sales', href: '/talk-to-sales?source=proof_residency' },
 		sections: [
 			{
 				title: 'What the public site can say today',
 				body: [
 					'Current public materials do not commit to a region-specific residency promise. That is a deliberate constraint so the site does not overclaim what must be handled as a scoped deployment discussion.',
-					'The right public posture is to expose review materials early and move environment-specific requirements into the enterprise diligence lane.'
+					'The right public posture is to expose review materials early and move environment-specific requirements into enterprise review.'
 				],
 				bullets: [
 					'No fabricated residency claim',
 					'Clear separation between public proof and scoped diligence',
-					'Buyer-safe review before environment-specific commitment'
+					'Clear review before any environment-specific commitment'
 				]
 			},
 			{
@@ -51,7 +51,7 @@ export const RAW_PUBLIC_CONTENT_PROOF = [
 		slug: 'safe-access-model',
 		title: 'Safe Access Model',
 		summary:
-			'Understand how Valdrics approaches buyer-safe access posture, early trust, and rollout proof without overclaiming prelaunch validation.',
+			'Understand how Valdrics approaches access posture, early trust, and rollout proof without overclaiming prelaunch validation.',
 		kicker: 'Proof Pack',
 		seoTitle: 'Safe Access Model',
 		seoDescription:
@@ -61,7 +61,7 @@ export const RAW_PUBLIC_CONTENT_PROOF = [
 		readingMinutes: 5,
 		audiences: ['security', 'platform', 'procurement'],
 		primaryCta: { label: 'Open Technical Validation', href: '/docs/technical-validation' },
-		secondaryCta: { label: 'Open Enterprise Path', href: '/enterprise' },
+		secondaryCta: { label: 'Enterprise Review', href: '/enterprise' },
 		sections: [
 			{
 				title: 'What buyers need early',
@@ -81,11 +81,7 @@ export const RAW_PUBLIC_CONTENT_PROOF = [
 					'This page is not a substitute for environment-specific security review, and it does not claim a blanket posture that every provider or workflow implements identically.',
 					'It exists to make the first diligence conversation concrete and honest.'
 				],
-				bullets: [
-					'Buyer-safe, not buyer-complacent',
-					'Specific before broad',
-					'Aligned with the enterprise diligence path'
-				]
+				bullets: ['Clear first review', 'Specific before broad', 'Aligned with enterprise review']
 			}
 		],
 		related: [
@@ -108,7 +104,7 @@ export const RAW_PUBLIC_CONTENT_PROOF = [
 		readingMinutes: 5,
 		audiences: ['security', 'finance', 'platform'],
 		primaryCta: { label: 'See the Decision Loop', href: '/#product' },
-		secondaryCta: { label: 'Open Enterprise Path', href: '/enterprise' },
+		secondaryCta: { label: 'Enterprise Review', href: '/enterprise' },
 		sections: [
 			{
 				title: 'Identity matters because accountability matters',

--- a/dashboard/src/lib/content/publicContent.resources.ts
+++ b/dashboard/src/lib/content/publicContent.resources.ts
@@ -4,25 +4,25 @@ export const RAW_PUBLIC_CONTENT_RESOURCES = [
 		slug: 'enterprise-governance-overview',
 		title: 'Enterprise Governance Overview',
 		summary:
-			'Understand the enterprise buying lane across governance, procurement, rollout design, and operating controls.',
+			'Understand enterprise buying across governance, procurement, rollout design, and operating controls.',
 		kicker: 'Resource',
 		seoTitle: 'Enterprise Governance Overview',
 		seoDescription:
-			'Review the enterprise governance lane for Valdrics, including procurement, security review, and rollout expectations.',
+			'Review enterprise governance for Valdrics, including procurement, security review, and rollout expectations.',
 		updatedAt: '2026-03-09T00:00:00.000Z',
 		stage: 'evaluate',
 		readingMinutes: 4,
 		audiences: ['procurement', 'security', 'executive'],
-		primaryCta: { label: 'Open Enterprise Path', href: '/enterprise' },
+		primaryCta: { label: 'Enterprise Review', href: '/enterprise' },
 		secondaryCta: {
 			label: 'Request Validation Briefing',
 			href: '/talk-to-sales?intent=enterprise_briefing'
 		},
 		sections: [
 			{
-				title: 'When to use the enterprise lane',
+				title: 'When to use enterprise review',
 				body: [
-					'Use the enterprise lane when security review, procurement diligence, SSO or SCIM expectations, or staged rollout controls need a dedicated path.',
+					'Use enterprise review when security review, procurement diligence, SSO or SCIM expectations, or staged rollout controls need a dedicated process.',
 					'The goal is to separate fast product evaluation from formal organizational review when those motions need different participants.'
 				],
 				bullets: [
@@ -126,7 +126,7 @@ export const RAW_PUBLIC_CONTENT_RESOURCES = [
 				]
 			},
 			{
-				title: 'What a buyer-safe framework looks like',
+				title: 'What a clear framework looks like',
 				body: [
 					'The framework should show who owns the decision, what guardrails apply, and what evidence remains afterward.',
 					'That gives platform and leadership teams one narrative instead of multiple competing reports.'
@@ -204,7 +204,7 @@ export const RAW_PUBLIC_CONTENT_RESOURCES = [
 			label: 'Download One-Pager',
 			href: '/resources/valdrics-enterprise-one-pager.md'
 		},
-		secondaryCta: { label: 'Open Enterprise Path', href: '/enterprise' },
+		secondaryCta: { label: 'Enterprise Review', href: '/enterprise' },
 		downloads: [
 			{
 				label: 'Executive One-Pager (Markdown)',
@@ -302,7 +302,7 @@ export const RAW_PUBLIC_CONTENT_RESOURCES = [
 			label: 'Download Workbook',
 			href: '/resources/global-finops-compliance-workbook.md'
 		},
-		secondaryCta: { label: 'Open Enterprise Path', href: '/enterprise' },
+		secondaryCta: { label: 'Enterprise Review', href: '/enterprise' },
 		downloads: [
 			{
 				label: 'Compliance Workbook (Markdown)',

--- a/dashboard/src/lib/landing/heroContent.extended.ts
+++ b/dashboard/src/lib/landing/heroContent.extended.ts
@@ -66,7 +66,7 @@ export const PLAN_COMPARE_CARDS = Object.freeze(
 );
 
 export const PLANS_PRICING_EXPLANATION =
-	'Monthly starting prices shown here are entry points. Start self-serve for a first controlled workflow, then use the enterprise path when governance depth, procurement, or finance close requirements expand.';
+	'Monthly starting prices shown here are entry points. Start with one controlled workflow, then move up only when the team needs deeper governance, procurement support, or finance-close support.';
 
 export const FREE_TIER_HIGHLIGHTS = Object.freeze([
 	'Permanent free workspace for one owner-routed savings workflow',

--- a/dashboard/src/lib/landing/publicNav.ts
+++ b/dashboard/src/lib/landing/publicNav.ts
@@ -28,7 +28,7 @@ export const PUBLIC_RESOURCES_DROPDOWN_LINKS: readonly PublicNavLink[] = Object.
 export const PUBLIC_SECONDARY_LINKS: readonly PublicNavLink[] = Object.freeze([
 	{ href: '/docs', label: 'Docs' },
 	{ href: '/insights', label: 'Insights' },
-	{ href: '/enterprise', label: 'Enterprise Path' }
+	{ href: '/enterprise', label: 'Enterprise Review' }
 ]);
 
 export const PUBLIC_MOBILE_LINKS: readonly PublicNavLink[] = Object.freeze([
@@ -67,7 +67,7 @@ export const PUBLIC_FOOTER_SUBTITLE =
 	'Valdrics gives finance and engineering one operating layer for spend review, owner routing, approvals, and proof.';
 
 export const PUBLIC_FOOTER_CAPTION =
-	'Designed for teams that want clearer spend decisions, cleaner rollout paths, and buyer-safe review surfaces.';
+	'Designed for teams that want clearer spend decisions, cleaner rollout, and review-ready proof.';
 
 export const PUBLIC_CONTACT_CHANNELS: readonly PublicContactChannel[] = Object.freeze([
 	{ label: 'Sales', email: 'sales@valdrics.com', href: 'mailto:sales@valdrics.com' },

--- a/dashboard/src/lib/pricing/publicPlans.ts
+++ b/dashboard/src/lib/pricing/publicPlans.ts
@@ -174,7 +174,7 @@ export const DEFAULT_PRICING_PLANS: PricingPlan[] = [
 			bestFor:
 				'Finance, platform, and leadership need APIs, audit logs, reconciliation, close workflow, workflow automation, and stronger governance evidence.',
 			whyUpgrade:
-				'Move to the enterprise lane only when SCIM, private deployment, procurement review, or custom control requirements need a separate buying path.'
+				'Use enterprise review only when SCIM, private deployment, procurement review, or custom control requirements need a separate process.'
 		}
 	}
 ];

--- a/dashboard/src/routes/about/+page.svelte
+++ b/dashboard/src/routes/about/+page.svelte
@@ -53,7 +53,7 @@
 			label: 'Public review',
 			value: 'Proof, docs, and enterprise diligence available upfront'
 		},
-		{ label: 'Evaluation style', value: 'Proof pack first, enterprise lane when needed' }
+		{ label: 'How to evaluate', value: 'Proof, docs, pricing, and team details are public' }
 	] as const;
 
 	const originCards = [
@@ -63,9 +63,9 @@
 				'Most teams can already see spend problems. The harder part is turning the alert into one accountable action path with approvals and proof.'
 		},
 		{
-			title: 'What the public site should do',
+			title: 'How to evaluate',
 			detail:
-				'The public site should help buyers understand the company, the workflow, the pricing posture, and the review path without dumping internal product details on every page.'
+				'Start with proof, docs, pricing, or a trial workspace. Use enterprise review only when a separate procurement or deployment conversation is required.'
 		}
 	] as const;
 
@@ -81,9 +81,9 @@
 			note: 'Technical validation, onboarding, and rollout guidance.'
 		},
 		{
-			label: 'Enterprise Path',
+			label: 'Enterprise Review',
 			href: enterpriseHref,
-			note: 'Formal review lane for procurement, residency, and rollout governance.'
+			note: 'Security, procurement, residency, and rollout review.'
 		}
 	]);
 </script>
@@ -140,8 +140,8 @@
 				{/if}
 			</div>
 			<p class="public-page__inline-note">
-				Valdrics supports buyer evaluations across multiple regions. Deployment, residency, and
-				procurement requirements that vary by region move through the enterprise review path.
+				Valdrics supports teams across multiple regions. Deployment, residency, and procurement
+				questions are handled during enterprise review.
 			</p>
 		</section>
 
@@ -168,11 +168,11 @@
 				<article class="public-page__card">
 					<p class="public-page__eyebrow">Deployment stance</p>
 					<h2 id="about-contact-title" class="public-page__section-title">
-						Deployment claims stay factual
+						Deployment details stay factual
 					</h2>
 					<p class="public-page__card-copy">{deploymentFact?.answer}</p>
 					<div class="public-page__actions-row">
-						<a href={enterpriseHref} class="btn btn-secondary">Open Enterprise Path</a>
+						<a href={enterpriseHref} class="btn btn-secondary">Enterprise Review</a>
 						<a href={docsHref} class="btn btn-secondary">Open Docs</a>
 					</div>
 				</article>

--- a/dashboard/src/routes/about/about-page.svelte.test.ts
+++ b/dashboard/src/routes/about/about-page.svelte.test.ts
@@ -31,13 +31,11 @@ describe('about page', () => {
 		expect(screen.getByText(/abdulgoniyy dare/i)).toBeTruthy();
 		expect(
 			screen.getByText(
-				/valdrics supports buyer evaluations across multiple regions\. deployment, residency, and procurement requirements that vary by region move through the enterprise review path\./i
+				/valdrics supports teams across multiple regions\. deployment, residency, and procurement questions are handled during enterprise review\./i
 			)
 		).toBeTruthy();
-		expect(screen.getByText(/deployment claims stay factual/i)).toBeTruthy();
-		expect(screen.getAllByRole('link', { name: /open enterprise path/i }).length).toBeGreaterThan(
-			0
-		);
+		expect(screen.getByText(/deployment details stay factual/i)).toBeTruthy();
+		expect(screen.getAllByRole('link', { name: /enterprise review/i }).length).toBeGreaterThan(0);
 		expect(screen.getByRole('link', { name: /legal@valdrics\.com/i })).toBeTruthy();
 		expect(screen.getByRole('link', { name: /security@valdrics\.com/i })).toBeTruthy();
 	});

--- a/dashboard/src/routes/billing/+page.svelte
+++ b/dashboard/src/routes/billing/+page.svelte
@@ -321,7 +321,7 @@
 		{#if !hasSelfServeUpgrade}
 			<article class="card billing-upgrade-note">
 				<p class="billing-card__copy">
-					You are already on the highest available self-serve tier. Use the enterprise lane for
+					You are already on the highest available self-serve tier. Use enterprise review for
 					security, procurement, or custom commercial review.
 				</p>
 			</article>
@@ -381,11 +381,11 @@
 			{/each}
 
 			<article class="card billing-enterprise-card">
-				<p class="billing-card__kicker">Enterprise lane</p>
+				<p class="billing-card__kicker">Enterprise review</p>
 				<h3 class="billing-card__title">Security, procurement, and rollout review</h3>
 				<p class="billing-card__copy">
-					Use the sales-assisted lane when your workspace needs SCIM, procurement diligence, private
-					deployment, or complex rollout governance.
+					Use the sales-assisted review when your workspace needs SCIM, procurement diligence,
+					private deployment, or complex rollout governance.
 				</p>
 				<ul class="billing-bullets">
 					<li>Security and identity review for SCIM and private deployment requirements</li>

--- a/dashboard/src/routes/billing/billing-page.svelte.test.ts
+++ b/dashboard/src/routes/billing/billing-page.svelte.test.ts
@@ -62,7 +62,7 @@ describe('billing page plan messaging', () => {
 		).toBeTruthy();
 		expect(
 			screen.getByText(
-				/move to the enterprise lane only when scim, private deployment, procurement review/i
+				/use enterprise review only when scim, private deployment, procurement review/i
 			)
 		).toBeTruthy();
 		const growthPlanCard = screen.getByRole('heading', { name: /^growth$/i }).closest('article');

--- a/dashboard/src/routes/docs/technical-validation/+page.svelte
+++ b/dashboard/src/routes/docs/technical-validation/+page.svelte
@@ -98,7 +98,7 @@
 	<div class="glass-panel space-y-3">
 		<h2 class="text-xl font-semibold">What this page is and is not</h2>
 		<ul class="text-sm text-ink-300 space-y-1 list-disc pl-5">
-			<li>It is a public, buyer-safe validation map for capability coverage.</li>
+			<li>It is a public validation map for capability coverage.</li>
 			<li>
 				It does not expose internal incident data, private traces, or tenant-sensitive evidence.
 			</li>

--- a/dashboard/src/routes/docs/technical-validation/technical-validation-page.svelte.test.ts
+++ b/dashboard/src/routes/docs/technical-validation/technical-validation-page.svelte.test.ts
@@ -13,7 +13,7 @@ vi.mock('$app/stores', () => ({
 }));
 
 describe('technical validation page', () => {
-	it('renders buyer-safe validation matrix and public links', () => {
+	it('renders the public validation matrix and public links', () => {
 		render(Page);
 
 		expect(

--- a/dashboard/src/routes/insights/+page.svelte
+++ b/dashboard/src/routes/insights/+page.svelte
@@ -57,11 +57,11 @@
 >
 	{#snippet heroActions()}
 		{#if buyingMotion === 'enterprise_first'}
-			<a href={enterprisePathHref} class="btn btn-primary">Open Enterprise Path</a>
+			<a href={enterprisePathHref} class="btn btn-primary">Enterprise Review</a>
 			<a href={startFreeHref} class="btn btn-secondary">Start Free Workspace</a>
 		{:else}
 			<a href={startFreeHref} class="btn btn-primary">Start Free Workspace</a>
-			<a href={enterprisePathHref} class="btn btn-secondary">See Enterprise Path</a>
+			<a href={enterprisePathHref} class="btn btn-secondary">Enterprise Review</a>
 		{/if}
 		<a href={`${base}/resources`} class="btn btn-secondary">Open Resources</a>
 	{/snippet}

--- a/dashboard/src/routes/insights/insights-page.svelte.test.ts
+++ b/dashboard/src/routes/insights/insights-page.svelte.test.ts
@@ -21,7 +21,7 @@ describe('insights page', () => {
 			screen.getByRole('link', { name: /start free workspace/i }).getAttribute('href') || ''
 		).toContain('/auth/login?');
 		expect(
-			screen.getByRole('link', { name: /see enterprise path/i }).getAttribute('href') || ''
+			screen.getByRole('link', { name: /enterprise review/i }).getAttribute('href') || ''
 		).toContain('/enterprise?');
 		expect(
 			screen.getByRole('heading', {

--- a/dashboard/src/routes/layout-public-menu.svelte.test.ts
+++ b/dashboard/src/routes/layout-public-menu.svelte.test.ts
@@ -170,7 +170,7 @@ describe('public layout mobile menu', () => {
 
 		await waitFor(() => {
 			const active = document.activeElement as HTMLElement | null;
-			expect(active?.textContent?.trim()).toMatch(/dark mode|light mode|enterprise path/i);
+			expect(active?.textContent?.trim()).toMatch(/dark mode|light mode|enterprise review/i);
 		});
 
 		await fireEvent.keyDown(window, { key: 'Tab', shiftKey: true });
@@ -182,7 +182,7 @@ describe('public layout mobile menu', () => {
 		await fireEvent.keyDown(window, { key: 'Tab' });
 		await waitFor(() => {
 			const active = document.activeElement as HTMLElement | null;
-			expect(active?.textContent?.trim()).toMatch(/dark mode|light mode|enterprise path/i);
+			expect(active?.textContent?.trim()).toMatch(/dark mode|light mode|enterprise review/i);
 		});
 
 		await fireEvent.keyDown(window, { key: 'Escape' });
@@ -215,7 +215,7 @@ describe('public layout mobile menu', () => {
 	it('keeps desktop conversion actions in the public header', () => {
 		renderPublicLayout();
 
-		expect(screen.getAllByRole('link', { name: /^enterprise path$/i }).length).toBeGreaterThan(0);
+		expect(screen.getAllByRole('link', { name: /^enterprise review$/i }).length).toBeGreaterThan(0);
 		expect(screen.getAllByRole('link', { name: /^start free$/i }).length).toBeGreaterThan(0);
 	});
 

--- a/dashboard/src/routes/layout/PublicSiteShell.svelte
+++ b/dashboard/src/routes/layout/PublicSiteShell.svelte
@@ -204,7 +204,7 @@
 					data-sveltekit-preload-data="hover"
 					data-sveltekit-preload-code="hover"
 				>
-					Enterprise Path
+					Enterprise Review
 				</a>
 				<a
 					href={toAppPath('/auth/login')}
@@ -340,8 +340,8 @@
 					<div class="public-mobile-menu-copy">
 						<p class="public-mobile-menu-kicker">Explore Valdrics</p>
 						<p class="public-mobile-menu-intro">
-							Start in a workspace, review pricing, or use the enterprise path when formal security
-							and procurement review is required.
+							Start in a workspace, review pricing, or contact enterprise when formal security and
+							procurement review is required.
 						</p>
 						<button
 							type="button"
@@ -400,7 +400,7 @@
 							data-sveltekit-preload-code="hover"
 							onclick={closePublicMenu}
 						>
-							Enterprise Path
+							Enterprise Review
 						</a>
 						<a
 							href={toAppPath('/auth/login')}

--- a/dashboard/src/routes/pricing/+page.svelte
+++ b/dashboard/src/routes/pricing/+page.svelte
@@ -204,11 +204,11 @@
 >
 	{#snippet heroActions()}
 		{#if buyingMotion === 'enterprise_first'}
-			<a href={pricingHeroEnterpriseHref} class="btn btn-primary">Open Enterprise Path</a>
+			<a href={pricingHeroEnterpriseHref} class="btn btn-primary">Enterprise Review</a>
 			<a href={getFreeTierHref()} class="btn btn-secondary">Start Free Workspace</a>
 		{:else}
 			<a href={getFreeTierHref()} class="btn btn-primary">Start Free Workspace</a>
-			<a href={pricingHeroEnterpriseHref} class="btn btn-secondary">See Enterprise Path</a>
+			<a href={pricingHeroEnterpriseHref} class="btn btn-secondary">Enterprise Review</a>
 		{/if}
 	{/snippet}
 
@@ -398,15 +398,15 @@
 				<div class="public-page__band-copy">
 					<p class="public-page__eyebrow">Need enterprise review?</p>
 					<h2 id="pricing-enterprise-title" class="public-page__section-title">
-						Keep the enterprise lane for buyers who truly need a separate diligence track
+						Use enterprise review only when the buying process requires it
 					</h2>
 					<p class="public-page__section-subtitle">
-						Most buyers should start with self-serve pricing. Move into enterprise review only when
-						procurement, private deployment, or custom control requirements need their own path.
+						Start with workspace access or published pricing. Use enterprise review for private
+						deployment, procurement, or custom control requirements.
 					</p>
 				</div>
 				<div class="public-page__actions-row">
-					<a href={pricingEnterprisePathHref} class="btn btn-primary">Open Enterprise Path</a>
+					<a href={pricingEnterprisePathHref} class="btn btn-primary">Enterprise Review</a>
 					<a href={pricingValidationBriefingHref} class="btn btn-secondary">
 						Request Validation Briefing
 					</a>

--- a/dashboard/src/routes/pricing/pricing-page.svelte.test.ts
+++ b/dashboard/src/routes/pricing/pricing-page.svelte.test.ts
@@ -32,7 +32,7 @@ vi.mock('$app/stores', () => {
 });
 
 describe('pricing page public messaging', () => {
-	it('shows the free tier entry path plus self-serve paid plans and enterprise lane', () => {
+	it('shows the free tier entry path plus self-serve paid plans and enterprise review', () => {
 		render(Page, {
 			props: {
 				data: {
@@ -73,21 +73,21 @@ describe('pricing page public messaging', () => {
 
 		expect(
 			screen.getByRole('heading', {
-				name: /keep the enterprise lane for buyers who truly need a separate diligence track/i
+				name: /use enterprise review only when the buying process requires it/i
 			})
 		).toBeTruthy();
-		expect(screen.getByText(/most buyers should start with self-serve pricing/i)).toBeTruthy();
-		expect(screen.getByText(/prices are shown in usd for easy plan comparison/i)).toBeTruthy();
+		expect(screen.getByText(/start with workspace access or published pricing/i)).toBeTruthy();
+		expect(screen.getByText(/prices shown in usd\./i)).toBeTruthy();
 		expect(
 			screen.getByText(/the permanent free tier does not require a checkout session/i)
 		).toBeTruthy();
 
-		expect(
-			screen.getByRole('link', { name: /see enterprise path/i }).getAttribute('href') || ''
-		).toContain('/enterprise?');
-		expect(
-			screen.getByRole('link', { name: /open enterprise path/i }).getAttribute('href') || ''
-		).toContain('/enterprise?');
+		const enterpriseReviewLinks = screen.getAllByRole('link', {
+			name: /^enterprise review$/i
+		});
+		expect(enterpriseReviewLinks.length).toBeGreaterThanOrEqual(2);
+		expect(enterpriseReviewLinks[0]?.getAttribute('href') || '').toContain('/enterprise?');
+		expect(enterpriseReviewLinks[1]?.getAttribute('href') || '').toContain('/enterprise?');
 		expect(
 			screen.getByRole('link', { name: /request validation briefing/i }).getAttribute('href') || ''
 		).toContain('/talk-to-sales?');

--- a/dashboard/src/routes/pricing/pricingPageContent.ts
+++ b/dashboard/src/routes/pricing/pricingPageContent.ts
@@ -15,6 +15,6 @@ export const PRICING_HERO_META = [
 ] as const;
 
 export const PRICING_BUYING_NOTES = [
-	'Prices are shown in USD for easy plan comparison.',
+	'Prices shown in USD.',
 	'The permanent free tier does not require a checkout session.'
 ] as const;

--- a/dashboard/src/routes/privacy/+page.svelte
+++ b/dashboard/src/routes/privacy/+page.svelte
@@ -117,11 +117,11 @@
 	</section>
 
 	<section class="space-y-3 rounded-3xl border border-white/10 bg-white/5 p-6">
-		<h2 class="text-xl font-semibold">10. Enterprise Privacy Review Path</h2>
+		<h2 class="text-xl font-semibold">10. Enterprise Privacy Review</h2>
 		<p class="text-sm text-ink-300">
 			Public privacy materials are meant to answer the first diligence questions without inventing a
 			universal deployment or processor answer. DPA requests, sub-processor review, and
-			residency-specific questions move into the enterprise/legal lane when a buyer needs scoped
+			residency-specific questions move into enterprise and legal review when a buyer needs scoped
 			answers.
 		</p>
 		<ul class="list-disc pl-5 text-sm text-ink-300 space-y-2">
@@ -133,7 +133,7 @@
 			<a class="btn btn-secondary" href={`${base}/proof/deployment-and-data-residency`}>
 				Deployment and Residency Proof
 			</a>
-			<a class="btn btn-secondary" href={`${base}/enterprise`}> Enterprise Review Path </a>
+			<a class="btn btn-secondary" href={`${base}/enterprise`}> Enterprise Review </a>
 			<a class="btn btn-secondary" href={`${base}/talk-to-sales`}> Talk to Sales </a>
 		</div>
 	</section>

--- a/dashboard/src/routes/privacy/privacy-page.svelte.test.ts
+++ b/dashboard/src/routes/privacy/privacy-page.svelte.test.ts
@@ -27,11 +27,11 @@ describe('privacy page', () => {
 		expect(supportMailLink.getAttribute('href')).toBe('mailto:support@valdrics.com');
 		const securityMailLink = screen.getByRole('link', { name: /security@valdrics.com/i });
 		expect(securityMailLink.getAttribute('href')).toBe('mailto:security@valdrics.com');
-		expect(screen.getByRole('heading', { name: /enterprise privacy review path/i })).toBeTruthy();
+		expect(screen.getByRole('heading', { name: /enterprise privacy review/i })).toBeTruthy();
 		expect(
 			screen.getByRole('link', { name: /deployment and residency proof/i }).getAttribute('href')
 		).toBe('/proof/deployment-and-data-residency');
-		expect(screen.getByRole('link', { name: /enterprise review path/i }).getAttribute('href')).toBe(
+		expect(screen.getByRole('link', { name: /enterprise review/i }).getAttribute('href')).toBe(
 			'/enterprise'
 		);
 		expect(screen.getByRole('link', { name: /talk to sales/i }).getAttribute('href')).toBe(

--- a/dashboard/src/routes/proof/+page.svelte
+++ b/dashboard/src/routes/proof/+page.svelte
@@ -91,14 +91,14 @@
 >
 	{#snippet heroActions()}
 		{#if buyingMotion === 'enterprise_first'}
-			<a href={enterprisePathHref} class="btn btn-primary">Open Enterprise Path</a>
+			<a href={enterprisePathHref} class="btn btn-primary">Enterprise Review</a>
 			<a href={`${base}/docs/technical-validation`} class="btn btn-secondary">
 				Open Technical Validation
 			</a>
 			<a href={startFreeHref} class="btn btn-secondary">Start Free Workspace</a>
 		{:else}
 			<a href={startFreeHref} class="btn btn-primary">Start Free Workspace</a>
-			<a href={enterprisePathHref} class="btn btn-secondary">See Enterprise Path</a>
+			<a href={enterprisePathHref} class="btn btn-secondary">Enterprise Review</a>
 			<a href={`${base}/docs/technical-validation`} class="btn btn-secondary">
 				Open Technical Validation
 			</a>
@@ -185,7 +185,7 @@
 					</p>
 				</div>
 				<div class="public-page__actions-row">
-					<a href={enterprisePathHref} class="btn btn-primary">Open Enterprise Path</a>
+					<a href={enterprisePathHref} class="btn btn-primary">Enterprise Review</a>
 					<a href={`${base}/docs`} class="btn btn-secondary">Documentation</a>
 					<a href={`${base}/docs/api`} class="btn btn-secondary">API Reference</a>
 					<a href={startFreeHref} class="btn btn-secondary">Start Free Workspace</a>

--- a/dashboard/src/routes/proof/proof-page.svelte.test.ts
+++ b/dashboard/src/routes/proof/proof-page.svelte.test.ts
@@ -20,7 +20,7 @@ describe('proof page', () => {
 			screen.getByRole('heading', { level: 1, name: /proof surfaces for buyer diligence/i })
 		).toBeTruthy();
 		expect(
-			screen.getAllByRole('link', { name: /open enterprise path/i })[0]?.getAttribute('href') || ''
+			screen.getAllByRole('link', { name: /enterprise review/i })[0]?.getAttribute('href') || ''
 		).toContain('/enterprise?');
 		expect(
 			screen.getAllByRole('link', { name: /start free workspace/i })[0]?.getAttribute('href') || ''

--- a/dashboard/src/routes/resources/+page.svelte
+++ b/dashboard/src/routes/resources/+page.svelte
@@ -121,11 +121,11 @@
 >
 	{#snippet heroActions()}
 		{#if buyingMotion === 'enterprise_first'}
-			<a href={enterprisePathHref} class="btn btn-primary">Open Enterprise Path</a>
+			<a href={enterprisePathHref} class="btn btn-primary">Enterprise Review</a>
 			<a href={startFreeHref} class="btn btn-secondary">Start Free Workspace</a>
 		{:else}
 			<a href={startFreeHref} class="btn btn-primary">Start Free Workspace</a>
-			<a href={enterprisePathHref} class="btn btn-secondary">See Enterprise Path</a>
+			<a href={enterprisePathHref} class="btn btn-secondary">Enterprise Review</a>
 		{/if}
 		<a href={`${base}/insights`} class="btn btn-secondary">Open Insights</a>
 	{/snippet}

--- a/dashboard/src/routes/resources/resources-page.svelte.test.ts
+++ b/dashboard/src/routes/resources/resources-page.svelte.test.ts
@@ -26,7 +26,7 @@ describe('resources page contact directory', () => {
 			screen.getByRole('link', { name: /start free workspace/i }).getAttribute('href') || ''
 		).toContain('/auth/login?');
 		expect(
-			screen.getByRole('link', { name: /see enterprise path/i }).getAttribute('href') || ''
+			screen.getByRole('link', { name: /enterprise review/i }).getAttribute('href') || ''
 		).toContain('/enterprise?');
 		expect(screen.getByRole('heading', { name: /contact directory/i })).toBeTruthy();
 		expect(

--- a/dashboard/src/routes/roi-planner/+page.svelte
+++ b/dashboard/src/routes/roi-planner/+page.svelte
@@ -16,7 +16,6 @@
 		normalizeLandingRoiInputs,
 		formatCurrencyAmount
 	} from '$lib/landing/roiCalculator';
-	import '$lib/components/LandingHero.css';
 
 	let { data } = $props();
 

--- a/dashboard/src/routes/talk-to-sales/talk-to-sales-page-content.ts
+++ b/dashboard/src/routes/talk-to-sales/talk-to-sales-page-content.ts
@@ -17,7 +17,7 @@ export const salesMailHref =
 
 export const heroHighlights = [
 	{
-		label: 'Buyer-safe path',
+		label: 'Direct review',
 		value: 'Security, rollout effort, and commercial fit handled in one conversation'
 	},
 	{
@@ -25,7 +25,7 @@ export const heroHighlights = [
 		value: 'Most qualified inquiries receive a human reply within one business day'
 	},
 	{
-		label: 'No forced lane',
+		label: 'Flexible next step',
 		value: 'We can route you to free, self-serve, or enterprise without restarting the process'
 	}
 ] as const;

--- a/dashboard/src/routes/terms/+page.svelte
+++ b/dashboard/src/routes/terms/+page.svelte
@@ -123,26 +123,26 @@
 	</section>
 
 	<section class="space-y-3 rounded-3xl border border-white/10 bg-white/5 p-6">
-		<h2 class="text-xl font-semibold">12. Enterprise Contracting and Procurement Path</h2>
+		<h2 class="text-xl font-semibold">12. Enterprise Contracting and Procurement</h2>
 		<p class="text-sm text-ink-300">
 			Public terms explain the baseline service posture, but enterprise evaluation usually needs a
-			more explicit commercial and legal path. Order-form review, governing-law questions, DPA
-			attachment, and procurement-specific requirements move into the enterprise lane rather than
-			being improvised over general support email.
+			more explicit commercial and legal process. Order-form review, governing-law questions, DPA
+			attachment, and procurement-specific requirements should move into enterprise review rather
+			than general support email.
 		</p>
 		<ul class="list-disc pl-5 text-sm text-ink-300 space-y-2">
 			<li>
 				Legal review and contracting requests route through the legal and enterprise contacts.
 			</li>
-			<li>Pricing-fit and commercial questions route through the sales and procurement path.</li>
 			<li>
-				Privacy, DPA, and deployment-specific questions stay connected to the privacy review lane.
+				Pricing-fit and commercial questions route through the sales and procurement contacts.
 			</li>
+			<li>Privacy, DPA, and deployment-specific questions stay connected to the privacy review.</li>
 		</ul>
 		<div class="flex flex-wrap gap-3 pt-2">
-			<a class="btn btn-secondary" href={`${base}/enterprise`}> Open Enterprise Path </a>
+			<a class="btn btn-secondary" href={`${base}/enterprise`}> Enterprise Review </a>
 			<a class="btn btn-secondary" href={`${base}/pricing`}> View Pricing </a>
-			<a class="btn btn-secondary" href={`${base}/privacy`}> Privacy and DPA Path </a>
+			<a class="btn btn-secondary" href={`${base}/privacy`}> Privacy and DPA </a>
 			<a class="btn btn-secondary" href={`${base}/talk-to-sales`}> Talk to Sales </a>
 		</div>
 	</section>

--- a/dashboard/src/routes/terms/terms-page.svelte.test.ts
+++ b/dashboard/src/routes/terms/terms-page.svelte.test.ts
@@ -22,19 +22,19 @@ describe('terms page', () => {
 		expect(screen.getByRole('heading', { name: /limitation of liability/i })).toBeTruthy();
 		expect(screen.getByRole('heading', { name: /governing law and disputes/i })).toBeTruthy();
 		expect(
-			screen.getByRole('heading', { name: /enterprise contracting and procurement path/i })
+			screen.getByRole('heading', { name: /enterprise contracting and procurement/i })
 		).toBeTruthy();
 		const legalMailLink = screen.getByRole('link', { name: /legal@valdrics.com/i });
 		expect(legalMailLink.getAttribute('href')).toBe('mailto:legal@valdrics.com');
 		const billingMailLink = screen.getByRole('link', { name: /billing@valdrics.com/i });
 		expect(billingMailLink.getAttribute('href')).toBe('mailto:billing@valdrics.com');
-		expect(screen.getByRole('link', { name: /open enterprise path/i }).getAttribute('href')).toBe(
+		expect(screen.getByRole('link', { name: /enterprise review/i }).getAttribute('href')).toBe(
 			'/enterprise'
 		);
 		expect(screen.getByRole('link', { name: /view pricing/i }).getAttribute('href')).toBe(
 			'/pricing'
 		);
-		expect(screen.getByRole('link', { name: /privacy and dpa path/i }).getAttribute('href')).toBe(
+		expect(screen.getByRole('link', { name: /privacy and dpa/i }).getAttribute('href')).toBe(
 			'/privacy'
 		);
 		expect(screen.getByRole('link', { name: /talk to sales/i }).getAttribute('href')).toBe(

--- a/docs/ops/all_changes_categorization_2026-03-23.md
+++ b/docs/ops/all_changes_categorization_2026-03-23.md
@@ -1,0 +1,92 @@
+# All Changes Categorization (2026-03-23)
+
+Snapshot:
+- Captured at: `2026-03-23T00:00:00Z`
+- Base commit: `4cb0686024d41a3686585599abccfb67b1626fe9`
+- Pending paths: `43`
+- Branch at snapshot: `chore/all-changes-categorization-2026-03-22`
+
+## Track CG: Landing Hero Composition, Visual System, and Capture Automation
+Scope:
+- Consolidate landing hero composition, shared landing styles, calculator surfaces, and visual-capture automation in one frontend implementation lane.
+- Keep the landing component test coverage with the exact components and styles it exercises.
+- Treat this as the core landing-build track separate from route-level page delivery.
+
+Paths:
+- `dashboard/scripts/capture-dashboard-hero-still.ts`
+- `dashboard/src/lib/components/LandingHero.svelte`
+- `dashboard/src/lib/components/LandingHero.svelte.test.ts`
+- `dashboard/src/lib/components/landing/LandingCurrencyToggle.svelte`
+- `dashboard/src/lib/components/landing/LandingHeroCopy.svelte`
+- `dashboard/src/lib/components/landing/LandingHeroView.public.css`
+- `dashboard/src/lib/components/landing/LandingHeroView.svelte`
+- `dashboard/src/lib/components/landing/LandingMarketingShared.css`
+- `dashboard/src/lib/components/landing/LandingPlansSection.svelte`
+- `dashboard/src/lib/components/landing/LandingRoiCalculator.svelte`
+- `dashboard/src/lib/components/landing/LandingRoiSimulator.svelte`
+- `dashboard/src/lib/components/landing/LandingTrustSection.svelte`
+- `dashboard/src/lib/landing/heroContent.extended.ts`
+
+Notes:
+- This track is the primary landing composition and visual-system slice of the batch.
+
+## Track CH: Public Content, Pricing Data, and Navigation Contracts
+Scope:
+- Group shared public content models, pricing-plan data, talk-to-sales content, and public navigation contracts together.
+- Keep non-route content and navigation sources in one review lane so route changes can stay focused on delivery surfaces.
+- Treat this as the shared marketing-data and copy-contract track for the batch.
+
+Paths:
+- `dashboard/src/lib/content/publicCompany.ts`
+- `dashboard/src/lib/content/publicContent.docs.ts`
+- `dashboard/src/lib/content/publicContent.insights.ts`
+- `dashboard/src/lib/content/publicContent.proof.ts`
+- `dashboard/src/lib/content/publicContent.resources.ts`
+- `dashboard/src/lib/landing/publicNav.ts`
+- `dashboard/src/lib/pricing/publicPlans.ts`
+- `dashboard/src/routes/pricing/pricingPageContent.ts`
+- `dashboard/src/routes/talk-to-sales/talk-to-sales-page-content.ts`
+
+Notes:
+- This track captures shared content and navigation sources used across the public site.
+
+## Track CI: Public Routes, Shell, and Page-Level Regression Coverage
+Scope:
+- Batch the public shell and page-route changes together with their page-level regression tests.
+- Keep public route delivery behavior separate from shared content and landing component composition.
+- Treat this as the route-level public web track for the follow-up batch.
+
+Paths:
+- `dashboard/src/routes/about/+page.svelte`
+- `dashboard/src/routes/about/about-page.svelte.test.ts`
+- `dashboard/src/routes/billing/+page.svelte`
+- `dashboard/src/routes/billing/billing-page.svelte.test.ts`
+- `dashboard/src/routes/docs/technical-validation/+page.svelte`
+- `dashboard/src/routes/docs/technical-validation/technical-validation-page.svelte.test.ts`
+- `dashboard/src/routes/insights/+page.svelte`
+- `dashboard/src/routes/insights/insights-page.svelte.test.ts`
+- `dashboard/src/routes/layout-public-menu.svelte.test.ts`
+- `dashboard/src/routes/layout/PublicSiteShell.svelte`
+- `dashboard/src/routes/pricing/+page.svelte`
+- `dashboard/src/routes/pricing/pricing-page.svelte.test.ts`
+- `dashboard/src/routes/privacy/+page.svelte`
+- `dashboard/src/routes/privacy/privacy-page.svelte.test.ts`
+- `dashboard/src/routes/proof/+page.svelte`
+- `dashboard/src/routes/proof/proof-page.svelte.test.ts`
+- `dashboard/src/routes/resources/+page.svelte`
+- `dashboard/src/routes/resources/resources-page.svelte.test.ts`
+- `dashboard/src/routes/roi-planner/+page.svelte`
+- `dashboard/src/routes/terms/+page.svelte`
+- `dashboard/src/routes/terms/terms-page.svelte.test.ts`
+
+Notes:
+- This track is the page-delivery and shell-integration slice of the public site.
+
+## Batching Decision
+Decision:
+- Merge as one consolidated PR.
+
+Reasoning:
+- The batch is one active dashboard and public-site follow-up slice centered on the same landing and public-route surfaces.
+- Splitting it further would create overlapping PRs across shared landing components, route content, and public shell contracts.
+- The issue split keeps review accountability without fragmenting the delivery batch.


### PR DESCRIPTION
## Summary
- categorize the full March 23 follow-up worktree in `docs/ops/all_changes_categorization_2026-03-23.md`
- consolidate the landing hero, shared public content, and public-route follow-up changes in one PR
- close the three track issues created for this batch

## Tracks
- closes #332
- closes #333
- closes #334

## Notes
- This is a consolidation PR across the current follow-up dashboard and public-site snapshot.
- I did not run a fresh full local test suite in this batching turn before opening the PR.
