### PR TITLE
chore: categorize and consolidate all pending changes (2026-03-27)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -19,6 +19,7 @@ from pydantic import BaseModel
 from slowapi import _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 
+from app.shared.core import app_runtime as app_runtime_module
 from app.shared.core.app_routes import register_api_routers, register_lifecycle_routes
 from app.shared.core.app_runtime import (
     _api_documentation_allowed,
@@ -127,6 +128,9 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     await dispose_db_runtime()
     validate_runtime_dependencies(settings)
     init_sentry()
+    from app.modules.governance.api.v1.health_dashboard import set_startup_time
+
+    set_startup_time()
 
     # Setup: Initialize scheduler and emissions tracker
     logger.info("app_starting", app_name=settings.APP_NAME)
@@ -287,10 +291,12 @@ __all__ = ["app", "valdrics_app", "lifespan"]
 
 
 def refresh_fastapi_app_metadata(settings_obj: Any | None = None) -> None:
+    global EmissionsTracker
     settings_obj = settings_obj or get_settings()
     valdrics_app.title = str(settings_obj.APP_NAME)
     valdrics_app.version = str(settings_obj.VERSION)
     valdrics_app.openapi_schema = None
+    EmissionsTracker = app_runtime_module.refresh_emissions_tracker()
 
 # Initialize Tracing
 setup_tracing(valdrics_app)

--- a/app/modules/billing/api/v1/billing.py
+++ b/app/modules/billing/api/v1/billing.py
@@ -60,7 +60,12 @@ __all__ = [
 ]
 
 router = APIRouter(tags=["Billing"])
-settings = get_settings()
+
+
+def _settings():
+    return get_settings()
+
+
 def _build_checkout_callback_url(raw_callback_url: Optional[str]) -> str:
     """
     Validate and normalize user-provided checkout callback URLs.
@@ -70,6 +75,7 @@ def _build_checkout_callback_url(raw_callback_url: Optional[str]) -> str:
     - enforce HTTPS in staging/production
     - block credentialed URLs
     """
+    settings = _settings()
     default_callback = f"{settings.FRONTEND_URL.rstrip('/')}/billing?success=true"
     candidate = (raw_callback_url or "").strip()
     callback = candidate or default_callback
@@ -111,6 +117,7 @@ def _build_checkout_callback_url(raw_callback_url: Optional[str]) -> str:
 
 
 def _extract_client_ip(request: Request) -> str:
+    settings = _settings()
     return resolve_client_ip(request, settings_obj=settings)
 
 
@@ -237,6 +244,7 @@ async def create_checkout(
     db: AsyncSession = Depends(get_db),
 ) -> Dict[str, str]:
     """Initialize Paystack checkout session."""
+    settings = _settings()
     if not settings.PAYSTACK_SECRET_KEY:
         raise HTTPException(503, "Billing not configured")
 
@@ -318,6 +326,7 @@ async def handle_webhook(request: Request, db: AsyncSession = Depends(get_db)) -
     Webhooks are validated, persisted to background_jobs, and acknowledged
     immediately with 202 to keep provider latency out of the request path.
     """
+    settings = _settings()
     try:
         return await process_paystack_webhook(
             request,

--- a/app/modules/billing/domain/billing/paystack_shared.py
+++ b/app/modules/billing/domain/billing/paystack_shared.py
@@ -13,13 +13,31 @@ from app.shared.core.security import decrypt_string as _decrypt_string
 from app.shared.core.security import encrypt_string as _encrypt_string
 
 logger = structlog.get_logger()
-settings = get_settings()
 PAYSTACK_CHECKOUT_CURRENCY = "NGN"
 PAYSTACK_FX_PROVIDER = "cbn_nfem"
 PAYSTACK_USD_FX_PROVIDER = "native_usd"
 
 encrypt_string = _encrypt_string
 decrypt_string = _decrypt_string
+
+
+class _SettingsProxy:
+    """Resolve Paystack runtime settings lazily so config refreshes are honored."""
+
+    def __getattr__(self, name: str):
+        return getattr(get_settings(), name)
+
+    def __setattr__(self, name: str, value) -> None:
+        setattr(get_settings(), name, value)
+
+    def __delattr__(self, name: str) -> None:
+        delattr(get_settings(), name)
+
+    def __repr__(self) -> str:
+        return f"{type(self).__name__}({get_settings()!r})"
+
+
+settings = _SettingsProxy()
 
 
 class SubscriptionStatus(str, Enum):

--- a/app/modules/billing/domain/billing/webhook_retry.py
+++ b/app/modules/billing/domain/billing/webhook_retry.py
@@ -36,7 +36,6 @@ from app.modules.governance.domain.jobs.errors import (
     PermanentJobError,
 )
 from app.modules.governance.domain.jobs.processor import (
-    JOB_LOCK_TIMEOUT_MINUTES,
     enqueue_job,
 )
 from app.shared.core.config import get_settings
@@ -57,6 +56,17 @@ WEBHOOK_MAX_ATTEMPTS = 5  # More retries for revenue-critical
 def _webhook_idempotency_ttl_hours() -> int:
     """Resolve idempotency TTL from the current settings snapshot."""
     return get_settings().WEBHOOK_IDEMPOTENCY_TTL_HOURS
+
+
+def _job_lock_timeout_minutes() -> int:
+    """Resolve stale-running cutoff from the current job processor settings."""
+    try:
+        timeout_minutes = int(
+            getattr(get_settings(), "BACKGROUND_JOB_RUNNING_TIMEOUT_MINUTES", 30)
+        )
+    except (TypeError, ValueError):
+        timeout_minutes = 30
+    return max(1, timeout_minutes)
 
 
 class WebhookRetryableError(JobExecutionError):
@@ -172,7 +182,7 @@ class WebhookRetryService:
         started_at = self._normalize_datetime(getattr(job, "started_at", None))
         if started_at is None:
             return False
-        cutoff = now - timedelta(minutes=JOB_LOCK_TIMEOUT_MINUTES)
+        cutoff = now - timedelta(minutes=_job_lock_timeout_minutes())
         return started_at <= cutoff
 
     async def _reload_existing_job_for_update(self, job_id: Any) -> BackgroundJob | None:

--- a/app/modules/governance/api/v1/health_dashboard.py
+++ b/app/modules/governance/api/v1/health_dashboard.py
@@ -67,10 +67,27 @@ HEALTH_DASHBOARD_TIER_LOOKUP_RECOVERABLE_EXCEPTIONS = (
     ValueError,
 )
 
-# Track startup time
-_startup_time = datetime.now(timezone.utc)
+# Track process startup from the real FastAPI lifespan, not module import time.
+_startup_time: datetime | None = None
 HEALTH_DASHBOARD_CACHE_TTL = timedelta(seconds=20)
 FAIR_USE_RUNTIME_CACHE_TTL = timedelta(seconds=20)
+
+
+def set_startup_time(started_at: datetime | None = None) -> datetime:
+    """Record the service startup time for uptime calculations."""
+    global _startup_time
+    resolved = started_at or datetime.now(timezone.utc)
+    if resolved.tzinfo is None:
+        resolved = resolved.replace(tzinfo=timezone.utc)
+    else:
+        resolved = resolved.astimezone(timezone.utc)
+    _startup_time = resolved
+    return _startup_time
+
+
+def _resolve_startup_time(now: datetime) -> datetime:
+    """Return the tracked startup time, falling back to the current request time."""
+    return _startup_time or now
 
 
 @router.get("", response_model=InvestorHealthDashboard)
@@ -101,7 +118,7 @@ async def get_investor_health_dashboard(
             except HEALTH_DASHBOARD_CACHE_RECOVERABLE_EXCEPTIONS as exc:
                 logger.warning("health_dashboard_cache_decode_failed", error=str(exc))
 
-    uptime = now - _startup_time
+    uptime = now - _resolve_startup_time(now)
     system = SystemHealth(
         status="healthy",
         uptime_hours=round(uptime.total_seconds() / 3600, 2),

--- a/app/modules/governance/domain/jobs/processor.py
+++ b/app/modules/governance/domain/jobs/processor.py
@@ -49,13 +49,9 @@ __all__ = [
 from app.modules.governance.domain.jobs.handlers import get_handler_factory
 
 logger = structlog.get_logger()
-settings = get_settings()
 
 # Job processing configuration
 MAX_JOBS_PER_BATCH = 10
-JOB_LOCK_TIMEOUT_MINUTES = max(
-    1, int(getattr(settings, "BACKGROUND_JOB_RUNNING_TIMEOUT_MINUTES", 30))
-)
 BACKOFF_BASE_SECONDS = 60
 JOB_TIMEOUT_SECONDS = 300  # 5 minutes default timeout
 MAX_JOB_RESULT_BYTES = 256 * 1024
@@ -82,6 +78,20 @@ JOB_RUNTIME_UNEXPECTED_ERRORS: tuple[type[Exception], ...] = (
     UnicodeError,
     ArithmeticError,
 )
+
+
+def _job_lock_timeout_minutes() -> int:
+    """Resolve stale-running lock timeout from live settings."""
+    settings = get_settings()
+    try:
+        timeout_minutes = int(
+            getattr(settings, "BACKGROUND_JOB_RUNNING_TIMEOUT_MINUTES", 30)
+        )
+    except (TypeError, ValueError):
+        timeout_minutes = 30
+    return max(1, timeout_minutes)
+
+
 class JobProcessor:
     """
     Processes background jobs from the database queue.
@@ -107,7 +117,7 @@ class JobProcessor:
             return False
         if started_at.tzinfo is None:
             started_at = started_at.replace(tzinfo=timezone.utc)
-        cutoff = now - timedelta(minutes=JOB_LOCK_TIMEOUT_MINUTES)
+        cutoff = now - timedelta(minutes=_job_lock_timeout_minutes())
         return started_at <= cutoff
 
     def _apply_failure_transition(
@@ -138,7 +148,8 @@ class JobProcessor:
 
     async def _recover_stale_running_jobs(self, *, now: datetime) -> int:
         """Requeue or dead-letter RUNNING jobs abandoned by a crashed worker."""
-        cutoff = now - timedelta(minutes=JOB_LOCK_TIMEOUT_MINUTES)
+        lock_timeout_minutes = _job_lock_timeout_minutes()
+        cutoff = now - timedelta(minutes=lock_timeout_minutes)
         recovered = 0
 
         async with self.db.begin_nested():
@@ -161,7 +172,7 @@ class JobProcessor:
                     {
                         "status": "recovered_stale_running_job",
                         "recovered_at": now.isoformat(),
-                        "lock_timeout_minutes": JOB_LOCK_TIMEOUT_MINUTES,
+                        "lock_timeout_minutes": lock_timeout_minutes,
                     },
                 )
                 job.started_at = None
@@ -169,7 +180,7 @@ class JobProcessor:
                     job,
                     error_message=(
                         "Recovered stale RUNNING job after lock timeout "
-                        f"({JOB_LOCK_TIMEOUT_MINUTES} minutes)"
+                        f"({lock_timeout_minutes} minutes)"
                     ),
                     now=now,
                     permanent=False,
@@ -189,7 +200,7 @@ class JobProcessor:
             logger.warning(
                 "job_processor_recovered_stale_running_jobs",
                 recovered=recovered,
-                lock_timeout_minutes=JOB_LOCK_TIMEOUT_MINUTES,
+                lock_timeout_minutes=lock_timeout_minutes,
             )
 
         return recovered

--- a/app/modules/governance/domain/scheduler/orchestrator.py
+++ b/app/modules/governance/domain/scheduler/orchestrator.py
@@ -22,7 +22,6 @@ from app.shared.core.ops_metrics import (
 )
 
 logger = structlog.get_logger()
-settings = get_settings()
 
 # Arbitrary constant for scheduler advisory locks - DEPRECATED in favor of SELECT FOR UPDATE
 # Keeping for reference of lock inheritance
@@ -84,6 +83,10 @@ class SchedulerOrchestrator:
         self._last_run_success: bool | None = None
         self._last_run_time: str | None = None
         self._carbon_cache: dict[str, tuple[float, float]] = {}
+
+    @staticmethod
+    def _settings() -> Any:
+        return get_settings()
 
     async def _dispatch_task(
         self,
@@ -176,6 +179,7 @@ class SchedulerOrchestrator:
         Acquire a distributed dispatch lock to prevent duplicate schedule dispatches
         when multiple API instances are running APScheduler.
         """
+        settings = self._settings()
         # Test runs should be deterministic and fast; do not depend on Redis lock timing.
         if settings.TESTING or settings.PYTEST_CURRENT_TEST:
             return True
@@ -245,6 +249,7 @@ class SchedulerOrchestrator:
         """
         region_hint = str(region or "").strip().lower() or "global"
         live_intensity = await self._fetch_live_carbon_intensity(region_hint)
+        settings = self._settings()
         if live_intensity is not None:
             is_green = live_intensity <= settings.CARBON_LOW_INTENSITY_THRESHOLD
             logger.info(
@@ -270,6 +275,7 @@ class SchedulerOrchestrator:
 
     async def _fetch_live_carbon_intensity(self, region: str) -> float | None:
         region_hint = str(region or "").strip().lower() or "global"
+        settings = self._settings()
         api_key = settings.ELECTRICITY_MAPS_API_KEY
         if not api_key:
             return None
@@ -354,6 +360,7 @@ class SchedulerOrchestrator:
 
     async def enforcement_reconciliation_sweep_job(self) -> None:
         """Dispatches periodic enforcement reservation reconciliation sweep."""
+        settings = self._settings()
         if not bool(
             getattr(settings, "ENFORCEMENT_RECONCILIATION_SWEEP_ENABLED", True)
         ):
@@ -371,6 +378,7 @@ class SchedulerOrchestrator:
     async def _process_background_jobs_inline(self) -> None:
         from app.modules.governance.domain.jobs.processor import JobProcessor
 
+        settings = self._settings()
         batch_size = max(
             1, int(getattr(settings, "BACKGROUND_JOB_PROCESS_BATCH_SIZE", 25))
         )
@@ -409,6 +417,7 @@ class SchedulerOrchestrator:
         """
         Detect overdue pending jobs without mutating future-scheduled retries.
         """
+        settings = self._settings()
         async with self.session_maker() as db:
             from app.models.background_job import BackgroundJob, JobStatus
             from datetime import datetime, timezone, timedelta

--- a/app/modules/optimization/domain/ports.py
+++ b/app/modules/optimization/domain/ports.py
@@ -12,7 +12,6 @@ from app.shared.core.exceptions import ExternalAPIError
 from app.modules.optimization.domain.plugin import ZombiePlugin
 
 logger = structlog.get_logger()
-settings = get_settings()
 
 ZOMBIE_SCAN_RECOVERABLE_EXCEPTIONS: tuple[type[Exception], ...] = (
     ExternalAPIError,
@@ -275,7 +274,7 @@ class BaseZombieDetector(ABC):
             scan_coro = self._execute_plugin_scan(plugin)
 
             # Use global timeout from settings
-            timeout = settings.ZOMBIE_PLUGIN_TIMEOUT_SECONDS
+            timeout = get_settings().ZOMBIE_PLUGIN_TIMEOUT_SECONDS
             with cloud_api_scan_context(
                 tenant_id=tenant_id,
                 provider=self.provider_name,

--- a/app/shared/adapters/cost_cache.py
+++ b/app/shared/adapters/cost_cache.py
@@ -25,7 +25,6 @@ import structlog
 from app.shared.core.config import get_settings
 
 logger = structlog.get_logger()
-settings = get_settings()
 
 REDIS_CLIENT_INIT_RECOVERABLE_ERRORS: tuple[type[Exception], ...] = (
     ImportError,
@@ -48,7 +47,7 @@ REDIS_OPERATION_RECOVERABLE_ERRORS: tuple[type[Exception], ...] = (
 
 
 def _cache_settings() -> Any:
-    return settings
+    return get_settings()
 
 
 def _configured_redis_url(settings_obj: Any | None = None) -> str | None:

--- a/app/shared/core/app_runtime.py
+++ b/app/shared/core/app_runtime.py
@@ -62,6 +62,13 @@ EMISSIONS_TRACKER_STOP_RECOVERABLE_EXCEPTIONS = (
 )
 
 
+def refresh_emissions_tracker() -> Any:
+    """Refresh the CodeCarbon tracker class after settings reloads."""
+    global EmissionsTracker
+    EmissionsTracker = _load_emissions_tracker()
+    return EmissionsTracker
+
+
 def _stop_emissions_tracker(tracker: Any) -> None:
     if not tracker:
         return
@@ -80,4 +87,5 @@ __all__ = [
     "_runtime_data_dir",
     "_stop_emissions_tracker",
     "EmissionsTracker",
+    "refresh_emissions_tracker",
 ]

--- a/app/shared/core/health.py
+++ b/app/shared/core/health.py
@@ -32,7 +32,6 @@ from app.shared.core.cache import get_cache_service
 from app.shared.core.async_utils import maybe_await
 
 logger = structlog.get_logger()
-settings = get_settings()
 HEALTH_RECOVERABLE_ERRORS = (
     SQLAlchemyError,
     HTTPError,
@@ -271,8 +270,8 @@ class HealthService:
                 "system_resources": system_status,
                 "background_jobs": jobs_status,
             },
-            "version": getattr(settings, "VERSION", "unknown"),
-            "environment": getattr(settings, "ENVIRONMENT", "unknown"),
+            "version": getattr(self._get_settings(), "VERSION", "unknown"),
+            "environment": getattr(self._get_settings(), "ENVIRONMENT", "unknown"),
         }
 
         # Log health check results

--- a/app/shared/db/session.py
+++ b/app/shared/db/session.py
@@ -46,8 +46,6 @@ __all__ = ["ValdricsException"]
 # without importing `app/main.py`.
 import app.models  # noqa: F401, E402
 
-settings = get_settings()
-
 _RLS_EXEMPT_TABLE_PATTERN = re.compile(
     r"\b(" + "|".join(re.escape(table.lower()) for table in RLS_EXEMPT_TABLES) + r")\b"
 )
@@ -311,7 +309,9 @@ def async_session_maker(*args: Any, **kwargs: Any) -> Any:
 def _get_slow_query_threshold_seconds() -> float:
     """Return configurable slow-query threshold with a safe fallback."""
     try:
-        threshold = float(getattr(settings, "DB_SLOW_QUERY_THRESHOLD_SECONDS", 0.2))
+        threshold = float(
+            getattr(get_settings(), "DB_SLOW_QUERY_THRESHOLD_SECONDS", 0.2)
+        )
     except (TypeError, ValueError):
         threshold = 0.2
     return threshold if threshold > 0 else 0.2

--- a/app/shared/llm/circuit_breaker.py
+++ b/app/shared/llm/circuit_breaker.py
@@ -29,6 +29,7 @@ from typing import Any, Dict, Optional
 import structlog
 from contextlib import contextmanager
 import sys
+from threading import RLock
 
 logger = structlog.get_logger()
 FATAL_EXCEPTIONS = (SystemExit, KeyboardInterrupt, GeneratorExit)
@@ -50,6 +51,7 @@ class ProviderCircuit:
     success_count: int = 0
     last_failure_time: Optional[datetime] = None
     last_success_time: Optional[datetime] = None
+    probe_in_flight: bool = False
 
     # Thresholds
     failure_threshold: int = 3  # Failures to open circuit
@@ -77,99 +79,140 @@ class LLMCircuitBreaker:
         self.success_threshold = success_threshold
         self.recovery_timeout = recovery_timeout
         self._circuits: Dict[str, ProviderCircuit] = {}
+        self._lock = RLock()
 
     def _get_circuit(self, provider: str) -> ProviderCircuit:
         """Get or create circuit for provider."""
-        if provider not in self._circuits:
-            self._circuits[provider] = ProviderCircuit(
-                name=provider,
-                failure_threshold=self.failure_threshold,
-                success_threshold=self.success_threshold,
-                recovery_timeout=self.recovery_timeout,
-            )
-        return self._circuits[provider]
+        with self._lock:
+            if provider not in self._circuits:
+                self._circuits[provider] = ProviderCircuit(
+                    name=provider,
+                    failure_threshold=self.failure_threshold,
+                    success_threshold=self.success_threshold,
+                    recovery_timeout=self.recovery_timeout,
+                )
+            return self._circuits[provider]
 
     def is_available(self, provider: str) -> bool:
         """Check if provider is available for requests."""
-        circuit = self._get_circuit(provider)
-        now = datetime.now(timezone.utc)
+        with self._lock:
+            circuit = self._get_circuit(provider)
+            now = datetime.now(timezone.utc)
 
-        if circuit.state == CircuitState.CLOSED:
-            return True
+            if circuit.state == CircuitState.CLOSED:
+                return True
 
-        if circuit.state == CircuitState.OPEN:
-            # Check if recovery timeout has passed
-            if circuit.last_failure_time:
-                elapsed = (now - circuit.last_failure_time).total_seconds()
-                if elapsed >= circuit.recovery_timeout:
-                    # Transition to half-open
-                    circuit.state = CircuitState.HALF_OPEN
-                    logger.info(
-                        "circuit_half_open",
-                        provider=provider,
-                        message="Testing recovery",
-                    )
-                    return True
+            if circuit.state == CircuitState.OPEN:
+                # Check if recovery timeout has passed
+                if circuit.last_failure_time:
+                    elapsed = (now - circuit.last_failure_time).total_seconds()
+                    if elapsed >= circuit.recovery_timeout:
+                        # Transition to half-open
+                        circuit.state = CircuitState.HALF_OPEN
+                        logger.info(
+                            "circuit_half_open",
+                            provider=provider,
+                            message="Testing recovery",
+                        )
+                        return True
+                return False
+
+            if circuit.state == CircuitState.HALF_OPEN:
+                return True
+
             return False
 
-        if circuit.state == CircuitState.HALF_OPEN:
-            # Allow one request to test recovery
-            return True
+    def _try_acquire_probe(self, provider: str) -> bool:
+        """Acquire the single half-open probe slot for a provider."""
+        with self._lock:
+            circuit = self._get_circuit(provider)
+            now = datetime.now(timezone.utc)
 
-        return False
+            if circuit.state == CircuitState.CLOSED:
+                return True
+
+            if circuit.state == CircuitState.OPEN:
+                if circuit.last_failure_time is None:
+                    return False
+                elapsed = (now - circuit.last_failure_time).total_seconds()
+                if elapsed < circuit.recovery_timeout:
+                    return False
+                circuit.state = CircuitState.HALF_OPEN
+                circuit.probe_in_flight = True
+                logger.info(
+                    "circuit_half_open",
+                    provider=provider,
+                    message="Testing recovery",
+                )
+                return True
+
+            if circuit.state == CircuitState.HALF_OPEN:
+                if circuit.probe_in_flight:
+                    return False
+                circuit.probe_in_flight = True
+                return True
+
+            return False
 
     def record_success(self, provider: str) -> None:
         """Record successful request to provider."""
-        circuit = self._get_circuit(provider)
-        circuit.success_count += 1
-        circuit.last_success_time = datetime.now(timezone.utc)
+        with self._lock:
+            circuit = self._get_circuit(provider)
+            circuit.success_count += 1
+            circuit.last_success_time = datetime.now(timezone.utc)
 
-        if circuit.state == CircuitState.HALF_OPEN:
-            if circuit.success_count >= circuit.success_threshold:
-                # Recovery confirmed, close circuit
-                circuit.state = CircuitState.CLOSED
+            if circuit.state == CircuitState.HALF_OPEN:
+                if circuit.success_count >= circuit.success_threshold:
+                    # Recovery confirmed, close circuit
+                    circuit.state = CircuitState.CLOSED
+                    circuit.failure_count = 0
+                    circuit.success_count = 0
+                    circuit.probe_in_flight = False
+                    logger.info(
+                        "circuit_closed", provider=provider, message="Provider recovered"
+                    )
+                else:
+                    circuit.probe_in_flight = False
+
+            elif circuit.state == CircuitState.CLOSED:
+                # Reset failure count on success
                 circuit.failure_count = 0
-                circuit.success_count = 0
-                logger.info(
-                    "circuit_closed", provider=provider, message="Provider recovered"
-                )
-
-        elif circuit.state == CircuitState.CLOSED:
-            # Reset failure count on success
-            circuit.failure_count = 0
+                circuit.probe_in_flight = False
 
     def record_failure(self, provider: str, error: Optional[str] = None) -> None:
         """Record failed request to provider."""
-        circuit = self._get_circuit(provider)
-        circuit.failure_count += 1
-        circuit.last_failure_time = datetime.now(timezone.utc)
-        circuit.success_count = 0  # Reset success count
+        with self._lock:
+            circuit = self._get_circuit(provider)
+            circuit.failure_count += 1
+            circuit.last_failure_time = datetime.now(timezone.utc)
+            circuit.success_count = 0  # Reset success count
+            circuit.probe_in_flight = False
 
-        logger.warning(
-            "llm_provider_failure",
-            provider=provider,
-            failure_count=circuit.failure_count,
-            threshold=circuit.failure_threshold,
-            error=error,
-        )
-
-        if circuit.state == CircuitState.HALF_OPEN:
-            # Failed during recovery test, reopen circuit
-            circuit.state = CircuitState.OPEN
             logger.warning(
-                "circuit_reopened", provider=provider, message="Recovery failed"
+                "llm_provider_failure",
+                provider=provider,
+                failure_count=circuit.failure_count,
+                threshold=circuit.failure_threshold,
+                error=error,
             )
 
-        elif circuit.state == CircuitState.CLOSED:
-            if circuit.failure_count >= circuit.failure_threshold:
-                # Too many failures, open circuit
+            if circuit.state == CircuitState.HALF_OPEN:
+                # Failed during recovery test, reopen circuit
                 circuit.state = CircuitState.OPEN
-                logger.error(
-                    "circuit_opened",
-                    provider=provider,
-                    failure_count=circuit.failure_count,
-                    message="Provider marked unavailable",
+                logger.warning(
+                    "circuit_reopened", provider=provider, message="Recovery failed"
                 )
+
+            elif circuit.state == CircuitState.CLOSED:
+                if circuit.failure_count >= circuit.failure_threshold:
+                    # Too many failures, open circuit
+                    circuit.state = CircuitState.OPEN
+                    logger.error(
+                        "circuit_opened",
+                        provider=provider,
+                        failure_count=circuit.failure_count,
+                        message="Provider marked unavailable",
+                    )
 
     @contextmanager
     def protect(self, provider: str) -> Any:
@@ -180,7 +223,7 @@ class LLMCircuitBreaker:
             with breaker.protect("groq"):
                 response = await client.chat(...)
         """
-        if not self.is_available(provider):
+        if not self._try_acquire_probe(provider):
             raise CircuitOpenError(f"Circuit open for {provider}")
 
         try:
@@ -194,31 +237,33 @@ class LLMCircuitBreaker:
 
     def get_status(self) -> Dict[str, dict[str, Any]]:
         """Get status of all circuits for monitoring."""
-        return {
-            name: {
-                "state": circuit.state.value,
-                "failure_count": circuit.failure_count,
-                "success_count": circuit.success_count,
-                "last_failure": circuit.last_failure_time.isoformat()
-                if circuit.last_failure_time
-                else None,
-                "last_success": circuit.last_success_time.isoformat()
-                if circuit.last_success_time
-                else None,
+        with self._lock:
+            return {
+                name: {
+                    "state": circuit.state.value,
+                    "failure_count": circuit.failure_count,
+                    "success_count": circuit.success_count,
+                    "last_failure": circuit.last_failure_time.isoformat()
+                    if circuit.last_failure_time
+                    else None,
+                    "last_success": circuit.last_success_time.isoformat()
+                    if circuit.last_success_time
+                    else None,
+                }
+                for name, circuit in self._circuits.items()
             }
-            for name, circuit in self._circuits.items()
-        }
 
     def reset(self, provider: str) -> None:
         """Manually reset a circuit (for admin use)."""
-        if provider in self._circuits:
-            self._circuits[provider] = ProviderCircuit(
-                name=provider,
-                failure_threshold=self.failure_threshold,
-                success_threshold=self.success_threshold,
-                recovery_timeout=self.recovery_timeout,
-            )
-            logger.info("circuit_reset", provider=provider)
+        with self._lock:
+            if provider in self._circuits:
+                self._circuits[provider] = ProviderCircuit(
+                    name=provider,
+                    failure_threshold=self.failure_threshold,
+                    success_threshold=self.success_threshold,
+                    recovery_timeout=self.recovery_timeout,
+                )
+                logger.info("circuit_reset", provider=provider)
 
 
 class CircuitOpenError(Exception):

--- a/dashboard/src/lib/components/LandingHero.svelte
+++ b/dashboard/src/lib/components/LandingHero.svelte
@@ -15,7 +15,8 @@
 		setLandingCurrencyPreference,
 		type LandingCurrencyCode
 	} from '$lib/landing/currencyPreference';
-	import type { LandingAttribution } from '$lib/landing/landingFunnel';
+	import type { FunnelStage, LandingAttribution } from '$lib/landing/landingFunnel';
+	import type { LandingTelemetryContext } from '$lib/landing/landingTelemetry';
 	import {
 		DEFAULT_EXPERIMENT_ASSIGNMENTS,
 		LANDING_CONSENT_KEY,
@@ -28,7 +29,6 @@
 		buildLandingHeroSignupPath
 	} from '$lib/landing/landingHeroActions';
 	import { buildLandingPublicPath } from '$lib/landing/landingPublicAttribution';
-	import { createLandingHeroTelemetryBridge } from '$lib/landing/landingHeroTelemetryBridge';
 	import {
 		calculateLandingHeroScenarioMetrics,
 		formatLandingHeroCurrencyAmount
@@ -39,8 +39,24 @@
 	} from '$lib/landing/roiCalculator';
 	import { getReducedMotionPreference } from '$lib/landing/reducedMotion';
 	import { nextSnapshotIndex } from '$lib/landing/signalRotation';
-	import { BUYER_ROLE_VIEWS, HERO_ROLE_CONTEXT } from '$lib/landing/heroContent';
+	import { BUYER_ROLE_VIEWS, HERO_ROLE_CONTEXT } from '$lib/landing/heroContent.core';
 	import LandingHeroView from '$lib/components/landing/LandingHeroView.svelte';
+
+	type LandingHeroTelemetryApi = {
+		buildTelemetryContext: (stage?: FunnelStage) => LandingTelemetryContext;
+		emitLandingTelemetrySafe: (
+			name: string,
+			section: string,
+			value?: string,
+			context?: LandingTelemetryContext
+		) => void;
+		markEngaged: () => void;
+		initialize: () => void;
+		setTelemetryConsent: (accepted: boolean) => void;
+		trackCta: (action: string, section: string, value: string) => void;
+		trackScenarioAdjust: (control: string) => void;
+	};
+
 	const DEFAULT_SIGNAL_SNAPSHOT = LANDING_SIGNAL_SNAPSHOTS[0];
 	const ONE_PAGER_HREF = `${base}/resources/valdrics-enterprise-one-pager.md`,
 		RESOURCES_PATH = `${base}/resources`;
@@ -81,6 +97,7 @@
 		cookieBannerVisible = $state(false),
 		localCurrencyCode = $state<LandingCurrencyCode>(resolveDetectedLandingCurrency()),
 		roiCurrencyCode = $state<LandingCurrencyCode>(resolveInitialLandingCurrency());
+	let telemetryApi = $state<LandingHeroTelemetryApi | null>(null);
 	let activeSnapshot = $derived(LANDING_SIGNAL_SNAPSHOTS[snapshotIndex] ?? DEFAULT_SIGNAL_SNAPSHOT);
 	let activeBuyerRole = $derived(BUYER_ROLE_VIEWS[buyerRoleIndex] ?? BUYER_ROLE_VIEWS[0]);
 	let activeSignalLane = $derived(
@@ -160,6 +177,123 @@
 			windowMonths: scenarioWindowMonths
 		})
 	);
+
+	let telemetryBridgePromise: Promise<LandingHeroTelemetryApi> | null = null;
+
+	function buildFallbackTelemetryContext(stage?: FunnelStage): LandingTelemetryContext {
+		return {
+			visitorId,
+			persona: activeBuyerRole.id,
+			referrer: pageReferrer || undefined,
+			pagePath: $page.url.pathname,
+			funnelStage: stage,
+			experiment: {
+				hero: experiments.heroVariant,
+				cta: experiments.ctaVariant,
+				order: experiments.sectionOrderVariant
+			},
+			utm: attribution.utm
+		};
+	}
+
+	function buildTelemetryContext(stage?: FunnelStage): LandingTelemetryContext {
+		return telemetryApi?.buildTelemetryContext(stage) ?? buildFallbackTelemetryContext(stage);
+	}
+
+	function emitLandingTelemetrySafe(
+		name: string,
+		section: string,
+		value?: string,
+		context?: LandingTelemetryContext
+	): void {
+		telemetryApi?.emitLandingTelemetrySafe(name, section, value, context);
+	}
+
+	function initializeTelemetry(): void {
+		telemetryApi?.initialize();
+	}
+
+	function markEngaged(): void {
+		if (telemetryApi) {
+			telemetryApi.markEngaged();
+			return;
+		}
+
+		void ensureTelemetryBridge().then((api) => api.markEngaged());
+	}
+
+	function trackCta(action: string, section: string, value: string): void {
+		if (telemetryApi) {
+			telemetryApi.trackCta(action, section, value);
+			return;
+		}
+
+		void ensureTelemetryBridge().then((api) => api.trackCta(action, section, value));
+	}
+
+	function trackScenarioAdjust(control: string): void {
+		if (telemetryApi) {
+			telemetryApi.trackScenarioAdjust(control);
+			return;
+		}
+
+		void ensureTelemetryBridge().then((api) => api.trackScenarioAdjust(control));
+	}
+
+	function setTelemetryConsent(accepted: boolean): void {
+		telemetryEnabled = accepted;
+		cookieBannerVisible = false;
+
+		if (browser && typeof window !== 'undefined') {
+			window.localStorage.setItem(LANDING_CONSENT_KEY, accepted ? 'accepted' : 'rejected');
+		}
+
+		void ensureTelemetryBridge().then((api) => api.setTelemetryConsent(accepted));
+	}
+
+	async function ensureTelemetryBridge(): Promise<LandingHeroTelemetryApi> {
+		if (telemetryApi) {
+			return telemetryApi;
+		}
+
+		if (!telemetryBridgePromise) {
+			telemetryBridgePromise = import('$lib/landing/landingHeroTelemetryBridge')
+				.then(({ createLandingHeroTelemetryBridge }) => {
+					const nextTelemetryApi = createLandingHeroTelemetryBridge({
+						getTelemetryEnabled: () => telemetryEnabled,
+						setTelemetryEnabled: (value) => (telemetryEnabled = value),
+						getTelemetryInitialized: () => telemetryInitialized,
+						setTelemetryInitialized: (value) => (telemetryInitialized = value),
+						setCookieBannerVisible: (value) => (cookieBannerVisible = value),
+						getEngagedCaptured: () => engagedCaptured,
+						setEngagedCaptured: (value) => (engagedCaptured = value),
+						getScenarioAdjustCaptured: () => scenarioAdjustCaptured,
+						setScenarioAdjustCaptured: (value) => (scenarioAdjustCaptured = value),
+						getVisitorId: () => visitorId,
+						setVisitorId: (value) => (visitorId = value),
+						getExperiments: () => experiments,
+						setExperiments: (value) => (experiments = value),
+						getAttribution: () => attribution,
+						setAttribution: (value) => (attribution = value),
+						getPersona: () => activeBuyerRole.id,
+						getPagePath: () => $page.url.pathname,
+						getReferrer: () => pageReferrer,
+						getStorage: () => (browser ? window.localStorage : undefined),
+						getPageUrl: () => $page.url,
+						consentStorageKey: LANDING_CONSENT_KEY
+					});
+					telemetryApi = nextTelemetryApi;
+					return nextTelemetryApi;
+				})
+				.catch((error) => {
+					telemetryBridgePromise = null;
+					throw error;
+				});
+		}
+
+		return telemetryBridgePromise!;
+	}
+
 	$effect(() => {
 		const defaultBuyerIndex = BUYER_ROLE_VIEWS.findIndex(
 			(role) => role.id === experiments.buyerPersonaDefault
@@ -179,8 +313,9 @@
 		let cancelled = false;
 		let teardown: (() => void) | void;
 
-		void import('$lib/landing/landingHeroBrowserRuntime').then(
-			({ mountLandingHeroBrowserRuntime }) => {
+		void ensureTelemetryBridge()
+			.then(() => import('$lib/landing/landingHeroBrowserRuntime'))
+			.then(({ mountLandingHeroBrowserRuntime }) => {
 				if (cancelled) return;
 				teardown = mountLandingHeroBrowserRuntime({
 					browserEnabled: browser,
@@ -189,7 +324,7 @@
 					signalMapElement,
 					consentStorageKey: LANDING_CONSENT_KEY,
 					scrollMilestones: LANDING_SCROLL_MILESTONES,
-					initializeTelemetry: initialize,
+					initializeTelemetry,
 					markEngaged,
 					buildTelemetryContext,
 					emitLandingTelemetrySafe,
@@ -201,46 +336,16 @@
 					setSignalMapInView: (value) => (signalMapInView = value),
 					setLandingScrollProgressPct: (value) => (landingScrollProgressPct = value)
 				});
-			}
-		);
+			})
+			.catch(() => {
+				// Telemetry/runtime failures must not block landing rendering.
+			});
 
 		return () => {
 			cancelled = true;
 			teardown?.();
 		};
 	});
-	const telemetry = createLandingHeroTelemetryBridge({
-		getTelemetryEnabled: () => telemetryEnabled,
-		setTelemetryEnabled: (value) => (telemetryEnabled = value),
-		getTelemetryInitialized: () => telemetryInitialized,
-		setTelemetryInitialized: (value) => (telemetryInitialized = value),
-		setCookieBannerVisible: (value) => (cookieBannerVisible = value),
-		getEngagedCaptured: () => engagedCaptured,
-		setEngagedCaptured: (value) => (engagedCaptured = value),
-		getScenarioAdjustCaptured: () => scenarioAdjustCaptured,
-		setScenarioAdjustCaptured: (value) => (scenarioAdjustCaptured = value),
-		getVisitorId: () => visitorId,
-		setVisitorId: (value) => (visitorId = value),
-		getExperiments: () => experiments,
-		setExperiments: (value) => (experiments = value),
-		getAttribution: () => attribution,
-		setAttribution: (value) => (attribution = value),
-		getPersona: () => activeBuyerRole.id,
-		getPagePath: () => $page.url.pathname,
-		getReferrer: () => pageReferrer,
-		getStorage: () => (browser ? window.localStorage : undefined),
-		getPageUrl: () => $page.url,
-		consentStorageKey: LANDING_CONSENT_KEY
-	});
-	const {
-		buildTelemetryContext,
-		emitLandingTelemetrySafe,
-		markEngaged,
-		initialize,
-		setTelemetryConsent,
-		trackCta,
-		trackScenarioAdjust
-	} = telemetry;
 	const closeCookieBanner = () => (cookieBannerVisible = false),
 		openCookieSettings = () => (cookieBannerVisible = true);
 	function buildSignupHref(intent: string, extraParams: Record<string, string> = {}): string {

--- a/dashboard/src/lib/components/landing/LandingHeroCopy.svelte
+++ b/dashboard/src/lib/components/landing/LandingHeroCopy.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { ABOVE_FOLD_TRUST_RAIL } from '$lib/landing/heroContent';
+	import { ABOVE_FOLD_TRUST_RAIL } from '$lib/landing/heroContent.core';
 	import './LandingMarketingShared.css';
 
 	const heroTrustRail = ABOVE_FOLD_TRUST_RAIL.slice(0, 3);

--- a/dashboard/src/lib/components/landing/LandingHeroView.svelte
+++ b/dashboard/src/lib/components/landing/LandingHeroView.svelte
@@ -26,6 +26,13 @@
 		() => import('$lib/components/landing/LandingExitIntentPrompt.svelte')
 	);
 
+	const publicLaneTitles: Record<SignalLaneId, string> = {
+		economic_visibility: 'Signal captured',
+		deterministic_enforcement: 'Checks applied',
+		financial_governance: 'Approval routed',
+		operational_resilience: 'Outcome recorded'
+	};
+
 	const productPillars = [
 		{
 			title: 'See the issue with context',
@@ -43,13 +50,6 @@
 				'Every material action keeps the decision trail and savings story ready for finance, security, or procurement review.'
 		}
 	] as const;
-
-	const publicLaneTitles: Record<SignalLaneId, string> = {
-		economic_visibility: 'Signal captured',
-		deterministic_enforcement: 'Checks applied',
-		financial_governance: 'Approval routed',
-		operational_resilience: 'Outcome recorded'
-	};
 
 	const landingPlanPreview = [
 		{
@@ -440,7 +440,7 @@
 			<div class="landing-public-band landing-public-band--compact">
 				<div>
 					<p class="landing-public-eyebrow">Full pricing</p>
-					<h3>Prices shown in USD.</h3>
+					<h3>Compare the full plan details before you commit</h3>
 					<p>
 						Use the pricing page for full plan details. Contact enterprise for security,
 						procurement, or deployment requirements.

--- a/dashboard/src/lib/components/landing/LandingPersonaSection.svelte
+++ b/dashboard/src/lib/components/landing/LandingPersonaSection.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { BUYER_ROLE_VIEWS } from '$lib/landing/heroContent';
+	import { BUYER_ROLE_VIEWS } from '$lib/landing/heroContent.core';
 
 	type BuyerRoleView = {
 		id: string;

--- a/dashboard/src/lib/components/landing/LandingPlansSection.svelte
+++ b/dashboard/src/lib/components/landing/LandingPlansSection.svelte
@@ -1,151 +1,103 @@
 <script lang="ts">
 	import { base } from '$app/paths';
-	import {
-		FREE_TIER_HIGHLIGHTS,
-		FREE_TIER_LIMIT_NOTE,
-		IMPLEMENTATION_COST_FACTS,
-		PLAN_COMPARE_CARDS,
-		PLANS_PRICING_EXPLANATION
-	} from '$lib/landing/heroContent';
-	import { DEFAULT_PRICING_PLANS } from '$lib/pricing/publicPlans';
+
+	const landingPlanPreview = [
+		{
+			name: 'Free',
+			price: '$0',
+			summary: 'Prove one owner-routed workflow without procurement overhead.',
+			cta: 'Start Free Workspace',
+			href: null
+		},
+		{
+			name: 'Growth',
+			price: '$149',
+			summary:
+				'Best fit for cross-functional teams that need shared cost ownership and collaboration.',
+			cta: 'See Growth on Pricing',
+			href: `${base}/pricing`
+		},
+		{
+			name: 'Pro',
+			price: '$299',
+			summary:
+				'Finance-grade controls, exports, and workflow depth without jumping straight into enterprise sales.',
+			cta: 'Review Pro Details',
+			href: `${base}/pricing`
+		}
+	] as const;
 
 	let {
-		buildFreeTierCtaHref,
-		buildPlanCtaHref,
+		freeTierCtaHref,
+		trustEnterpriseHref,
 		onTrackCta
 	}: {
-		buildFreeTierCtaHref: () => string;
-		buildPlanCtaHref: (planId: string) => string;
+		freeTierCtaHref: string;
+		trustEnterpriseHref: string;
 		onTrackCta: (action: string, section: string, value: string) => void;
 	} = $props();
-
-	const freePlan = DEFAULT_PRICING_PLANS.find((plan) => plan.id === 'free');
-
-	if (!freePlan?.story) {
-		throw new Error('Landing plans section requires a free-plan public story.');
-	}
-
-	const freePlanStory = freePlan.story;
-	const enterprisePathHref = `${base}/enterprise`;
 </script>
 
-<section
-	id="plans"
-	class="container mx-auto px-6 pb-16 landing-section-lazy"
-	data-landing-section="plans"
->
-	<div class="landing-section-head">
-		<h2 class="landing-h2">Choose the plan that fits your control depth</h2>
-		<p class="landing-section-sub">{PLANS_PRICING_EXPLANATION}</p>
-	</div>
-
-	<div class="landing-plan-choices">
-		<div class="landing-plans-grid">
-			{#each PLAN_COMPARE_CARDS as plan (plan.id)}
-				<article
-					class={`glass-panel landing-plan-card ${plan.popular ? 'is-featured' : ''}`}
-					data-plan-id={plan.id}
-				>
-					<p class="landing-proof-k">{plan.badge}</p>
-					<h3 class="landing-h3">{plan.name}</h3>
-					<p class="landing-plan-price">{plan.price}</p>
-					<p class="landing-plan-price-note">{plan.priceNote}</p>
-					<p class="landing-p">{plan.summary}</p>
-					<ul class="landing-plan-features">
-						{#each plan.features.slice(0, 3) as feature (feature)}
-							<li>{feature}</li>
-						{/each}
-					</ul>
-					<div class="landing-plan-context" aria-label={`${plan.name} plan fit`}>
-						<dl class="landing-plan-context__row landing-plan-context__row--stacked">
-							<dt class="landing-plan-context__label">Best for</dt>
-							<dd class="landing-plan-context__value">{plan.bestFor}</dd>
-						</dl>
-					</div>
-					<a
-						href={buildPlanCtaHref(plan.id)}
-						class={`btn ${plan.popular ? 'btn-primary landing-plan-primary-cta' : 'btn-secondary landing-plan-secondary-cta'}`}
-						onclick={() => onTrackCta('cta_click', 'plans', `start_plan_${plan.id}`)}
-					>
-						{`Start with ${plan.name}`}
-					</a>
+<section id="plans" class="landing-public-section" data-landing-section="plans">
+	<div class="container mx-auto px-6 py-12">
+		<div class="landing-public-section-head">
+			<p class="landing-public-eyebrow">Pricing</p>
+			<h2>Pricing that matches rollout stage</h2>
+			<p>
+				Start small, prove the workflow, and only move up when the team needs more governance depth.
+			</p>
+		</div>
+		<div class="landing-public-plan-grid">
+			{#each landingPlanPreview as plan (plan.name)}
+				<article class="landing-public-surface landing-public-plan-card">
+					<p class="landing-public-proof-label">{plan.name}</p>
+					<div class="landing-public-plan-price">{plan.price}</div>
+					<p>{plan.summary}</p>
+					{#if plan.href}
+						<a
+							href={plan.href}
+							class="btn btn-secondary"
+							onclick={() => onTrackCta('cta_click', 'plans', plan.name.toLowerCase())}
+						>
+							{plan.cta}
+						</a>
+					{:else}
+						<a
+							href={freeTierCtaHref}
+							class="btn btn-primary"
+							onclick={() => onTrackCta('cta_click', 'plans', 'free')}
+						>
+							{plan.cta}
+						</a>
+					{/if}
 				</article>
 			{/each}
 		</div>
-
-		<div class="landing-free-tier-strip glass-panel">
-			<div class="landing-free-tier-strip-copy">
-				<p class="landing-free-tier-badge">{freePlanStory.badge}</p>
-				<div>
-					<p class="landing-proof-k">Free workspace strip</p>
-					<h3 class="landing-h3">{freePlanStory.headline}</h3>
-					<p class="landing-p">{FREE_TIER_LIMIT_NOTE}</p>
-				</div>
+		<div class="landing-public-band landing-public-band--compact">
+			<div>
+				<p class="landing-public-eyebrow">Full pricing</p>
+				<h3>Compare the full plan details before you commit</h3>
+				<p>
+					Use the pricing page for the full plan breakdown. Use enterprise review only when
+					security, procurement, or deployment requirements need a separate path.
+				</p>
 			</div>
-			<ul class="landing-plan-features">
-				{#each FREE_TIER_HIGHLIGHTS.slice(0, 3) as feature (feature)}
-					<li>{feature}</li>
-				{/each}
-			</ul>
-			<div class="landing-free-tier-strip-actions">
-				<p class="landing-free-tier-strip-price">$0 / month</p>
-				<p class="landing-free-tier-note">Published list prices shown in USD.</p>
+			<div class="landing-public-band-actions">
 				<a
-					href={buildFreeTierCtaHref()}
-					class="btn btn-secondary landing-free-tier-primary-cta"
-					onclick={() => onTrackCta('cta_click', 'plans', 'start_plan_free')}
+					href={`${base}/pricing`}
+					class="btn btn-secondary"
+					onclick={() => onTrackCta('cta_click', 'plans', 'view_pricing')}
 				>
-					Start on Free Tier
+					See Detailed Pricing
+				</a>
+				<a
+					href={trustEnterpriseHref}
+					class="btn btn-secondary"
+					onclick={() => onTrackCta('cta_click', 'plans', 'enterprise_review')}
+				>
+					Enterprise Review
 				</a>
 			</div>
 		</div>
 	</div>
-
-	<section class="landing-rollout-section glass-panel" aria-labelledby="rollout-tco-title">
-		<p class="landing-proof-k">Rollout and buying path</p>
-		<h3 id="rollout-tco-title" class="landing-h3">
-			Know the team footprint before signup or procurement
-		</h3>
-		<p class="landing-p">
-			Start with one controlled workflow in a workspace. Use enterprise review only when audit,
-			procurement, or rollout governance needs a separate process.
-		</p>
-
-		<div class="landing-rollout-grid">
-			<article class="landing-rollout-block">
-				<p class="landing-proof-k">Setup path</p>
-				<ol class="landing-onboard-steps">
-					<li>Connect cloud and software sources.</li>
-					<li>Assign owners and approval responsibilities.</li>
-					<li>Run your first owner-led remediation cycle.</li>
-				</ol>
-			</article>
-
-			<article class="landing-rollout-block">
-				<p class="landing-proof-k">Implementation facts</p>
-				<ul class="landing-plan-features">
-					{#each IMPLEMENTATION_COST_FACTS.slice(0, 3) as detail (detail)}
-						<li>{detail}</li>
-					{/each}
-				</ul>
-			</article>
-		</div>
-
-		<div class="landing-rollout-actions">
-			<a
-				href={`${base}/pricing`}
-				class="landing-cta-link"
-				onclick={() => onTrackCta('cta_click', 'plans', 'view_full_pricing')}
-			>
-				View full pricing
-			</a>
-			<a
-				href={enterprisePathHref}
-				class="btn btn-secondary"
-				onclick={() => onTrackCta('cta_click', 'plans', 'enterprise_review')}
-			>
-				Enterprise Review
-			</a>
-		</div>
-	</section>
 </section>

--- a/dashboard/src/lib/components/landing/LandingProductSection.svelte
+++ b/dashboard/src/lib/components/landing/LandingProductSection.svelte
@@ -1,82 +1,74 @@
 <script lang="ts">
-	import { BACKEND_CAPABILITY_PILLARS, DECISION_LEDGER_SUMMARY } from '$lib/landing/heroContent';
-	import type {
-		SignalLaneId,
-		SignalLaneSnapshot,
-		SignalSnapshot
-	} from '$lib/landing/realtimeSignalMap';
-	import LandingSignalMapCard from '$lib/components/landing/LandingSignalMapCard.svelte';
+	const productPillars = [
+		{
+			title: 'See the issue with context',
+			detail:
+				'Cost, owner, approval, and policy context stay on one record instead of being rebuilt across dashboards and threads.'
+		},
+		{
+			title: 'Route it to the right person',
+			detail:
+				'Engineering and finance move from the same operating record instead of chasing ownership in chat.'
+		},
+		{
+			title: 'Finish with proof',
+			detail:
+				'Every material action keeps the decision trail and savings story ready for finance, security, or procurement review.'
+		}
+	] as const;
 
 	let {
-		activeSnapshot,
-		activeSignalLane,
-		signalMapInView,
-		snapshotIndex,
-		demoStepIndex,
-		onSelectSignalLane,
-		onSelectDemoStep,
-		onSelectSnapshot,
-		onSignalMapElementChange
+		currentStageLabel,
+		actionLabel,
+		sourceCount
 	}: {
-		activeSnapshot: SignalSnapshot;
-		activeSignalLane: SignalLaneSnapshot;
-		signalMapInView: boolean;
-		snapshotIndex: number;
-		demoStepIndex: number;
-		onSelectSignalLane: (laneId: SignalLaneId) => void;
-		onSelectDemoStep: (index: number) => void;
-		onSelectSnapshot: (index: number) => void;
-		onSignalMapElementChange: (element: HTMLDivElement | null) => void;
+		currentStageLabel: string;
+		actionLabel: string;
+		sourceCount: number;
 	} = $props();
-
-	const productPillars = BACKEND_CAPABILITY_PILLARS.slice(0, 4);
-	const summaryMetrics = DECISION_LEDGER_SUMMARY;
 </script>
 
-<section
-	id="product"
-	class="container mx-auto px-6 pb-16 landing-section-lazy"
-	data-landing-section="product"
->
-	<div class="landing-section-head">
-		<h2 class="landing-h2">A governed operating layer after detection</h2>
-		<p class="landing-section-sub">
-			This is where Valdrics differentiates: the signal keeps its owner, checks, approvals,
-			workflow, and proof all the way through execution.
-		</p>
-	</div>
-
-	<div class="landing-product-grid">
-		<div class="landing-product-primary">
-			<div class="landing-product-summary glass-panel" aria-label="Operating loop summary">
-				{#each summaryMetrics as item (item.label)}
-					<div class="landing-product-summary-item">
-						<p>{item.label}</p>
-						<strong>{item.value}</strong>
-					</div>
-				{/each}
-			</div>
-			<LandingSignalMapCard
-				{activeSnapshot}
-				{activeSignalLane}
-				{signalMapInView}
-				{snapshotIndex}
-				{demoStepIndex}
-				{onSelectSignalLane}
-				{onSelectDemoStep}
-				{onSelectSnapshot}
-				{onSignalMapElementChange}
-			/>
+<section id="product" class="landing-public-section" data-landing-section="product">
+	<div class="container mx-auto px-6 py-12">
+		<div class="landing-public-section-head">
+			<p class="landing-public-eyebrow">Why it feels calmer</p>
+			<h2>Replace reactive cleanup with one operating path</h2>
+			<p>
+				Most teams already know where the waste is. The hard part is ownership, approval, and proof.
+				Valdrics keeps that work in one place.
+			</p>
 		</div>
-
-		<div class="landing-product-support">
+		<div class="landing-public-pillar-grid">
 			{#each productPillars as pillar (pillar.title)}
-				<article class="glass-panel landing-product-support-card">
-					<p class="landing-proof-k">Capability</p>
-					<h3 class="landing-h3">{pillar.title}</h3>
-					<p class="landing-p">{pillar.detail}</p>
+				<article class="landing-public-surface landing-public-pillar-card">
+					<h3>{pillar.title}</h3>
+					<p>{pillar.detail}</p>
 				</article>
 			{/each}
+		</div>
+		<div class="landing-public-band">
+			<div>
+				<p class="landing-public-eyebrow">What changes in practice</p>
+				<h3>One record carries the issue from alert to decision</h3>
+				<p>
+					Finance, engineering, and leadership review the same story instead of rebuilding context
+					from dashboards, tickets, and chat threads.
+				</p>
+			</div>
+			<div class="landing-public-impact-grid">
+				<div>
+					<span>Current stage</span>
+					<strong>{currentStageLabel}</strong>
+				</div>
+				<div>
+					<span>Action path</span>
+					<strong>{actionLabel}</strong>
+				</div>
+				<div>
+					<span>Linked sources</span>
+					<strong>{sourceCount} attached inputs</strong>
+				</div>
+			</div>
 		</div>
 	</div>
 </section>

--- a/dashboard/src/lib/components/landing/LandingTrustSection.svelte
+++ b/dashboard/src/lib/components/landing/LandingTrustSection.svelte
@@ -1,190 +1,87 @@
 <script lang="ts">
-	import { base } from '$app/paths';
-	import {
-		COMPLIANCE_FOUNDATION_BADGES,
-		EXECUTIVE_CONFIDENCE_POINTS
-	} from '$lib/landing/heroContent';
-
 	let {
-		onTrackCta,
-		enterprisePathHref,
-		aboutHref,
-		docsHref,
-		statusHref,
-		proofHref = '/proof',
-		requestValidationBriefingHref,
+		proofHref,
 		onePagerHref,
-		globalComplianceWorkbookHref = `${base}/resources/global-finops-compliance-workbook.md`
+		docsHref,
+		aboutHref,
+		statusHref,
+		trustEnterpriseHref,
+		requestValidationBriefingHref,
+		onTrackCta
 	}: {
-		onTrackCta: (
-			value:
-				| 'about_review'
-				| 'docs_review'
-				| 'status_review'
-				| 'proof_review'
-				| 'enterprise_review'
-				| 'request_validation_briefing'
-				| 'download_executive_one_pager'
-				| 'download_global_compliance_workbook'
-				| 'deployment_residency_review'
-		) => void;
-		enterprisePathHref: string;
-		aboutHref: string;
-		docsHref: string;
-		statusHref: string;
-		proofHref?: string;
-		requestValidationBriefingHref: string;
+		proofHref: string;
 		onePagerHref: string;
-		globalComplianceWorkbookHref?: string;
+		docsHref: string;
+		aboutHref: string;
+		statusHref: string;
+		trustEnterpriseHref: string;
+		requestValidationBriefingHref: string;
+		onTrackCta: (action: string, section: string, value: string) => void;
 	} = $props();
-
-	const deploymentResidencyHref = `${base}/proof/deployment-and-data-residency`;
-	const executiveConfidence = EXECUTIVE_CONFIDENCE_POINTS.slice(0, 3);
 </script>
 
-<section
-	id="trust"
-	class="container mx-auto px-6 pb-16 landing-section-lazy"
-	data-landing-section="proof"
->
-	<div class="landing-section-head">
-		<h2 class="landing-h2">Proof, review surfaces, and rollout clarity</h2>
-		<p class="landing-section-sub">
-			Public proof should reduce uncertainty without inventing customer evidence. Valdrics exposes
-			clear materials for security, rollout, procurement, and executive review.
-		</p>
-	</div>
-
-	<div class="landing-proof-state-grid">
-		<article class="glass-panel landing-proof-state-card">
-			<p class="landing-proof-k">Proof pack</p>
-			<h3 class="landing-h3">Start with materials you can inspect without a sales call</h3>
-			<p class="landing-p">
-				Review access posture, approval controls, decision-history integrity, and the current
-				validation scope before broader diligence starts.
-			</p>
-			<div class="landing-proof-state-links">
-				<a href={proofHref} class="landing-cta-link" onclick={() => onTrackCta('proof_review')}>
-					Open Proof Pack
-				</a>
-				<a
-					href={onePagerHref}
-					class="landing-cta-link"
-					onclick={() => onTrackCta('download_executive_one_pager')}
-				>
-					Download Executive One-Pager
-				</a>
-			</div>
-		</article>
-
-		<article class="glass-panel landing-proof-state-card">
-			<p class="landing-proof-k">Security and access review</p>
-			<h3 class="landing-h3">Review how control, access, and evidence fit together</h3>
-			<p class="landing-p">
-				The public docs and proof pages explain the first diligence lane without pretending a
-				generic marketing claim replaces environment-specific review.
-			</p>
-			<div class="landing-proof-state-links">
-				<a href={docsHref} class="landing-cta-link" onclick={() => onTrackCta('docs_review')}>
-					Open Docs
-				</a>
-				<a
-					href={globalComplianceWorkbookHref}
-					class="landing-cta-link"
-					onclick={() => onTrackCta('download_global_compliance_workbook')}
-				>
-					Control and Access Checklist
-				</a>
-			</div>
-		</article>
-
-		<article class="glass-panel landing-proof-state-card">
-			<p class="landing-proof-k">Deployment and data residency review</p>
-			<h3 class="landing-h3">Answer region and residency questions factually</h3>
-			<p class="landing-p">
-				Use the deployment-residency review note when buyers ask where public materials stop and
-				enterprise evaluation begins.
-			</p>
-			<div class="landing-proof-state-links">
-				<a
-					href={deploymentResidencyHref}
-					class="landing-cta-link"
-					onclick={() => onTrackCta('deployment_residency_review')}
-				>
-					Open Deployment Review
-				</a>
-				<a href={statusHref} class="landing-cta-link" onclick={() => onTrackCta('status_review')}>
-					View Status
-				</a>
-			</div>
-		</article>
-
-		<article class="glass-panel landing-proof-state-card">
-			<p class="landing-proof-k">Enterprise validation lane</p>
-			<h3 class="landing-h3">Use the formal path only when diligence actually needs it</h3>
-			<p class="landing-p">
-				Self-serve teams can start in the workspace. Procurement, architecture review, and security
-				review can move into enterprise review without restarting the conversation.
-			</p>
-			<div class="landing-lead-actions">
-				<a
-					href={enterprisePathHref}
-					class="btn btn-primary w-fit pulse-glow"
-					onclick={() => onTrackCta('enterprise_review')}
-				>
-					Enterprise Review
-				</a>
-				<a
-					href={requestValidationBriefingHref}
-					class="btn btn-secondary w-fit"
-					onclick={() => onTrackCta('request_validation_briefing')}
-				>
-					Book Validation Briefing
-				</a>
-			</div>
-		</article>
-	</div>
-
-	<div class="landing-evidence-grid">
-		{#each executiveConfidence as point (point.title)}
-			<article class="glass-panel landing-evidence-card">
-				<p class="landing-proof-k">{point.kicker}</p>
-				<h3 class="landing-h3">{point.title}</h3>
-				<p class="landing-p">{point.detail}</p>
+<section id="trust" class="landing-public-section" data-landing-section="trust">
+	<div class="container mx-auto px-6 py-12">
+		<div class="landing-public-section-head">
+			<p class="landing-public-eyebrow">Trust</p>
+			<h2>Review the company before you talk to us</h2>
+			<p>Review the company, proof pack, and technical materials before you book a call.</p>
+		</div>
+		<div class="landing-public-trust-grid">
+			<article class="landing-public-surface landing-public-trust-card">
+				<p class="landing-public-proof-label">Proof pack</p>
+				<h3>Start with the materials, not the pitch</h3>
+				<p>Open the proof pack, one-pager, and technical validation notes directly.</p>
+				<div class="landing-public-link-list">
+					<a href={proofHref} onclick={() => onTrackCta('cta_click', 'trust', 'proof_pack')}>
+						Open Proof Pack
+					</a>
+					<a href={onePagerHref} onclick={() => onTrackCta('cta_click', 'trust', 'one_pager')}>
+						Download One-Pager
+					</a>
+					<a href={docsHref} onclick={() => onTrackCta('cta_click', 'trust', 'docs')}>
+						Technical Validation
+					</a>
+				</div>
 			</article>
-		{/each}
-	</div>
-
-	<div class="landing-proof-footnote glass-panel">
-		<div>
-			<p class="landing-proof-k">Company and review surface</p>
-			<h3 class="landing-h3">Verify the company and review materials directly</h3>
-			<p class="landing-p">
-				Valdrics does not publish customer logos or case studies yet. Public trust comes from
-				transparent pricing, docs, proof materials, status visibility, and direct company review.
-			</p>
-		</div>
-		<div class="landing-proof-state-links">
-			<a href={aboutHref} class="landing-cta-link" onclick={() => onTrackCta('about_review')}>
-				About / Team
-			</a>
-			<a href={docsHref} class="landing-cta-link" onclick={() => onTrackCta('docs_review')}>
-				Open Docs
-			</a>
-			<a href={statusHref} class="landing-cta-link" onclick={() => onTrackCta('status_review')}>
-				View Status
-			</a>
-		</div>
-	</div>
-
-	<div class="landing-compliance-block">
-		<p class="landing-proof-k">Control foundations</p>
-		<div class="landing-trust-badges">
-			{#each COMPLIANCE_FOUNDATION_BADGES as badge (badge)}
-				<span class="landing-trust-badge {badge.includes('Decision history') ? 'is-featured' : ''}">
-					{badge}
-				</span>
-			{/each}
+			<article class="landing-public-surface landing-public-trust-card">
+				<p class="landing-public-proof-label">Company</p>
+				<h3>Know who is behind the product</h3>
+				<p>
+					Review the founder, company background, and public contact channels before procurement
+					starts.
+				</p>
+				<div class="landing-public-link-list">
+					<a href={aboutHref} onclick={() => onTrackCta('cta_click', 'trust', 'about')}>
+						About / Team
+					</a>
+					<a href={statusHref} onclick={() => onTrackCta('cta_click', 'trust', 'status')}>
+						Status Page
+					</a>
+				</div>
+			</article>
+			<article class="landing-public-surface landing-public-trust-card">
+				<p class="landing-public-proof-label">Enterprise review</p>
+				<h3>Use enterprise review when it is needed</h3>
+				<p>
+					Security, privacy, residency, and procurement questions can be handled separately without
+					slowing down a basic evaluation.
+				</p>
+				<div class="landing-public-link-list">
+					<a
+						href={trustEnterpriseHref}
+						onclick={() => onTrackCta('cta_click', 'trust', 'enterprise')}
+					>
+						Enterprise Review
+					</a>
+					<a
+						href={requestValidationBriefingHref}
+						onclick={() => onTrackCta('cta_click', 'trust', 'validation_briefing')}
+					>
+						Request Validation Briefing
+					</a>
+				</div>
+			</article>
 		</div>
 	</div>
 </section>

--- a/dashboard/src/routes/dashboard/EngineeringDashboardSection.svelte
+++ b/dashboard/src/routes/dashboard/EngineeringDashboardSection.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-	import FindingsTable from '$lib/components/FindingsTable.svelte';
+	import { onMount } from 'svelte';
+	import { createLazyComponent } from '$lib/lazyComponent';
 	import SavingsHero from '$lib/components/SavingsHero.svelte';
-	import ZombieTable from '$lib/components/ZombieTable.svelte';
 	import type { ZombieCollections } from '$lib/zombieCollections';
 
 	type DashboardFinding = {
@@ -53,39 +53,76 @@
 		recommended_instance_type?: string;
 	};
 
+	type FindingsTableProps = {
+		resources: Array<{
+			provider: 'aws' | 'azure' | 'gcp';
+			finding_id?: string;
+			resource_id: string;
+			resource_type?: string;
+			monthly_cost?: string | number;
+			confidence?: 'high' | 'medium' | 'low';
+			risk_if_deleted?: 'high' | 'medium' | 'low';
+			explanation: string;
+			confidence_reason?: string;
+			recommended_action?: string;
+			connection_id?: string;
+			owner?: string;
+			is_gpu?: boolean;
+		}>;
+		onRemediate: (finding: RemediationFinding) => void;
+	};
+
+	type ZombieTableProps = {
+		zombies: ZombieCollections<RemediationFinding> | null | undefined;
+		zombieCount: number;
+		onRemediate: (finding: RemediationFinding) => void;
+	};
+
+	const loadFindingsTable = createLazyComponent<FindingsTableProps>(
+		() => import('$lib/components/FindingsTable.svelte')
+	);
+	const loadZombieTable = createLazyComponent<ZombieTableProps>(
+		() => import('$lib/components/ZombieTable.svelte')
+	);
+
 	let { zombies, analysisText, zombieCount, onRemediate } = $props<{
 		zombies: DashboardZombieCollections | null | undefined;
 		analysisText: string;
 		zombieCount: number;
 		onRemediate: (finding: RemediationFinding) => void;
 	}>();
+
+	let heavyTablesAnchor: HTMLDivElement | null = $state(null);
+	let heavyTablesVisible = $state(false);
+
+	onMount(() => {
+		if (import.meta.env.MODE === 'test' || typeof IntersectionObserver === 'undefined') {
+			heavyTablesVisible = true;
+			return;
+		}
+
+		const observer = new IntersectionObserver(
+			(entries) => {
+				if (entries.some((entry) => entry.isIntersecting)) {
+					heavyTablesVisible = true;
+					observer.disconnect();
+				}
+			},
+			{ rootMargin: '220px 0px' }
+		);
+
+		if (heavyTablesAnchor) {
+			observer.observe(heavyTablesAnchor);
+		}
+
+		return () => observer.disconnect();
+	});
 </script>
 
 {#if zombies?.ai_analysis}
 	{@const aiData = zombies.ai_analysis as SavingsHeroData}
 
 	<SavingsHero {aiData} />
-
-	{#if aiData.resources && aiData.resources.length > 0}
-		<FindingsTable
-			resources={aiData.resources as Array<{
-				provider: 'aws' | 'azure' | 'gcp';
-				finding_id?: string;
-				resource_id: string;
-				resource_type?: string;
-				monthly_cost?: string | number;
-				confidence?: 'high' | 'medium' | 'low';
-				risk_if_deleted?: 'high' | 'medium' | 'low';
-				explanation: string;
-				confidence_reason?: string;
-				recommended_action?: string;
-				connection_id?: string;
-				owner?: string;
-				is_gpu?: boolean;
-			}>}
-			{onRemediate}
-		/>
-	{/if}
 
 	{#if aiData.general_recommendations && aiData.general_recommendations.length > 0}
 		<div class="card stagger-enter engineering-dashboard__recommendations">
@@ -110,12 +147,49 @@
 	</div>
 {/if}
 
-{#if zombieCount > 0}
-	<ZombieTable
-		zombies={zombies as ZombieCollections<RemediationFinding> | null | undefined}
-		{zombieCount}
-		{onRemediate}
-	/>
+{#if (zombies?.ai_analysis && (zombies.ai_analysis as SavingsHeroData).resources?.length) || zombieCount > 0}
+	<div bind:this={heavyTablesAnchor}>
+		{#if heavyTablesVisible}
+			{#if zombies?.ai_analysis}
+				{@const aiData = zombies.ai_analysis as SavingsHeroData}
+				{#if aiData.resources && aiData.resources.length > 0}
+					{#await loadFindingsTable()}
+						<div class="card stagger-enter engineering-dashboard__table-skeleton">
+							<div class="skeleton h-8 w-48 mb-4"></div>
+							<div class="skeleton h-64 rounded-2xl"></div>
+						</div>
+					{:then module}
+						{@const FindingsTable = module.default}
+						<FindingsTable
+							resources={aiData.resources as FindingsTableProps['resources']}
+							{onRemediate}
+						/>
+					{/await}
+				{/if}
+			{/if}
+
+			{#if zombieCount > 0}
+				{#await loadZombieTable()}
+					<div class="card stagger-enter engineering-dashboard__table-skeleton">
+						<div class="skeleton h-8 w-48 mb-4"></div>
+						<div class="skeleton h-64 rounded-2xl"></div>
+					</div>
+				{:then module}
+					{@const ZombieTable = module.default}
+					<ZombieTable
+						zombies={zombies as ZombieCollections<RemediationFinding> | null | undefined}
+						{zombieCount}
+						{onRemediate}
+					/>
+				{/await}
+			{/if}
+		{:else}
+			<div class="card stagger-enter engineering-dashboard__table-skeleton">
+				<div class="skeleton h-8 w-48 mb-4"></div>
+				<div class="skeleton h-64 rounded-2xl"></div>
+			</div>
+		{/if}
+	</div>
 {/if}
 
 <style>
@@ -166,5 +240,9 @@
 		font-size: var(--text-sm);
 		line-height: 1.7;
 		color: var(--color-ink-300);
+	}
+
+	.engineering-dashboard__table-skeleton {
+		animation-delay: 520ms;
 	}
 </style>

--- a/dashboard/src/routes/dashboard/FinanceDashboardSection.svelte
+++ b/dashboard/src/routes/dashboard/FinanceDashboardSection.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
-	import AllocationBreakdown from '$lib/components/AllocationBreakdown.svelte';
-	import CloudDistributionMatrix from '$lib/components/CloudDistributionMatrix.svelte';
+	import { onMount } from 'svelte';
+	import { createLazyComponent } from '$lib/lazyComponent';
 	import GreenOpsWidget from '$lib/components/GreenOpsWidget.svelte';
-	import ROAChart from '$lib/components/ROAChart.svelte';
 	import UnitEconomicsCards from '$lib/components/UnitEconomicsCards.svelte';
 	import UpgradeNotice from '$lib/components/UpgradeNotice.svelte';
 	import { tierAtLeast } from '$lib/tier';
@@ -16,33 +15,197 @@
 		buckets?: AllocationBucket[];
 	};
 
+	type CloudDistributionMatrixProps = {
+		data?: Array<{
+			label: string;
+			value: number;
+			color: string;
+		}>;
+	};
+
+	type AllocationBreakdownProps = {
+		data: {
+			buckets: Array<{
+				name: string;
+				total_amount: number;
+				record_count: number;
+				color?: string;
+			}>;
+			total: number;
+		} | null;
+		loading?: boolean;
+		error?: string | null;
+	};
+
+	const loadCloudDistributionMatrix = createLazyComponent<CloudDistributionMatrixProps>(
+		() => import('$lib/components/CloudDistributionMatrix.svelte')
+	);
+	const loadRoaChart = createLazyComponent<Record<string, never>>(
+		() => import('$lib/components/ROAChart.svelte')
+	);
+	const loadAllocationBreakdown = createLazyComponent<AllocationBreakdownProps>(
+		() => import('$lib/components/AllocationBreakdown.svelte')
+	);
+
 	let { allocation, tier, unitEconomics } = $props<{
 		allocation: AllocationData | null | undefined;
 		tier: string;
 		unitEconomics: Record<string, unknown> | null | undefined;
 	}>();
+
+	let financeDetailAnchor: HTMLDivElement | null = $state(null);
+	let financeDetailsVisible = $state(false);
+
+	onMount(() => {
+		if (import.meta.env.MODE === 'test' || typeof IntersectionObserver === 'undefined') {
+			financeDetailsVisible = true;
+			return;
+		}
+
+		const observer = new IntersectionObserver(
+			(entries) => {
+				if (entries.some((entry) => entry.isIntersecting)) {
+					financeDetailsVisible = true;
+					observer.disconnect();
+				}
+			},
+			{ rootMargin: '220px 0px' }
+		);
+
+		if (financeDetailAnchor) {
+			observer.observe(financeDetailAnchor);
+		}
+
+		return () => observer.disconnect();
+	});
 </script>
 
 <UnitEconomicsCards {unitEconomics} />
 
-<div class="grid gap-6 md:grid-cols-2 lg:grid-cols-2">
+<div class="grid gap-6 md:grid-cols-2 lg:grid-cols-2 finance-dashboard__summary-grid">
 	<GreenOpsWidget />
-	<CloudDistributionMatrix />
+	<div bind:this={financeDetailAnchor}>
+		{#if financeDetailsVisible}
+			{#await loadCloudDistributionMatrix()}
+				<div class="glass-panel finance-dashboard__card-skeleton" aria-hidden="true">
+					<div class="skeleton h-8 w-40"></div>
+					<div class="skeleton finance-dashboard__chart-skeleton"></div>
+				</div>
+			{:then module}
+				{@const CloudDistributionMatrix = module.default}
+				<CloudDistributionMatrix />
+			{/await}
+		{:else}
+			<div class="glass-panel finance-dashboard__card-skeleton" aria-hidden="true">
+				<div class="skeleton h-8 w-40"></div>
+				<div class="skeleton finance-dashboard__chart-skeleton"></div>
+			</div>
+		{/if}
+	</div>
 </div>
 
-<div class="grid gap-6 md:grid-cols-1 lg:grid-cols-2">
-	<ROAChart />
-	{#if allocation && allocation.buckets && allocation.buckets.length > 0}
-		<AllocationBreakdown data={allocation} />
-	{:else if !tierAtLeast(tier, 'growth')}
-		<UpgradeNotice
-			currentTier={tier}
-			requiredTier="growth"
-			feature="Cost Allocation (chargeback/showback)"
-		/>
-	{:else}
-		<div class="glass-panel flex flex-col items-center justify-center text-ink-500">
-			<p>Cost Allocation data will appear here once attribution rules are defined.</p>
+{#if financeDetailsVisible}
+	<div class="grid gap-6 md:grid-cols-1 lg:grid-cols-2 finance-dashboard__detail-grid">
+		{#await loadRoaChart()}
+			<div class="glass-panel finance-dashboard__card-skeleton" aria-hidden="true">
+				<div class="skeleton h-8 w-32"></div>
+				<div
+					class="skeleton finance-dashboard__chart-skeleton finance-dashboard__chart-skeleton--tall"
+				></div>
+			</div>
+		{:then module}
+			{@const ROAChart = module.default}
+			<ROAChart />
+		{/await}
+
+		{#if allocation && allocation.buckets && allocation.buckets.length > 0}
+			{#await loadAllocationBreakdown()}
+				<div class="glass-panel finance-dashboard__card-skeleton" aria-hidden="true">
+					<div class="skeleton h-8 w-44"></div>
+					<div
+						class="skeleton finance-dashboard__chart-skeleton finance-dashboard__chart-skeleton--tall"
+					></div>
+				</div>
+			{:then module}
+				{@const AllocationBreakdown = module.default}
+				<AllocationBreakdown
+					data={{
+						buckets: allocation.buckets.map((bucket: AllocationBucket) => ({
+							name: bucket.name ?? 'Unallocated',
+							total_amount: bucket.value ?? 0,
+							record_count: 0
+						})),
+						total: allocation.buckets.reduce(
+							(sum: number, bucket: AllocationBucket) => sum + (bucket.value ?? 0),
+							0
+						)
+					}}
+				/>
+			{/await}
+		{:else if !tierAtLeast(tier, 'growth')}
+			<UpgradeNotice
+				currentTier={tier}
+				requiredTier="growth"
+				feature="Cost Allocation (chargeback/showback)"
+			/>
+		{:else}
+			<div class="glass-panel finance-dashboard__empty-state">
+				<p>Cost Allocation data will appear here once attribution rules are defined.</p>
+			</div>
+		{/if}
+	</div>
+{:else}
+	<div class="grid gap-6 md:grid-cols-1 lg:grid-cols-2 finance-dashboard__detail-grid">
+		<div class="glass-panel finance-dashboard__card-skeleton" aria-hidden="true">
+			<div class="skeleton h-8 w-32"></div>
+			<div
+				class="skeleton finance-dashboard__chart-skeleton finance-dashboard__chart-skeleton--tall"
+			></div>
 		</div>
-	{/if}
-</div>
+		<div class="glass-panel finance-dashboard__card-skeleton" aria-hidden="true">
+			<div class="skeleton h-8 w-44"></div>
+			<div
+				class="skeleton finance-dashboard__chart-skeleton finance-dashboard__chart-skeleton--tall"
+			></div>
+		</div>
+	</div>
+{/if}
+
+<style>
+	.finance-dashboard__summary-grid,
+	.finance-dashboard__detail-grid {
+		align-items: stretch;
+	}
+
+	.finance-dashboard__card-skeleton {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-4);
+		padding: var(--space-6);
+		min-height: 18rem;
+	}
+
+	.finance-dashboard__chart-skeleton {
+		width: 100%;
+		min-height: 13rem;
+		border-radius: 1.5rem;
+	}
+
+	.finance-dashboard__chart-skeleton--tall {
+		min-height: 18rem;
+	}
+
+	.finance-dashboard__empty-state {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		min-height: 18rem;
+		color: var(--color-ink-500);
+		text-align: center;
+		padding: var(--space-6);
+	}
+
+	.finance-dashboard__empty-state p {
+		margin: 0;
+	}
+</style>

--- a/dashboard/src/routes/dashboard/dashboard-page.svelte.test.ts
+++ b/dashboard/src/routes/dashboard/dashboard-page.svelte.test.ts
@@ -123,7 +123,7 @@ describe('dashboard page lazy sections', () => {
 
 		await screen.findByText(/greenops sustainability/i);
 		expect(screen.getByRole('heading', { name: /unit economics/i })).toBeTruthy();
-		expect(screen.getByRole('heading', { name: /12-month roa/i })).toBeTruthy();
+		expect(await screen.findByRole('heading', { name: /12-month roa/i })).toBeTruthy();
 		await waitFor(() => {
 			expect(screen.queryByText(/loading finance insights/i)).toBeNull();
 		});

--- a/dashboard/src/routes/ops/OpsOperationalHealthSection.svelte
+++ b/dashboard/src/routes/ops/OpsOperationalHealthSection.svelte
@@ -8,8 +8,6 @@
 		canAccessOpsJobSlo
 	} from '$lib/entitlements';
 	import OpsStatusBanners from './OpsStatusBanners.svelte';
-	import OpsIngestionSlaSection from './OpsIngestionSlaSection.svelte';
-	import OpsJobSloSection from './OpsJobSloSection.svelte';
 	import OpsUnitEconomicsSection from './OpsUnitEconomicsSection.svelte';
 	import { buildOpsOperationalInitialState } from './opsOperationalState';
 	import { createOpsOperationalCoreActions } from './opsOperationalCoreActions';
@@ -27,6 +25,7 @@
 		jobSloMetricBadgeClass
 	} from './opsUtils';
 	import { formatDelta, unitDeltaClass } from './unitEconomics';
+	import type { IngestionSLAResponse, JobSLOResponse } from './opsTypes';
 
 	const OPS_REQUEST_TIMEOUT_MS = 10000;
 	const loadOpsAcceptanceKpiSection = createLazyComponent(
@@ -38,11 +37,34 @@
 	const loadOpsCloseWorkflowSection = createLazyComponent(
 		() => import('./OpsCloseWorkflowSection.svelte')
 	);
+	const loadOpsIngestionSlaSection = createLazyComponent<{
+		ingestionSlaWindowHours: number;
+		refreshingIngestionSla: boolean;
+		refreshIngestionSla: () => void | Promise<void>;
+		ingestionSla: IngestionSLAResponse | null;
+		ingestionSlaBadgeClass: (value: IngestionSLAResponse) => string;
+		formatNumber: (value: number | null | undefined, digits?: number) => string;
+		formatDuration: (value: number | null | undefined) => string;
+		formatDate: (value: string | null | undefined) => string;
+	}>(() => import('./OpsIngestionSlaSection.svelte'));
+	const loadOpsJobSloSection = createLazyComponent<{
+		jobSloWindowHours: number;
+		refreshingJobSlo: boolean;
+		refreshJobSlo: () => void | Promise<void>;
+		jobSlo: JobSLOResponse | null;
+		jobSloBadgeClass: (value: JobSLOResponse) => string;
+		jobSloMetricBadgeClass: (metric: JobSLOResponse['metrics'][number]) => string;
+		formatDuration: (value: number | null | undefined) => string;
+	}>(() => import('./OpsJobSloSection.svelte'));
 
 	let { data } = $props();
 	const opsState = $state(buildOpsOperationalInitialState());
+	let reliabilityAnchor: HTMLDivElement | null = $state(null);
 	let advancedEvidenceAnchor: HTMLDivElement | null = $state(null);
+	let reliabilityVisible = $state(false);
 	let advancedEvidenceVisible = $state(false);
+	let reliabilityLoaded = $state(false);
+	let advancedEvidenceLoaded = $state(false);
 	const canAccessJobSlo = () => canAccessOpsJobSlo(data.subscription?.tier, data.profile?.role);
 	const canAccessAcceptanceKpis = () =>
 		canAccessOpsAcceptanceEvidence(data.subscription?.tier, data.profile?.role);
@@ -54,9 +76,7 @@
 		state: opsState,
 		requestTimeoutMs: OPS_REQUEST_TIMEOUT_MS,
 		access: {
-			jobSlo: canAccessJobSlo,
-			acceptanceKpis: canAccessAcceptanceKpis,
-			closeWorkflow: canAccessCloseWorkflow
+			jobSlo: canAccessJobSlo
 		}
 	});
 
@@ -81,29 +101,65 @@
 	const closeStatusBadgeClassSafe = (value: string | null | undefined): string =>
 		closeStatusBadgeClass(value ?? undefined);
 
+	$effect(() => {
+		if (!reliabilityVisible || reliabilityLoaded) return;
+		reliabilityLoaded = true;
+		void coreActions.loadReliabilityData({ silent: true });
+	});
+
+	$effect(() => {
+		if (!advancedEvidenceVisible || advancedEvidenceLoaded) return;
+		advancedEvidenceLoaded = true;
+		void acceptanceActions.preloadAcceptanceEvidence({
+			includeKpis: canAccessAcceptanceKpis(),
+			includeRuns: true
+		});
+		if (canAccessCloseWorkflow()) {
+			void closeActions.preloadClosePackage();
+		}
+	});
+
 	onMount(() => {
 		if (import.meta.env.MODE === 'test' || typeof IntersectionObserver === 'undefined') {
+			reliabilityVisible = true;
 			advancedEvidenceVisible = true;
-		} else {
-			const observer = new IntersectionObserver(
-				(entries) => {
-					if (entries.some((entry) => entry.isIntersecting)) {
-						advancedEvidenceVisible = true;
-						observer.disconnect();
-					}
-				},
-				{ rootMargin: '240px 0px' }
-			);
-
-			if (advancedEvidenceAnchor) {
-				observer.observe(advancedEvidenceAnchor);
-			}
-
-			void coreActions.loadOperationalData();
-			return () => observer.disconnect();
+			void coreActions.loadPrimaryOperationalData();
+			return;
 		}
 
-		void coreActions.loadOperationalData();
+		const reliabilityObserver = new IntersectionObserver(
+			(entries) => {
+				if (entries.some((entry) => entry.isIntersecting)) {
+					reliabilityVisible = true;
+					reliabilityObserver.disconnect();
+				}
+			},
+			{ rootMargin: '200px 0px' }
+		);
+
+		const advancedObserver = new IntersectionObserver(
+			(entries) => {
+				if (entries.some((entry) => entry.isIntersecting)) {
+					advancedEvidenceVisible = true;
+					advancedObserver.disconnect();
+				}
+			},
+			{ rootMargin: '240px 0px' }
+		);
+
+		if (reliabilityAnchor) {
+			reliabilityObserver.observe(reliabilityAnchor);
+		}
+
+		if (advancedEvidenceAnchor) {
+			advancedObserver.observe(advancedEvidenceAnchor);
+		}
+
+		void coreActions.loadPrimaryOperationalData();
+		return () => {
+			reliabilityObserver.disconnect();
+			advancedObserver.disconnect();
+		};
 	});
 </script>
 
@@ -127,38 +183,71 @@
 		bind:unitSettings={opsState.unitSettings}
 	/>
 
-	<OpsIngestionSlaSection
-		{...{
-			refreshingIngestionSla: opsState.refreshingIngestionSla,
-			refreshIngestionSla: coreActions.refreshIngestionSla,
-			ingestionSla: opsState.ingestionSla,
-			ingestionSlaBadgeClass,
-			formatNumber: formatNumberSafe,
-			formatDuration: formatDurationSafe,
-			formatDate: formatDateSafe
-		}}
-		bind:ingestionSlaWindowHours={opsState.ingestionSlaWindowHours}
-	/>
+	<div bind:this={reliabilityAnchor}>
+		{#if reliabilityVisible}
+			{#await loadOpsIngestionSlaSection()}
+				<div class="card">
+					<div class="skeleton h-8 w-48 mb-4"></div>
+					<div class="skeleton h-40 rounded-2xl"></div>
+				</div>
+			{:then module}
+				{@const OpsIngestionSlaSection = module.default}
+				<OpsIngestionSlaSection
+					{...{
+						refreshingIngestionSla: opsState.refreshingIngestionSla,
+						refreshIngestionSla: coreActions.refreshIngestionSla,
+						ingestionSla: opsState.ingestionSla,
+						ingestionSlaBadgeClass,
+						formatNumber: formatNumberSafe,
+						formatDuration: formatDurationSafe,
+						formatDate: formatDateSafe
+					}}
+					bind:ingestionSlaWindowHours={opsState.ingestionSlaWindowHours}
+				/>
+			{:catch}
+				<div class="card">
+					<div class="skeleton h-8 w-48 mb-4"></div>
+				</div>
+			{/await}
 
-	{#if canAccessJobSlo()}
-		<OpsJobSloSection
-			{...{
-				refreshingJobSlo: opsState.refreshingJobSlo,
-				refreshJobSlo: coreActions.refreshJobSlo,
-				jobSlo: opsState.jobSlo,
-				jobSloBadgeClass,
-				jobSloMetricBadgeClass,
-				formatDuration: formatDurationSafe
-			}}
-			bind:jobSloWindowHours={opsState.jobSloWindowHours}
-		/>
-	{:else}
-		<UpgradeNotice
-			currentTier={data.subscription?.tier}
-			requiredTier="pro"
-			feature="job reliability SLO evidence"
-		/>
-	{/if}
+			{#if canAccessJobSlo()}
+				{#await loadOpsJobSloSection()}
+					<div class="card">
+						<div class="skeleton h-8 w-48 mb-4"></div>
+						<div class="skeleton h-40 rounded-2xl"></div>
+					</div>
+				{:then module}
+					{@const OpsJobSloSection = module.default}
+					<OpsJobSloSection
+						{...{
+							refreshingJobSlo: opsState.refreshingJobSlo,
+							refreshJobSlo: coreActions.refreshJobSlo,
+							jobSlo: opsState.jobSlo,
+							jobSloBadgeClass,
+							jobSloMetricBadgeClass,
+							formatDuration: formatDurationSafe
+						}}
+						bind:jobSloWindowHours={opsState.jobSloWindowHours}
+					/>
+				{:catch}
+					<div class="card">
+						<div class="skeleton h-8 w-48 mb-4"></div>
+					</div>
+				{/await}
+			{:else}
+				<UpgradeNotice
+					currentTier={data.subscription?.tier}
+					requiredTier="pro"
+					feature="job reliability SLO evidence"
+				/>
+			{/if}
+		{:else}
+			<div class="card">
+				<div class="skeleton h-8 w-48 mb-4"></div>
+				<div class="skeleton h-40 rounded-2xl"></div>
+			</div>
+		{/if}
+	</div>
 
 	<div bind:this={advancedEvidenceAnchor}>
 		{#if advancedEvidenceVisible}

--- a/dashboard/src/routes/ops/opsOperationalAcceptanceActions.ts
+++ b/dashboard/src/routes/ops/opsOperationalAcceptanceActions.ts
@@ -45,7 +45,7 @@ async function parseErrorMessage(response: Response, fallback: string): Promise<
 export function createOpsOperationalAcceptanceActions(input: AcceptanceActionsInput) {
 	const { getData, state } = input;
 
-	async function refreshAcceptanceKpis() {
+	async function loadAcceptanceKpisInternal({ silent = false }: { silent?: boolean } = {}) {
 		const data = getData();
 		if (!hasSessionToken(data)) return;
 		if (hasInvalidUnitWindow(state.unitStartDate, state.unitEndDate)) {
@@ -55,8 +55,10 @@ export function createOpsOperationalAcceptanceActions(input: AcceptanceActionsIn
 		}
 
 		state.refreshingAcceptanceKpis = true;
-		state.error = '';
-		state.success = '';
+		if (!silent) {
+			state.error = '';
+			state.success = '';
+		}
 		try {
 			const headers = buildHeaders(data);
 			const res = await api.get(
@@ -73,21 +75,31 @@ export function createOpsOperationalAcceptanceActions(input: AcceptanceActionsIn
 				throw new Error(await parseErrorMessage(res, 'Failed to load acceptance KPIs.'));
 			}
 			state.acceptanceKpis = await res.json();
-			state.success = 'Acceptance KPI evidence refreshed.';
+			if (!silent) {
+				state.success = 'Acceptance KPI evidence refreshed.';
+			}
 		} catch (error) {
-			const err = error as Error;
-			state.error = err.message || 'Failed to refresh acceptance KPIs.';
+			if (!silent) {
+				const err = error as Error;
+				state.error = err.message || 'Failed to refresh acceptance KPIs.';
+			}
 		} finally {
 			state.refreshingAcceptanceKpis = false;
 		}
 	}
 
-	async function refreshAcceptanceKpiHistory() {
+	async function refreshAcceptanceKpis() {
+		await loadAcceptanceKpisInternal();
+	}
+
+	async function loadAcceptanceKpiHistoryInternal({ silent = false }: { silent?: boolean } = {}) {
 		const data = getData();
 		if (!hasSessionToken(data)) return;
 		state.refreshingAcceptanceKpiHistory = true;
-		state.error = '';
-		state.success = '';
+		if (!silent) {
+			state.error = '';
+			state.success = '';
+		}
 		try {
 			const headers = buildHeaders(data);
 			const res = await api.get(edgeApiPath(buildAcceptanceKpiHistoryUrl(50)), { headers });
@@ -96,13 +108,21 @@ export function createOpsOperationalAcceptanceActions(input: AcceptanceActionsIn
 			}
 			const payload = (await res.json()) as AcceptanceKpiEvidenceResponse;
 			state.acceptanceKpiHistory = payload.items || [];
-			state.success = 'Acceptance KPI evidence history refreshed.';
+			if (!silent) {
+				state.success = 'Acceptance KPI evidence history refreshed.';
+			}
 		} catch (error) {
-			const err = error as Error;
-			state.error = err.message || 'Failed to refresh acceptance KPI history.';
+			if (!silent) {
+				const err = error as Error;
+				state.error = err.message || 'Failed to refresh acceptance KPI history.';
+			}
 		} finally {
 			state.refreshingAcceptanceKpiHistory = false;
 		}
+	}
+
+	async function refreshAcceptanceKpiHistory() {
+		await loadAcceptanceKpiHistoryInternal();
 	}
 
 	async function captureAcceptanceKpis() {
@@ -137,7 +157,7 @@ export function createOpsOperationalAcceptanceActions(input: AcceptanceActionsIn
 			state.lastAcceptanceKpiCapture = payload;
 			state.acceptanceKpis = payload.acceptance_kpis;
 			state.success = 'Acceptance KPI evidence captured.';
-			void refreshAcceptanceKpiHistory();
+			void loadAcceptanceKpiHistoryInternal({ silent: true });
 		} catch (error) {
 			const err = error as Error;
 			state.error = err.message || 'Failed to capture acceptance KPI evidence.';
@@ -146,12 +166,14 @@ export function createOpsOperationalAcceptanceActions(input: AcceptanceActionsIn
 		}
 	}
 
-	async function refreshAcceptanceRuns() {
+	async function loadAcceptanceRunsInternal({ silent = false }: { silent?: boolean } = {}) {
 		const data = getData();
 		if (!hasSessionToken(data)) return;
 		state.refreshingAcceptanceRuns = true;
-		state.error = '';
-		state.success = '';
+		if (!silent) {
+			state.error = '';
+			state.success = '';
+		}
 		try {
 			const headers = buildHeaders(data);
 			const res = await api.get(edgeApiPath(buildAcceptanceEvidenceUrl()), { headers });
@@ -162,13 +184,39 @@ export function createOpsOperationalAcceptanceActions(input: AcceptanceActionsIn
 			}
 			const payload = (await res.json()) as IntegrationAcceptanceEvidenceResponse;
 			state.acceptanceRuns = buildAcceptanceRuns(payload.items || []);
-			state.success = 'Integration acceptance evidence refreshed.';
+			if (!silent) {
+				state.success = 'Integration acceptance evidence refreshed.';
+			}
 		} catch (error) {
-			const err = error as Error;
-			state.error = err.message || 'Failed to refresh integration acceptance evidence.';
+			if (!silent) {
+				const err = error as Error;
+				state.error = err.message || 'Failed to refresh integration acceptance evidence.';
+			}
 		} finally {
 			state.refreshingAcceptanceRuns = false;
 		}
+	}
+
+	async function refreshAcceptanceRuns() {
+		await loadAcceptanceRunsInternal();
+	}
+
+	async function preloadAcceptanceEvidence({
+		includeKpis = true,
+		includeRuns = true
+	}: {
+		includeKpis?: boolean;
+		includeRuns?: boolean;
+	} = {}) {
+		const tasks: Promise<void>[] = [];
+		if (includeKpis) {
+			tasks.push(loadAcceptanceKpisInternal({ silent: true }));
+			tasks.push(loadAcceptanceKpiHistoryInternal({ silent: true }));
+		}
+		if (includeRuns) {
+			tasks.push(loadAcceptanceRunsInternal({ silent: true }));
+		}
+		await Promise.all(tasks);
 	}
 
 	async function captureAcceptanceRuns() {
@@ -208,7 +256,7 @@ export function createOpsOperationalAcceptanceActions(input: AcceptanceActionsIn
 			}
 			const payload = (await res.json()) as IntegrationAcceptanceCaptureResponse;
 			state.lastAcceptanceCapture = payload;
-			await refreshAcceptanceRuns();
+			await loadAcceptanceRunsInternal({ silent: true });
 			state.success = `Integration acceptance run captured (${payload.run_id.slice(0, 8)}...) - ${payload.passed} passed / ${payload.failed} failed.`;
 		} catch (error) {
 			const err = error as Error;
@@ -289,13 +337,13 @@ export function createOpsOperationalAcceptanceActions(input: AcceptanceActionsIn
 			const kpiPayload = await captureAcceptanceKpisOrThrow(data);
 			state.lastAcceptanceKpiCapture = kpiPayload;
 			state.acceptanceKpis = kpiPayload.acceptance_kpis;
-			await refreshAcceptanceKpiHistory();
+			await loadAcceptanceKpiHistoryInternal({ silent: true });
 			state.capturingAcceptanceKpis = false;
 
 			state.capturingAcceptanceRuns = true;
 			const integrationPayload = await captureIntegrationAcceptanceOrThrow(data);
 			state.lastAcceptanceCapture = integrationPayload;
-			await refreshAcceptanceRuns();
+			await loadAcceptanceRunsInternal({ silent: true });
 			state.capturingAcceptanceRuns = false;
 
 			state.success = `Acceptance suite captured: KPIs (${kpiPayload.event_id.slice(0, 8)}...) + integrations (${integrationPayload.run_id.slice(0, 8)}...)`;
@@ -374,6 +422,7 @@ export function createOpsOperationalAcceptanceActions(input: AcceptanceActionsIn
 	return {
 		refreshAcceptanceKpis,
 		refreshAcceptanceKpiHistory,
+		preloadAcceptanceEvidence,
 		captureAcceptanceKpis,
 		refreshAcceptanceRuns,
 		captureAcceptanceRuns,

--- a/dashboard/src/routes/ops/opsOperationalCloseActions.ts
+++ b/dashboard/src/routes/ops/opsOperationalCloseActions.ts
@@ -91,6 +91,10 @@ export function createOpsOperationalCloseActions(input: CloseActionsInput) {
 		await previewClosePackageInternal();
 	}
 
+	async function preloadClosePackage() {
+		await previewClosePackageInternal({ silent: true });
+	}
+
 	async function saveProviderInvoice(event?: SubmitEvent) {
 		event?.preventDefault();
 		const data = getData();
@@ -291,6 +295,7 @@ export function createOpsOperationalCloseActions(input: CloseActionsInput) {
 
 	return {
 		previewClosePackage,
+		preloadClosePackage,
 		saveProviderInvoice,
 		deleteProviderInvoice,
 		downloadClosePackageJson,

--- a/dashboard/src/routes/ops/opsOperationalCoreActions.ts
+++ b/dashboard/src/routes/ops/opsOperationalCoreActions.ts
@@ -1,25 +1,11 @@
 import { api } from '$lib/api';
 import { edgeApiPath } from '$lib/edgeProxy';
 import { TimeoutError } from '$lib/fetchWithTimeout';
-import {
-	buildAcceptanceEvidenceUrl,
-	buildAcceptanceKpiHistoryUrl,
-	buildAcceptanceKpiUrl,
-	buildClosePackageUrl,
-	buildIngestionSlaUrl,
-	buildJobSloUrl,
-	buildAcceptanceRuns
-} from './opsUtils';
+import { buildIngestionSlaUrl, buildJobSloUrl } from './opsUtils';
 import { buildUnitEconomicsUrl, hasInvalidUnitWindow } from './unitEconomics';
-import {
-	syncInvoiceFormFromClosePackage,
-	type OpsOperationalState,
-	type OpsRuntimeData
-} from './opsOperationalState';
+import type { OpsOperationalState, OpsRuntimeData } from './opsOperationalState';
 import type {
-	AcceptanceKpiEvidenceResponse,
 	IngestionSLAResponse,
-	IntegrationAcceptanceEvidenceResponse,
 	JobSLOResponse,
 	UnitEconomicsResponse,
 	UnitEconomicsSettings
@@ -33,8 +19,6 @@ interface CoreActionsInput {
 	requestTimeoutMs: number;
 	access: {
 		jobSlo: () => boolean;
-		acceptanceKpis: () => boolean;
-		closeWorkflow: () => boolean;
 	};
 }
 
@@ -66,7 +50,7 @@ async function parseErrorMessage(response: Response, fallback: string): Promise<
 export function createOpsOperationalCoreActions(input: CoreActionsInput) {
 	const { getData, state, requestTimeoutMs, access } = input;
 
-	async function loadOperationalData() {
+	async function loadPrimaryOperationalData() {
 		const data = getData();
 		if (!hasSessionToken(data)) {
 			return;
@@ -91,7 +75,43 @@ export function createOpsOperationalCoreActions(input: CoreActionsInput) {
 					),
 					headers,
 					requestTimeoutMs
-				),
+				)
+			]);
+
+			const responseOrNull = (index: number): Response | null =>
+				results[index]?.status === 'fulfilled'
+					? (results[index] as PromiseFulfilledResult<Response>).value
+					: null;
+
+			const settingsRes = responseOrNull(0);
+			const unitRes = responseOrNull(1);
+
+			state.unitSettings = settingsRes?.ok
+				? ((await settingsRes.json()) as UnitEconomicsSettings)
+				: null;
+			state.unitEconomics = unitRes?.ok ? ((await unitRes.json()) as UnitEconomicsResponse) : null;
+
+			const timedOutCount = results.filter(
+				(result) => result.status === 'rejected' && result.reason instanceof TimeoutError
+			).length;
+			if (timedOutCount > 0) {
+				state.error = `${timedOutCount} Ops widgets timed out. You can refresh unit economics.`;
+			}
+		} catch (error) {
+			const err = error as Error;
+			state.error = err.message || 'Failed to load unit economics widgets.';
+		}
+	}
+
+	async function loadReliabilityData({ silent = true }: { silent?: boolean } = {}) {
+		const data = getData();
+		if (!hasSessionToken(data)) {
+			return;
+		}
+
+		try {
+			const headers = buildHeaders(data);
+			const results = await Promise.allSettled([
 				getWithTimeout(
 					edgeApiPath(buildIngestionSlaUrl(state.ingestionSlaWindowHours)),
 					headers,
@@ -103,39 +123,7 @@ export function createOpsOperationalCoreActions(input: CoreActionsInput) {
 							headers,
 							requestTimeoutMs
 						)
-					: Promise.resolve(null),
-				access.acceptanceKpis()
-					? getWithTimeout(
-							edgeApiPath(
-								buildAcceptanceKpiUrl(
-									state.unitStartDate,
-									state.unitEndDate,
-									state.ingestionSlaWindowHours
-								)
-							),
-							headers,
-							requestTimeoutMs
-						)
-					: Promise.resolve(null),
-				access.acceptanceKpis()
-					? getWithTimeout(edgeApiPath(buildAcceptanceKpiHistoryUrl(25)), headers, requestTimeoutMs)
-					: Promise.resolve(null),
-				access.closeWorkflow()
-					? getWithTimeout(
-							edgeApiPath(
-								buildClosePackageUrl(
-									state.closeStartDate,
-									state.closeEndDate,
-									state.closeProvider,
-									'json',
-									false
-								)
-							),
-							headers,
-							requestTimeoutMs
-						)
-					: Promise.resolve(null),
-				getWithTimeout(edgeApiPath(buildAcceptanceEvidenceUrl()), headers, requestTimeoutMs)
+					: Promise.resolve(null)
 			]);
 
 			const responseOrNull = (index: number): Response | null =>
@@ -143,50 +131,31 @@ export function createOpsOperationalCoreActions(input: CoreActionsInput) {
 					? (results[index] as PromiseFulfilledResult<Response>).value
 					: null;
 
-			const settingsRes = responseOrNull(0);
-			const unitRes = responseOrNull(1);
-			const ingestionSlaRes = responseOrNull(2);
-			const jobSloRes = responseOrNull(3);
-			const acceptanceRes = responseOrNull(4);
-			const acceptanceHistoryRes = responseOrNull(5);
-			const closePackageRes = responseOrNull(6);
-			const acceptanceEvidenceRes = responseOrNull(7);
+			const ingestionSlaRes = responseOrNull(0);
+			const jobSloRes = responseOrNull(1);
 
-			state.unitSettings = settingsRes?.ok
-				? ((await settingsRes.json()) as UnitEconomicsSettings)
-				: null;
-			state.unitEconomics = unitRes?.ok ? ((await unitRes.json()) as UnitEconomicsResponse) : null;
 			state.ingestionSla = ingestionSlaRes?.ok
 				? ((await ingestionSlaRes.json()) as IngestionSLAResponse)
 				: null;
 			state.jobSlo = jobSloRes?.ok ? ((await jobSloRes.json()) as JobSLOResponse) : null;
-			state.acceptanceKpis = acceptanceRes?.ok ? await acceptanceRes.json() : null;
-
-			const acceptanceHistoryPayload = acceptanceHistoryRes?.ok
-				? ((await acceptanceHistoryRes.json()) as AcceptanceKpiEvidenceResponse)
-				: null;
-			state.acceptanceKpiHistory = acceptanceHistoryPayload?.items || [];
-
-			state.closePackage = closePackageRes?.ok ? await closePackageRes.json() : null;
-			if (state.closePackage) {
-				syncInvoiceFormFromClosePackage(state);
-			}
-
-			const acceptanceEvidencePayload = acceptanceEvidenceRes?.ok
-				? ((await acceptanceEvidenceRes.json()) as IntegrationAcceptanceEvidenceResponse)
-				: null;
-			state.acceptanceRuns = buildAcceptanceRuns(acceptanceEvidencePayload?.items || []);
 
 			const timedOutCount = results.filter(
 				(result) => result.status === 'rejected' && result.reason instanceof TimeoutError
 			).length;
-			if (timedOutCount > 0) {
-				state.error = `${timedOutCount} Ops widgets timed out. You can refresh individual sections.`;
+			if (timedOutCount > 0 && !silent) {
+				state.error = `${timedOutCount} reliability widgets timed out. You can refresh individual sections.`;
 			}
 		} catch (error) {
-			const err = error as Error;
-			state.error = err.message || 'Failed to load operations widgets.';
+			if (!silent) {
+				const err = error as Error;
+				state.error = err.message || 'Failed to load reliability widgets.';
+			}
 		}
+	}
+
+	async function loadOperationalData() {
+		await loadPrimaryOperationalData();
+		await loadReliabilityData({ silent: true });
 	}
 
 	async function refreshUnitEconomics() {
@@ -320,6 +289,8 @@ export function createOpsOperationalCoreActions(input: CoreActionsInput) {
 
 	return {
 		loadOperationalData,
+		loadPrimaryOperationalData,
+		loadReliabilityData,
 		refreshUnitEconomics,
 		refreshIngestionSla,
 		refreshJobSlo,

--- a/docs/ops/all_changes_categorization_2026-03-27.md
+++ b/docs/ops/all_changes_categorization_2026-03-27.md
@@ -1,0 +1,96 @@
+# All Changes Categorization (2026-03-27)
+
+Snapshot:
+- Captured at: `2026-03-27T00:00:00Z`
+- Base commit: `18d10335155f3d529b98069edb4347bfae9fcfe1`
+- Pending paths: `47`
+- Branch at snapshot: `main`
+
+## Track CR: Backend Billing, Governance, Runtime, and Core Regression Coverage
+Scope:
+- Group billing, governance, scheduler, health, session, cost-cache, optimization, and LLM runtime changes together.
+- Keep the related backend API, integration, core, governance, reporting, services, and circuit-breaker regression suites in the same review lane.
+- Treat this as the backend runtime and correctness slice of the batch.
+
+Paths:
+- `app/main.py`
+- `app/modules/billing/api/v1/billing.py`
+- `app/modules/billing/domain/billing/paystack_shared.py`
+- `app/modules/billing/domain/billing/webhook_retry.py`
+- `app/modules/governance/api/v1/health_dashboard.py`
+- `app/modules/governance/domain/jobs/processor.py`
+- `app/modules/governance/domain/scheduler/orchestrator.py`
+- `app/modules/optimization/domain/ports.py`
+- `app/shared/adapters/cost_cache.py`
+- `app/shared/core/app_runtime.py`
+- `app/shared/core/health.py`
+- `app/shared/db/session.py`
+- `app/shared/llm/circuit_breaker.py`
+- `tests/core/test_llm_circuit_breaker.py`
+- `tests/governance/test_cost_cache_root.py`
+- `tests/integration/billing/test_paystack_flows.py`
+- `tests/unit/api/v1/test_billing.py`
+- `tests/unit/api/v1/test_health_dashboard_endpoints.py`
+- `tests/unit/core/test_health_deep.py`
+- `tests/unit/core/test_main.py`
+- `tests/unit/db/test_session_branch_paths_2.py`
+- `tests/unit/governance/jobs/test_job_processor.py`
+- `tests/unit/governance/scheduler/test_orchestrator_branches.py`
+- `tests/unit/llm/test_circuit_breaker.py`
+- `tests/unit/modules/reporting/test_webhook_retry.py`
+- `tests/unit/reporting/test_billing_api.py`
+- `tests/unit/services/adapters/test_cost_cache.py`
+- `tests/unit/services/billing/test_paystack_billing.py`
+- `tests/unit/services/zombies/test_base.py`
+- `tests/unit/test_main_coverage.py`
+
+Notes:
+- This track contains all `app/` changes and the aligned backend test coverage.
+
+## Track CS: Dashboard Landing, Dashboard Sections, and Ops Interaction Surfaces
+Scope:
+- Consolidate landing hero and persona copy changes with dashboard section and ops interaction updates in one frontend review lane.
+- Keep the dashboard route regression coverage with the exact UI surfaces and action models it exercises.
+- Treat this as the dashboard and product-surface slice of the batch.
+
+Paths:
+- `dashboard/src/lib/components/LandingHero.svelte`
+- `dashboard/src/lib/components/landing/LandingHeroCopy.svelte`
+- `dashboard/src/lib/components/landing/LandingHeroView.svelte`
+- `dashboard/src/lib/components/landing/LandingPersonaSection.svelte`
+- `dashboard/src/lib/components/landing/LandingPlansSection.svelte`
+- `dashboard/src/lib/components/landing/LandingProductSection.svelte`
+- `dashboard/src/lib/components/landing/LandingTrustSection.svelte`
+- `dashboard/src/routes/dashboard/EngineeringDashboardSection.svelte`
+- `dashboard/src/routes/dashboard/FinanceDashboardSection.svelte`
+- `dashboard/src/routes/dashboard/dashboard-page.svelte.test.ts`
+- `dashboard/src/routes/ops/OpsOperationalHealthSection.svelte`
+- `dashboard/src/routes/ops/opsOperationalAcceptanceActions.ts`
+- `dashboard/src/routes/ops/opsOperationalCloseActions.ts`
+- `dashboard/src/routes/ops/opsOperationalCoreActions.ts`
+
+Notes:
+- This track contains all `dashboard/` path changes in the batch.
+
+## Track CT: Deployment Handoff, Production Checklist, and Ops Verification
+Scope:
+- Batch the managed deployment handoff generator, its direct regression coverage, and the production environment checklist together.
+- Keep deployment handoff documentation in the same review lane as the script and test that validate it.
+- Treat this as the runbook and deployment-handoff slice of the batch.
+
+Paths:
+- `docs/runbooks/production_env_checklist.md`
+- `scripts/render_managed_deployment_handoff.py`
+- `tests/unit/ops/test_render_managed_deployment_handoff.py`
+
+Notes:
+- This track contains the operational handoff script, its tests, and the runbook update.
+
+## Batching Decision
+Decision:
+- Merge as one consolidated PR to `main`.
+
+Reasoning:
+- The batch is one active runtime and dashboard follow-up touching billing flows, health surfaces, dashboard sections, and deployment-handoff documentation together.
+- The issue split keeps review accountability without fragmenting the delivery batch across overlapping runtime and product surfaces.
+- No clearly unwanted tracked docs or artifacts were found in this batch; only ignored local `__pycache__` files were cleaned outside the tracked diff.

--- a/docs/runbooks/production_env_checklist.md
+++ b/docs/runbooks/production_env_checklist.md
@@ -265,6 +265,24 @@ This check fails if any of the following drift:
 
 Promotion should not proceed when the bundle verifier fails.
 
+## 2e. Render the operator handoff from verified reports
+
+Once the bundle verifies cleanly, render the single operator-facing handoff file:
+
+```bash
+uv run python scripts/render_managed_deployment_handoff.py --environment production
+```
+
+Default output:
+
+- `.runtime/deploy/<environment>/operator-handoff.md`
+
+Contract notes:
+
+- This file is derived from the verified runtime, migration, and deployment reports.
+- It is a human-friendly handoff for promotion review; the JSON reports remain the source of truth.
+- Regenerate it after any runtime env, migration env, or deployment artifact change.
+
 ## 3. Strict SaaS integration rules
 
 When `SAAS_STRICT_INTEGRATIONS=true`:
@@ -296,14 +314,15 @@ All tokens/secrets are stored in tenant notification settings.
 2. Publish immutable images with `.github/workflows/publish-release-images.yml`.
 3. Generate `.runtime/deploy/production/deployment.report.json` with `--release-tag`, `--api-image-digest`, and `--dashboard-image-digest`.
 4. Verify the bundle: `uv run python scripts/verify_managed_deployment_bundle.py --environment production`
-5. Validate the migration env: `uv run python scripts/validate_migration_env.py --env-file .runtime/production.migrate.env`
-6. Run migrations with the migration env:
+5. Render the operator handoff: `uv run python scripts/render_managed_deployment_handoff.py --environment production`
+6. Validate the migration env: `uv run python scripts/validate_migration_env.py --env-file .runtime/production.migrate.env`
+7. Run migrations with the migration env:
    `set -a && source .runtime/production.migrate.env && uv run alembic upgrade head`
-7. Validate the full runtime env:
+8. Validate the full runtime env:
    `uv run python scripts/validate_runtime_env.py --environment production --env-file .runtime/production.env`
-8. Apply the generated Koyeb secrets and dashboard public env.
-9. Promote API, worker, and dashboard using the digest-pinned `promotion_ref` values recorded in `.runtime/deploy/production/koyeb-release.json`.
-10. Validate health and notification paths.
+9. Apply the generated Koyeb secrets and dashboard public env.
+10. Promote API, worker, and dashboard using the digest-pinned `promotion_ref` values recorded in `.runtime/deploy/production/koyeb-release.json`.
+11. Validate health and notification paths.
 
 ## 6. Smoke tests after deploy
 

--- a/scripts/render_managed_deployment_handoff.py
+++ b/scripts/render_managed_deployment_handoff.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+"""Render a single operator-facing handoff from managed deployment reports."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+from typing import Any
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.env_generation_common import (
+    ensure_parent_dir,
+    promote_staged_file,
+    protected_output_paths_from_root,
+    repo_root_for as _repo_root_for,
+    resolve_cli_path_from_root,
+    resolve_output_path_from_root,
+    stage_text_file,
+)
+from scripts.managed_deployment_contract import SUPPORTED_ENVIRONMENTS
+from scripts.verify_managed_deployment_bundle import (
+    verify_managed_deployment_bundle as _verify_managed_deployment_bundle,
+)
+
+
+CURRENT_PROFILE_NAME = "Koyeb managed services with immutable image promotion"
+FUTURE_SCALE_PROFILE_NAME = "Helm + Terraform (AWS/EKS)"
+
+
+def _repo_root() -> Path:
+    return _repo_root_for(__file__)
+
+
+def _resolve_report_path(path: Path, *, field_name: str) -> Path:
+    resolved = resolve_cli_path_from_root(_repo_root(), path, field_name=field_name)
+    if resolved.exists() and not resolved.is_file():
+        raise ValueError(f"{field_name} must be file paths: {resolved.as_posix()}")
+    return resolved
+
+
+def _normalize_strings(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value]
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"Expected JSON object in {path.as_posix()}.")
+    return payload
+
+
+def _status(flag: bool) -> str:
+    return "READY" if flag else "BLOCKED"
+
+
+def _render_items(items: list[str], *, prefix: str = "- ") -> list[str]:
+    if not items:
+        return [f"{prefix}None"]
+    return [f"{prefix}`{item}`" for item in items]
+
+
+def _render_handoff_markdown(
+    *,
+    environment: str,
+    runtime_report_path: Path,
+    migration_report_path: Path,
+    deployment_report_path: Path,
+    runtime_report: dict[str, Any],
+    migration_report: dict[str, Any],
+    deployment_report: dict[str, Any],
+) -> str:
+    runtime_blockers = _normalize_strings(runtime_report.get("runtime_validation_blockers"))
+    migration_blockers = _normalize_strings(
+        migration_report.get("migration_validation_blockers")
+    )
+    dashboard_blockers = _normalize_strings(
+        deployment_report.get("koyeb_dashboard_public_env_blockers")
+    )
+    release_blockers = _normalize_strings(
+        deployment_report.get("koyeb_release_value_blockers")
+    )
+    terraform_inputs = _normalize_strings(
+        deployment_report.get("terraform_remaining_inputs")
+    )
+    koyeb_secret_blockers = _normalize_strings(
+        deployment_report.get("koyeb_secret_value_blockers")
+    )
+    helm_secret_blockers = _normalize_strings(
+        deployment_report.get("helm_runtime_secret_value_blockers")
+    )
+    nonblocking_placeholders = _normalize_strings(
+        runtime_report.get("declared_but_not_runtime_required")
+    )
+
+    runtime_ready = bool(runtime_report.get("validation_ready"))
+    migration_ready = bool(migration_report.get("migration_ready"))
+    koyeb_ready = bool(deployment_report.get("ready_for_koyeb"))
+    koyeb_release_ready = bool(deployment_report.get("ready_for_koyeb_release"))
+    helm_ready = bool(deployment_report.get("ready_for_helm"))
+    future_scale_ready = migration_ready and helm_ready and not terraform_inputs
+
+    lines = [
+        f"# Managed Deployment Handoff: {environment}",
+        "",
+        "This file is derived from the verified managed deployment reports.",
+        "It is an operator summary, not the canonical source of truth.",
+        "",
+        "## Status",
+        "",
+        f"- Runtime env validation: {_status(runtime_ready)}",
+        f"- Migration env validation: {_status(migration_ready)}",
+        f"- Current supported profile (`{CURRENT_PROFILE_NAME}`): {_status(koyeb_release_ready and migration_ready)}",
+        f"- Koyeb service deploy contract: {_status(koyeb_ready)}",
+        f"- Koyeb immutable release contract: {_status(koyeb_release_ready)}",
+        f"- Future scale profile (`{FUTURE_SCALE_PROFILE_NAME}`): {_status(future_scale_ready)}",
+        "",
+        "## Source Reports",
+        "",
+        f"- Runtime report: `{runtime_report_path}`",
+        f"- Migration report: `{migration_report_path}`",
+        f"- Deployment report: `{deployment_report_path}`",
+        "",
+        "## Root Operator Gaps",
+        "",
+        f"### Runtime env blockers in `{runtime_report.get('output_path', '')}`",
+        *_render_items(runtime_blockers),
+        "",
+        f"### Migration env blockers in `{migration_report.get('output_path', '')}`",
+        *_render_items(migration_blockers),
+        "",
+        "### Dashboard public env blockers in "
+        f"`{deployment_report.get('artifacts', {}).get('koyeb_dashboard_env_json', '')}`",
+        *_render_items(dashboard_blockers),
+        "",
+        "### Immutable release blockers in "
+        f"`{deployment_report.get('artifacts', {}).get('koyeb_release_metadata', '')}`",
+        *_render_items(release_blockers),
+        "",
+        "### Terraform inputs still required outside generated env",
+        *_render_items(terraform_inputs),
+        "",
+        "## Derived Deployment Gaps",
+        "",
+        "### Koyeb secret payload blockers in "
+        f"`{deployment_report.get('artifacts', {}).get('koyeb_secret_payload', '')}`",
+        *_render_items(koyeb_secret_blockers),
+        "",
+        "### Helm runtime secret blockers in "
+        f"`{deployment_report.get('artifacts', {}).get('helm_runtime_secret_json', '')}`",
+        *_render_items(helm_secret_blockers),
+        "",
+        "## Declared Non-Blocking External Placeholders",
+        "",
+        *_render_items(nonblocking_placeholders),
+        "",
+        "## Verification Commands",
+        "",
+        f"- Runtime validation: `{runtime_report.get('validation_command', '')}`",
+        f"- Migration validation: `{migration_report.get('validation_command', '')}`",
+        f"- Migration apply: `{migration_report.get('migration_command', '')}`",
+        "- Bundle verification: "
+        f"`uv run python scripts/verify_managed_deployment_bundle.py --environment {environment}`",
+        "",
+        "Regenerate this handoff after any runtime env, migration env, or deployment artifact change.",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def render_managed_deployment_handoff(
+    *,
+    environment: str,
+    runtime_report_path: Path,
+    migration_report_path: Path,
+    deployment_report_path: Path,
+    output_path: Path,
+) -> Path:
+    normalized_environment = str(environment or "").strip().lower()
+    if normalized_environment not in SUPPORTED_ENVIRONMENTS:
+        raise ValueError(
+            "environment must be one of: " + ", ".join(SUPPORTED_ENVIRONMENTS)
+        )
+
+    verification_errors = _verify_managed_deployment_bundle(
+        environment=normalized_environment,
+        runtime_report_path=runtime_report_path,
+        migration_report_path=migration_report_path,
+        deployment_report_path=deployment_report_path,
+    )
+    if verification_errors:
+        raise ValueError(
+            "cannot render managed deployment handoff for incoherent bundle:\n- "
+            + "\n- ".join(verification_errors)
+        )
+
+    runtime_report = _load_json(runtime_report_path)
+    migration_report = _load_json(migration_report_path)
+    deployment_report = _load_json(deployment_report_path)
+    content = _render_handoff_markdown(
+        environment=normalized_environment,
+        runtime_report_path=runtime_report_path,
+        migration_report_path=migration_report_path,
+        deployment_report_path=deployment_report_path,
+        runtime_report=runtime_report,
+        migration_report=migration_report,
+        deployment_report=deployment_report,
+    )
+    staged_path = stage_text_file(output_path, content)
+    promote_staged_file(staged_path, output_path, cleanup_output_on_failure=True)
+    return output_path
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Render a single operator-facing managed deployment handoff "
+            "from verified runtime, migration, and deployment reports."
+        )
+    )
+    parser.add_argument(
+        "--environment",
+        required=True,
+        choices=SUPPORTED_ENVIRONMENTS,
+    )
+    parser.add_argument(
+        "--runtime-report",
+        type=Path,
+        default=None,
+        help="Path to runtime report JSON (default: .runtime/<environment>.report.json).",
+    )
+    parser.add_argument(
+        "--migration-report",
+        type=Path,
+        default=None,
+        help="Path to migration report JSON (default: .runtime/<environment>.migrate.report.json).",
+    )
+    parser.add_argument(
+        "--deployment-report",
+        type=Path,
+        default=None,
+        help="Path to deployment report JSON (default: .runtime/deploy/<environment>/deployment.report.json).",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help=(
+            "Path to rendered handoff markdown "
+            "(default: .runtime/deploy/<environment>/operator-handoff.md)."
+        ),
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    environment = str(args.environment).strip().lower()
+    repo_root = _repo_root()
+    try:
+        runtime_report = _resolve_report_path(
+            args.runtime_report or Path(".runtime") / f"{environment}.report.json",
+            field_name="runtime report",
+        )
+        migration_report = _resolve_report_path(
+            args.migration_report or Path(".runtime") / f"{environment}.migrate.report.json",
+            field_name="migration report",
+        )
+        deployment_report = _resolve_report_path(
+            args.deployment_report
+            or Path(".runtime/deploy") / environment / "deployment.report.json",
+            field_name="deployment report",
+        )
+        protected_paths = protected_output_paths_from_root(
+            repo_root,
+            __file__,
+            runtime_report,
+            migration_report,
+            deployment_report,
+        )
+        output_path = resolve_output_path_from_root(
+            repo_root,
+            args.output or Path(".runtime/deploy") / environment / "operator-handoff.md",
+            field_name="output",
+            protected_paths=protected_paths,
+            protected_error=(
+                "output must not overwrite script sources, verified reports, or checked-in evidence"
+            ),
+        )
+        ensure_parent_dir(output_path, field_name="output")
+    except ValueError as exc:
+        print(f"[managed-deployment-handoff] failed: {exc}")
+        return 2
+
+    try:
+        rendered_path = render_managed_deployment_handoff(
+            environment=environment,
+            runtime_report_path=runtime_report,
+            migration_report_path=migration_report,
+            deployment_report_path=deployment_report,
+            output_path=output_path,
+        )
+    except ValueError as exc:
+        print(f"[managed-deployment-handoff] failed: {exc}")
+        return 1
+
+    print(
+        "[managed-deployment-handoff] ok "
+        f"environment={environment} "
+        f"output={rendered_path.as_posix()}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/core/test_llm_circuit_breaker.py
+++ b/tests/core/test_llm_circuit_breaker.py
@@ -92,6 +92,22 @@ class TestLLMCircuitBreaker:
         circuit = breaker._get_circuit("groq")
         assert circuit.state == CircuitState.CLOSED
 
+    def test_half_open_allows_only_single_probe_in_protect(self):
+        """Only one probe should be allowed while half-open recovery is in flight."""
+        breaker = LLMCircuitBreaker(
+            failure_threshold=1, success_threshold=1, recovery_timeout=0
+        )
+
+        breaker.record_failure("groq")
+
+        with breaker.protect("groq"):
+            with pytest.raises(CircuitOpenError):
+                with breaker.protect("groq"):
+                    pass
+            breaker.record_success("groq")
+
+        assert breaker.is_available("groq") is True
+
     def test_per_provider_isolation(self):
         """Each provider should have independent circuit state."""
         breaker = LLMCircuitBreaker(failure_threshold=2)

--- a/tests/governance/test_cost_cache_root.py
+++ b/tests/governance/test_cost_cache_root.py
@@ -169,7 +169,8 @@ class TestCostCacheFactory:
     @pytest.mark.asyncio
     async def test_factory_returns_cache(self):
         """Factory should return CostCache instance."""
-        with patch("app.shared.adapters.cost_cache.settings") as mock_settings:
+        with patch("app.shared.adapters.cost_cache.get_settings") as mock_get_settings:
+            mock_settings = mock_get_settings.return_value
             mock_settings.REDIS_URL = None
 
             # Reset singleton

--- a/tests/integration/billing/test_paystack_flows.py
+++ b/tests/integration/billing/test_paystack_flows.py
@@ -60,11 +60,12 @@ async def test_create_checkout_success(ac: AsyncClient, test_data, db):
     )
 
     with (
-        patch("app.modules.billing.api.v1.billing.settings") as api_settings,
+        patch("app.modules.billing.api.v1.billing.get_settings") as api_get_settings,
         patch(
             "app.modules.billing.domain.billing.paystack_shared.settings"
         ) as billing_settings,
     ):
+        api_settings = api_get_settings.return_value
         api_settings.PAYSTACK_SECRET_KEY = "test-secret-key"
         api_settings.FRONTEND_URL = "http://localhost:3000"
         api_settings.ENVIRONMENT = "development"

--- a/tests/unit/api/v1/test_billing.py
+++ b/tests/unit/api/v1/test_billing.py
@@ -74,13 +74,14 @@ async def test_get_public_plans_fallback_on_error(mock_db: AsyncMock) -> None:
 
 @pytest.mark.asyncio
 @patch("app.modules.billing.domain.billing.paystack_billing.BillingService")
-@patch("app.modules.billing.api.v1.billing.settings")
+@patch("app.modules.billing.api.v1.billing.get_settings")
 async def test_create_checkout_success(
-    mock_settings: MagicMock,
+    mock_get_settings: MagicMock,
     mock_billing_service_class: MagicMock,
     mock_db: AsyncMock,
     mock_user: MagicMock,
 ) -> None:
+    mock_settings = mock_get_settings.return_value
     mock_settings.PAYSTACK_SECRET_KEY = "sk_test_123"
     mock_settings.FRONTEND_URL = "https://app.valdrics.io"
     mock_settings.CORS_ORIGINS = ["https://app.valdrics.io"]
@@ -105,13 +106,14 @@ async def test_create_checkout_success(
 
 @pytest.mark.asyncio
 @patch("app.modules.billing.domain.billing.paystack_billing.BillingService")
-@patch("app.modules.billing.api.v1.billing.settings")
+@patch("app.modules.billing.api.v1.billing.get_settings")
 async def test_create_checkout_rejects_untrusted_callback(
-    mock_settings: MagicMock,
+    mock_get_settings: MagicMock,
     mock_billing_service_class: MagicMock,
     mock_db: AsyncMock,
     mock_user: MagicMock,
 ) -> None:
+    mock_settings = mock_get_settings.return_value
     mock_settings.PAYSTACK_SECRET_KEY = "sk_test_123"
     mock_settings.FRONTEND_URL = "https://app.valdrics.io"
     mock_settings.CORS_ORIGINS = ["https://app.valdrics.io"]
@@ -131,13 +133,14 @@ async def test_create_checkout_rejects_untrusted_callback(
 @pytest.mark.asyncio
 @patch("app.modules.billing.domain.billing.paystack_billing.WebhookHandler")
 @patch("app.modules.billing.domain.billing.webhook_retry.WebhookRetryService")
-@patch("app.modules.billing.api.v1.billing.settings")
+@patch("app.modules.billing.api.v1.billing.get_settings")
 async def test_handle_webhook_success(
-    mock_settings: MagicMock,
+    mock_get_settings: MagicMock,
     mock_retry_class: MagicMock,
     mock_handler_class: MagicMock,
     mock_db: AsyncMock,
 ) -> None:
+    mock_settings = mock_get_settings.return_value
     mock_settings.ENVIRONMENT = "development"
     request = AsyncMock()
     # Mock headers as MagicMock so .get is synchronous
@@ -174,13 +177,14 @@ async def test_handle_webhook_success(
 @pytest.mark.asyncio
 @patch("app.modules.billing.domain.billing.paystack_billing.WebhookHandler")
 @patch("app.modules.billing.domain.billing.webhook_retry.WebhookRetryService")
-@patch("app.modules.billing.api.v1.billing.settings")
+@patch("app.modules.billing.api.v1.billing.get_settings")
 async def test_handle_webhook_duplicate_short_circuits_to_duplicate_response(
-    mock_settings: MagicMock,
+    mock_get_settings: MagicMock,
     mock_retry_class: MagicMock,
     mock_handler_class: MagicMock,
     mock_db: AsyncMock,
 ) -> None:
+    mock_settings = mock_get_settings.return_value
     mock_settings.ENVIRONMENT = "development"
     request = AsyncMock()
     request.headers = MagicMock()
@@ -313,8 +317,8 @@ def test_extract_client_ip_ignores_xff_when_proxy_headers_untrusted() -> None:
     request.headers.get.return_value = "198.51.100.20, 198.51.100.21"
 
     with patch(
-        "app.modules.billing.api.v1.billing.settings",
-        SimpleNamespace(
+        "app.modules.billing.api.v1.billing.get_settings",
+        return_value=SimpleNamespace(
             TRUST_PROXY_HEADERS=False,
             TRUSTED_PROXY_HOPS=1,
             TRUSTED_PROXY_CIDRS=[],
@@ -329,8 +333,8 @@ def test_extract_client_ip_uses_xff_when_proxy_headers_trusted() -> None:
     request.headers.get.return_value = "198.51.100.20, 198.51.100.21"
 
     with patch(
-        "app.modules.billing.api.v1.billing.settings",
-        SimpleNamespace(
+        "app.modules.billing.api.v1.billing.get_settings",
+        return_value=SimpleNamespace(
             TRUST_PROXY_HEADERS=True,
             TRUSTED_PROXY_HOPS=1,
             TRUSTED_PROXY_CIDRS=["203.0.113.10/32"],
@@ -345,8 +349,8 @@ def test_extract_client_ip_ignores_xff_when_remote_not_in_trusted_proxy_cidrs() 
     request.headers.get.return_value = "198.51.100.20, 198.51.100.21"
 
     with patch(
-        "app.modules.billing.api.v1.billing.settings",
-        SimpleNamespace(
+        "app.modules.billing.api.v1.billing.get_settings",
+        return_value=SimpleNamespace(
             TRUST_PROXY_HEADERS=True,
             TRUSTED_PROXY_HOPS=1,
             TRUSTED_PROXY_CIDRS=["198.51.100.0/24"],

--- a/tests/unit/api/v1/test_health_dashboard_endpoints.py
+++ b/tests/unit/api/v1/test_health_dashboard_endpoints.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi import HTTPException
 
+import app.modules.governance.api.v1.health_dashboard as health_dashboard_module
 from app.modules.governance.api.v1.health_dashboard import (
     get_investor_health_dashboard,
     get_llm_fair_use_runtime,
@@ -263,6 +264,160 @@ async def test_get_investor_health_dashboard_handler_success():
     assert response.license_governance.requests_created_24h == 12
     assert response.landing_funnel.weekly_current.connected_tenants == 3
     assert response.landing_funnel.alerts[0].status == "healthy"
+
+
+@pytest.mark.asyncio
+async def test_get_investor_health_dashboard_uses_lifespan_startup_time():
+    mock_admin = MagicMock()
+    mock_admin.role = "admin"
+    mock_admin.tenant_id = None
+    mock_db = AsyncMock()
+    now = datetime(2026, 3, 27, 12, 0, tzinfo=timezone.utc)
+    started_at = datetime(2026, 3, 27, 10, 0, tzinfo=timezone.utc)
+
+    with (
+        patch(
+            "app.modules.governance.api.v1.health_dashboard.get_cache_service",
+            return_value=_DisabledCache(),
+        ),
+        patch.object(health_dashboard_module, "_startup_time", started_at),
+        patch(
+            "app.modules.governance.api.v1.health_dashboard.datetime",
+            wraps=datetime,
+        ) as mock_datetime,
+        patch(
+            "app.modules.governance.api.v1.health_dashboard._get_tenant_metrics",
+            new=AsyncMock(
+                return_value=TenantMetrics(
+                    total_tenants=0,
+                    active_last_24h=0,
+                    active_last_7d=0,
+                    free_tenants=0,
+                    paid_tenants=0,
+                    churn_risk=0,
+                )
+            ),
+        ),
+        patch(
+            "app.modules.governance.api.v1.health_dashboard._get_job_queue_health",
+            new=AsyncMock(
+                return_value=JobQueueHealth(
+                    pending_jobs=0,
+                    running_jobs=0,
+                    failed_last_24h=0,
+                    dead_letter_count=0,
+                    avg_processing_time_ms=0.0,
+                    p50_processing_time_ms=0.0,
+                    p95_processing_time_ms=0.0,
+                    p99_processing_time_ms=0.0,
+                )
+            ),
+        ),
+        patch(
+            "app.modules.governance.api.v1.health_dashboard._get_llm_usage_metrics",
+            new=AsyncMock(
+                return_value=LLMUsageMetrics(
+                    total_requests_24h=0,
+                    cache_hit_rate=0.0,
+                    estimated_cost_24h=0.0,
+                    budget_utilization=0.0,
+                )
+            ),
+        ),
+        patch(
+            "app.modules.governance.api.v1.health_dashboard._get_cloud_connection_health",
+            new=AsyncMock(
+                return_value=CloudConnectionHealth(
+                    total_connections=0,
+                    active_connections=0,
+                    inactive_connections=0,
+                    errored_connections=0,
+                    providers={},
+                )
+            ),
+        ),
+        patch(
+            "app.modules.governance.api.v1.health_dashboard._get_cloud_plus_connection_health",
+            new=AsyncMock(
+                return_value=CloudPlusConnectionHealth(
+                    total_connections=0,
+                    active_connections=0,
+                    inactive_connections=0,
+                    errored_connections=0,
+                    providers={},
+                )
+            ),
+        ),
+        patch(
+            "app.modules.governance.api.v1.health_dashboard._get_license_governance_health",
+            new=AsyncMock(
+                return_value=LicenseGovernanceHealth(
+                    window_hours=24,
+                    active_license_connections=0,
+                    requests_created_24h=0,
+                    requests_completed_24h=0,
+                    requests_failed_24h=0,
+                    requests_in_flight=0,
+                    completion_rate_percent=0.0,
+                    failure_rate_percent=0.0,
+                    avg_time_to_complete_hours=0.0,
+                )
+            ),
+        ),
+        patch(
+            "app.modules.governance.api.v1.health_dashboard._get_landing_funnel_health",
+            new=AsyncMock(
+                return_value={
+                    "weekly_current": {
+                        "total_events": 0,
+                        "cta_events": 0,
+                        "signup_intent_events": 0,
+                        "onboarded_tenants": 0,
+                        "connected_tenants": 0,
+                        "first_value_tenants": 0,
+                        "pql_tenants": 0,
+                        "pricing_view_tenants": 0,
+                        "checkout_started_tenants": 0,
+                        "paid_tenants": 0,
+                        "signup_to_connection_rate": 0.0,
+                        "connection_to_first_value_rate": 0.0,
+                    },
+                    "weekly_previous": {
+                        "total_events": 0,
+                        "cta_events": 0,
+                        "signup_intent_events": 0,
+                        "onboarded_tenants": 0,
+                        "connected_tenants": 0,
+                        "first_value_tenants": 0,
+                        "pql_tenants": 0,
+                        "pricing_view_tenants": 0,
+                        "checkout_started_tenants": 0,
+                        "paid_tenants": 0,
+                        "signup_to_connection_rate": 0.0,
+                        "connection_to_first_value_rate": 0.0,
+                    },
+                    "weekly_delta": {
+                        "total_events": 0,
+                        "signup_intent_events": 0,
+                        "onboarded_tenants": 0,
+                        "connected_tenants": 0,
+                        "first_value_tenants": 0,
+                        "pql_tenants": 0,
+                        "pricing_view_tenants": 0,
+                        "checkout_started_tenants": 0,
+                        "paid_tenants": 0,
+                        "signup_to_connection_rate": 0.0,
+                        "connection_to_first_value_rate": 0.0,
+                    },
+                    "alerts": [],
+                }
+            ),
+        ),
+    ):
+        mock_datetime.now.return_value = now
+        response = await get_investor_health_dashboard(mock_admin, mock_db)
+
+    assert response.system.uptime_hours == 2.0
 
 
 @pytest.mark.asyncio

--- a/tests/unit/core/test_health_deep.py
+++ b/tests/unit/core/test_health_deep.py
@@ -486,3 +486,39 @@ async def test_comprehensive_health_check_sequences_db_backed_checks():
     assert result["checks"]["background_jobs"]["status"] == "healthy"
     assert observed_order[0] == "database"
     assert observed_order[-1] == "background_jobs"
+
+
+@pytest.mark.asyncio
+async def test_comprehensive_health_check_uses_live_version_and_environment():
+    service = HealthService()
+    settings_obj = SimpleNamespace(VERSION="2026.03-live", ENVIRONMENT="staging")
+
+    with (
+        patch("app.shared.core.health.get_settings", return_value=settings_obj),
+        patch.object(service, "_check_database", AsyncMock(return_value={"status": "up"})),
+        patch.object(service, "_check_cache", AsyncMock(return_value={"status": "healthy"})),
+        patch.object(
+            service,
+            "_check_external_services",
+            AsyncMock(return_value={"status": "healthy", "services": {}}),
+        ),
+        patch.object(
+            service,
+            "_check_circuit_breakers",
+            AsyncMock(return_value={"status": "healthy"}),
+        ),
+        patch.object(
+            service,
+            "_check_system_resources",
+            AsyncMock(return_value={"status": "healthy"}),
+        ),
+        patch.object(
+            service,
+            "_check_background_jobs",
+            AsyncMock(return_value={"status": "healthy"}),
+        ),
+    ):
+        result = await service.comprehensive_health_check()
+
+    assert result["version"] == "2026.03-live"
+    assert result["environment"] == "staging"

--- a/tests/unit/core/test_main.py
+++ b/tests/unit/core/test_main.py
@@ -114,9 +114,12 @@ def test_gzip_middleware_registered():
 
 
 def test_refresh_fastapi_app_metadata_updates_title_version_and_openapi_cache():
+    from app import main as main_module
+
     original_title = valdrics_app.title
     original_version = valdrics_app.version
     original_openapi_schema = valdrics_app.openapi_schema
+    original_tracker = main_module.EmissionsTracker
     try:
         valdrics_app.openapi_schema = {"cached": True}
 
@@ -131,6 +134,28 @@ def test_refresh_fastapi_app_metadata_updates_title_version_and_openapi_cache():
         valdrics_app.title = original_title
         valdrics_app.version = original_version
         valdrics_app.openapi_schema = original_openapi_schema
+        main_module.EmissionsTracker = original_tracker
+
+
+def test_refresh_fastapi_app_metadata_refreshes_emissions_tracker():
+    from app import main as main_module
+
+    original_tracker = main_module.EmissionsTracker
+    try:
+        refreshed_tracker = object()
+        with patch(
+            "app.main.app_runtime_module.refresh_emissions_tracker",
+            return_value=refreshed_tracker,
+        ) as mock_refresh:
+            refresh_fastapi_app_metadata(
+                MagicMock(APP_NAME="Valdrics Reloaded", VERSION="9.9.9")
+            )
+
+        mock_refresh.assert_called_once_with()
+
+        assert main_module.EmissionsTracker is refreshed_tracker
+    finally:
+        main_module.EmissionsTracker = original_tracker
 
 
 def _make_request(path: str = "/boom", method: str = "GET") -> Request:

--- a/tests/unit/db/test_session_branch_paths_2.py
+++ b/tests/unit/db/test_session_branch_paths_2.py
@@ -304,9 +304,15 @@ def test_reset_db_runtime_dispose_exception_logged() -> None:
 
 
 def test_slow_query_threshold_and_after_cursor_execute_fast_path() -> None:
-    with patch.object(session_mod, "settings", SimpleNamespace(DB_SLOW_QUERY_THRESHOLD_SECONDS="bad")):
+    with patch(
+        "app.shared.db.session.get_settings",
+        return_value=SimpleNamespace(DB_SLOW_QUERY_THRESHOLD_SECONDS="bad"),
+    ):
         assert session_mod._get_slow_query_threshold_seconds() == 0.2
-    with patch.object(session_mod, "settings", SimpleNamespace(DB_SLOW_QUERY_THRESHOLD_SECONDS=0)):
+    with patch(
+        "app.shared.db.session.get_settings",
+        return_value=SimpleNamespace(DB_SLOW_QUERY_THRESHOLD_SECONDS=0),
+    ):
         assert session_mod._get_slow_query_threshold_seconds() == 0.2
 
     conn = MagicMock()
@@ -317,6 +323,18 @@ def test_slow_query_threshold_and_after_cursor_execute_fast_path() -> None:
     ):
         session_mod.after_cursor_execute(conn, None, "SELECT 1", {}, None, False)
     mock_logger.warning.assert_not_called()
+
+
+def test_slow_query_threshold_uses_live_settings_after_import() -> None:
+    stale_settings = SimpleNamespace(DB_SLOW_QUERY_THRESHOLD_SECONDS=0.2)
+    live_settings = SimpleNamespace(DB_SLOW_QUERY_THRESHOLD_SECONDS=1.5)
+
+    with patch(
+        "app.shared.db.session.get_settings",
+        side_effect=[stale_settings, live_settings],
+    ):
+        assert session_mod._get_slow_query_threshold_seconds() == 0.2
+        assert session_mod._get_slow_query_threshold_seconds() == 1.5
 
 
 def test_backend_from_url_and_session_backend_resolution_branches() -> None:

--- a/tests/unit/governance/jobs/test_job_processor.py
+++ b/tests/unit/governance/jobs/test_job_processor.py
@@ -1,5 +1,6 @@
 import asyncio
 from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
@@ -33,6 +34,31 @@ def mock_db_session():
 @pytest.fixture
 def job_processor(mock_db_session):
     return JobProcessor(mock_db_session)
+
+
+@pytest.mark.asyncio
+async def test_is_stale_running_job_uses_live_timeout_setting(job_processor):
+    now = datetime.now(timezone.utc)
+    job = BackgroundJob(
+        id=uuid4(),
+        job_type="test_job",
+        attempts=1,
+        max_attempts=3,
+        status=JobStatus.RUNNING.value,
+        started_at=now - timedelta(minutes=10),
+    )
+
+    with patch(
+        "app.modules.governance.domain.jobs.processor.get_settings",
+        return_value=SimpleNamespace(BACKGROUND_JOB_RUNNING_TIMEOUT_MINUTES=5),
+    ):
+        assert job_processor._is_stale_running_job(job, now=now) is True
+
+    with patch(
+        "app.modules.governance.domain.jobs.processor.get_settings",
+        return_value=SimpleNamespace(BACKGROUND_JOB_RUNNING_TIMEOUT_MINUTES=15),
+    ):
+        assert job_processor._is_stale_running_job(job, now=now) is False
 
 
 @pytest.mark.asyncio

--- a/tests/unit/governance/scheduler/test_orchestrator_branches.py
+++ b/tests/unit/governance/scheduler/test_orchestrator_branches.py
@@ -21,43 +21,77 @@ def orchestrator() -> SchedulerOrchestrator:
 
 @pytest.mark.asyncio
 async def test_acquire_dispatch_lock_paths(
-    orchestrator: SchedulerOrchestrator, monkeypatch: pytest.MonkeyPatch
+    orchestrator: SchedulerOrchestrator,
 ) -> None:
     import app.modules.governance.domain.scheduler.orchestrator as orchestrator_module
 
-    monkeypatch.setattr(orchestrator_module.settings, "TESTING", False, raising=False)
-    monkeypatch.setattr(
-        orchestrator_module.settings, "SCHEDULER_LOCK_FAIL_OPEN", False, raising=False
+    settings_obj = SimpleNamespace(
+        TESTING=False,
+        PYTEST_CURRENT_TEST="",
+        SCHEDULER_LOCK_FAIL_OPEN=False,
     )
 
-    with patch(
-        "app.modules.governance.domain.scheduler.orchestrator.get_redis_client",
-        return_value=None,
-    ):
-        assert await orchestrator._acquire_dispatch_lock("demo") is False
+    with patch.object(orchestrator_module, "get_settings", return_value=settings_obj):
+        with patch(
+            "app.modules.governance.domain.scheduler.orchestrator.get_redis_client",
+            return_value=None,
+        ):
+            assert await orchestrator._acquire_dispatch_lock("demo") is False
+
+        redis = MagicMock()
+        redis.set = AsyncMock(return_value=False)
+        with patch(
+            "app.modules.governance.domain.scheduler.orchestrator.get_redis_client",
+            return_value=redis,
+        ):
+            assert await orchestrator._acquire_dispatch_lock("demo") is False
+
+        redis.set = AsyncMock(side_effect=RuntimeError("redis down"))
+        with patch(
+            "app.modules.governance.domain.scheduler.orchestrator.get_redis_client",
+            return_value=redis,
+        ):
+            assert await orchestrator._acquire_dispatch_lock("demo") is False
+
+        settings_obj.SCHEDULER_LOCK_FAIL_OPEN = True
+        with patch(
+            "app.modules.governance.domain.scheduler.orchestrator.get_redis_client",
+            return_value=redis,
+        ):
+            assert await orchestrator._acquire_dispatch_lock("demo") is True
+
+
+@pytest.mark.asyncio
+async def test_acquire_dispatch_lock_uses_live_settings_after_construction(
+    orchestrator: SchedulerOrchestrator,
+) -> None:
+    import app.modules.governance.domain.scheduler.orchestrator as orchestrator_module
 
     redis = MagicMock()
-    redis.set = AsyncMock(return_value=False)
-    with patch(
-        "app.modules.governance.domain.scheduler.orchestrator.get_redis_client",
-        return_value=redis,
-    ):
-        assert await orchestrator._acquire_dispatch_lock("demo") is False
-
     redis.set = AsyncMock(side_effect=RuntimeError("redis down"))
-    with patch(
-        "app.modules.governance.domain.scheduler.orchestrator.get_redis_client",
-        return_value=redis,
+    stale_settings = SimpleNamespace(
+        TESTING=False,
+        PYTEST_CURRENT_TEST="",
+        SCHEDULER_LOCK_FAIL_OPEN=False,
+    )
+    live_settings = SimpleNamespace(
+        TESTING=False,
+        PYTEST_CURRENT_TEST="",
+        SCHEDULER_LOCK_FAIL_OPEN=True,
+    )
+
+    with (
+        patch.object(
+            orchestrator_module,
+            "get_settings",
+            side_effect=[stale_settings, live_settings],
+        ),
+        patch(
+            "app.modules.governance.domain.scheduler.orchestrator.get_redis_client",
+            return_value=redis,
+        ),
     ):
         assert await orchestrator._acquire_dispatch_lock("demo") is False
-
-    monkeypatch.setattr(
-        orchestrator_module.settings, "SCHEDULER_LOCK_FAIL_OPEN", True, raising=False
-    )
-    with patch(
-        "app.modules.governance.domain.scheduler.orchestrator.get_redis_client",
-        return_value=redis,
-    ):
         assert await orchestrator._acquire_dispatch_lock("demo") is True
 
 
@@ -95,21 +129,12 @@ async def test_cohort_analysis_job_celery_error_still_updates_last_run(
 @pytest.mark.asyncio
 async def test_fetch_live_carbon_intensity_success_and_cache(
     orchestrator: SchedulerOrchestrator,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     import app.modules.governance.domain.scheduler.orchestrator as orchestrator_module
 
-    monkeypatch.setattr(
-        orchestrator_module.settings,
-        "ELECTRICITY_MAPS_API_KEY",
-        "abc123",
-        raising=False,
-    )
-    monkeypatch.setattr(
-        orchestrator_module.settings,
-        "CARBON_INTENSITY_API_TIMEOUT_SECONDS",
-        3,
-        raising=False,
+    settings_obj = SimpleNamespace(
+        ELECTRICITY_MAPS_API_KEY="abc123",
+        CARBON_INTENSITY_API_TIMEOUT_SECONDS=3,
     )
 
     response = MagicMock()
@@ -119,57 +144,57 @@ async def test_fetch_live_carbon_intensity_success_and_cache(
     client = AsyncMock()
     client.get = AsyncMock(return_value=response)
 
-    with patch(
-        "app.shared.core.http.get_http_client",
-        return_value=client,
-    ):
-        value = await orchestrator._fetch_live_carbon_intensity("us-east-1")
-        assert value == 97.0
+    with patch.object(orchestrator_module, "get_settings", return_value=settings_obj):
+        with patch(
+            "app.shared.core.http.get_http_client",
+            return_value=client,
+        ):
+            value = await orchestrator._fetch_live_carbon_intensity("us-east-1")
+            assert value == 97.0
 
-    with patch(
-        "app.shared.core.http.get_http_client"
-    ) as get_http_client:
-        cached_value = await orchestrator._fetch_live_carbon_intensity("us-east-1")
-        assert cached_value == 97.0
-        get_http_client.assert_not_called()
+        with patch(
+            "app.shared.core.http.get_http_client"
+        ) as get_http_client:
+            cached_value = await orchestrator._fetch_live_carbon_intensity("us-east-1")
+            assert cached_value == 97.0
+            get_http_client.assert_not_called()
 
 
 @pytest.mark.asyncio
 async def test_fetch_live_carbon_intensity_none_and_exception_paths(
     orchestrator: SchedulerOrchestrator,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     import app.modules.governance.domain.scheduler.orchestrator as orchestrator_module
 
-    monkeypatch.setattr(
-        orchestrator_module.settings, "ELECTRICITY_MAPS_API_KEY", None, raising=False
-    )
-    assert await orchestrator._fetch_live_carbon_intensity("us-east-1") is None
+    settings_obj = SimpleNamespace(ELECTRICITY_MAPS_API_KEY=None)
+    with patch.object(orchestrator_module, "get_settings", return_value=settings_obj):
+        assert await orchestrator._fetch_live_carbon_intensity("us-east-1") is None
 
-    monkeypatch.setattr(
-        orchestrator_module.settings,
-        "ELECTRICITY_MAPS_API_KEY",
-        "abc123",
-        raising=False,
-    )
-    assert await orchestrator._fetch_live_carbon_intensity("unknown-region") is None
+        settings_obj.ELECTRICITY_MAPS_API_KEY = "abc123"
+        assert await orchestrator._fetch_live_carbon_intensity("unknown-region") is None
 
     response = MagicMock()
     response.raise_for_status.return_value = None
     response.json.return_value = {}
     client = AsyncMock()
     client.get = AsyncMock(return_value=response)
-    with patch(
-        "app.shared.core.http.get_http_client",
-        return_value=client,
+    with (
+        patch.object(orchestrator_module, "get_settings", return_value=settings_obj),
+        patch(
+            "app.shared.core.http.get_http_client",
+            return_value=client,
+        ),
     ):
         assert await orchestrator._fetch_live_carbon_intensity("us-east-1") is None
 
     client = AsyncMock()
     client.get = AsyncMock(side_effect=httpx.HTTPError("boom"))
-    with patch(
-        "app.shared.core.http.get_http_client",
-        return_value=client,
+    with (
+        patch.object(orchestrator_module, "get_settings", return_value=settings_obj),
+        patch(
+            "app.shared.core.http.get_http_client",
+            return_value=client,
+        ),
     ):
         assert await orchestrator._fetch_live_carbon_intensity("us-east-1") is None
 
@@ -177,24 +202,52 @@ async def test_fetch_live_carbon_intensity_none_and_exception_paths(
 @pytest.mark.asyncio
 async def test_is_low_carbon_window_uses_live_intensity_threshold(
     orchestrator: SchedulerOrchestrator,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     import app.modules.governance.domain.scheduler.orchestrator as orchestrator_module
 
-    monkeypatch.setattr(
-        orchestrator_module.settings,
-        "CARBON_LOW_INTENSITY_THRESHOLD",
-        150.0,
-        raising=False,
+    settings_obj = SimpleNamespace(CARBON_LOW_INTENSITY_THRESHOLD=150.0)
+    with patch.object(orchestrator_module, "get_settings", return_value=settings_obj):
+        with patch.object(
+            orchestrator, "_fetch_live_carbon_intensity", AsyncMock(return_value=120.0)
+        ):
+            assert await orchestrator.is_low_carbon_window("us-east-1") is True
+        with patch.object(
+            orchestrator, "_fetch_live_carbon_intensity", AsyncMock(return_value=180.0)
+        ):
+            assert await orchestrator.is_low_carbon_window("us-east-1") is False
+
+
+@pytest.mark.asyncio
+async def test_process_background_jobs_inline_uses_live_batch_settings(
+    orchestrator: SchedulerOrchestrator,
+) -> None:
+    import app.modules.governance.domain.scheduler.orchestrator as orchestrator_module
+
+    db = AsyncMock()
+    orchestrator.session_maker.return_value.__aenter__.return_value = db
+    orchestrator.session_maker.return_value.__aexit__.return_value = None
+    settings_obj = SimpleNamespace(
+        BACKGROUND_JOB_PROCESS_BATCH_SIZE=3,
+        BACKGROUND_JOB_PROCESS_MAX_BATCHES_PER_TICK=2,
     )
-    with patch.object(
-        orchestrator, "_fetch_live_carbon_intensity", AsyncMock(return_value=120.0)
+
+    with (
+        patch.object(orchestrator_module, "get_settings", return_value=settings_obj),
+        patch(
+            "app.modules.governance.domain.scheduler.orchestrator.mark_session_system_context",
+            new=AsyncMock(),
+        ),
+        patch(
+            "app.modules.governance.domain.jobs.processor.JobProcessor",
+        ) as processor_cls,
     ):
-        assert await orchestrator.is_low_carbon_window("us-east-1") is True
-    with patch.object(
-        orchestrator, "_fetch_live_carbon_intensity", AsyncMock(return_value=180.0)
-    ):
-        assert await orchestrator.is_low_carbon_window("us-east-1") is False
+        processor = processor_cls.return_value
+        processor.process_pending_jobs = AsyncMock(
+            return_value={"processed": 0, "succeeded": 0, "failed": 0}
+        )
+        await orchestrator._process_background_jobs_inline()
+
+    processor.process_pending_jobs.assert_awaited_once_with(limit=3)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/llm/test_circuit_breaker.py
+++ b/tests/unit/llm/test_circuit_breaker.py
@@ -271,6 +271,23 @@ class TestLLMCircuitBreaker:
             with breaker.protect("provider"):
                 pass
 
+    def test_protect_half_open_rejects_second_probe_while_first_in_flight(self, breaker):
+        """Half-open recovery should serialize probes instead of allowing concurrency."""
+        breaker.record_failure("provider")
+        breaker.record_failure("provider")
+        breaker.record_failure("provider")
+
+        circuit = breaker._get_circuit("provider")
+        circuit.last_failure_time = datetime.now(timezone.utc) - timedelta(seconds=61)
+
+        with breaker.protect("provider"):
+            with pytest.raises(CircuitOpenError, match="Circuit open for provider"):
+                with breaker.protect("provider"):
+                    pass
+            breaker.record_success("provider")
+
+        assert circuit.probe_in_flight is False
+
     def test_protect_context_manager_does_not_swallow_fatal_errors(self, breaker):
         with pytest.raises(KeyboardInterrupt):
             with breaker.protect("provider"):

--- a/tests/unit/modules/reporting/test_webhook_retry.py
+++ b/tests/unit/modules/reporting/test_webhook_retry.py
@@ -7,6 +7,7 @@ Covers webhook storage, idempotency, retry logic, duplicate detection, and Payst
 
 from datetime import datetime, timedelta, timezone
 import json
+from types import SimpleNamespace
 import uuid
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -103,6 +104,31 @@ class TestIdempotencyKeyGeneration:
         )
 
         assert key_paystack != key_stripe
+
+
+class TestRunningJobCutoff:
+    def test_is_stale_running_uses_live_timeout_setting(self, webhook_service):
+        now = datetime.now(timezone.utc)
+        job = BackgroundJob(
+            id=uuid.uuid4(),
+            job_type="webhook_retry",
+            attempts=1,
+            max_attempts=5,
+            status=JobStatus.RUNNING.value,
+            started_at=now - timedelta(minutes=10),
+        )
+
+        with patch(
+            "app.modules.billing.domain.billing.webhook_retry.get_settings",
+            return_value=SimpleNamespace(BACKGROUND_JOB_RUNNING_TIMEOUT_MINUTES=5),
+        ):
+            assert webhook_service._is_stale_running(job, now=now) is True
+
+        with patch(
+            "app.modules.billing.domain.billing.webhook_retry.get_settings",
+            return_value=SimpleNamespace(BACKGROUND_JOB_RUNNING_TIMEOUT_MINUTES=15),
+        ):
+            assert webhook_service._is_stale_running(job, now=now) is False
 
 
 class TestDuplicateDetection:

--- a/tests/unit/ops/test_render_managed_deployment_handoff.py
+++ b/tests/unit/ops/test_render_managed_deployment_handoff.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import scripts.render_managed_deployment_handoff as managed_handoff
+from scripts.generate_managed_deployment_artifacts import (
+    generate_managed_deployment_artifacts,
+)
+from scripts.generate_managed_migration_env import generate_managed_migration_env
+from scripts.generate_managed_runtime_env import generate_managed_runtime_env
+from scripts.render_managed_deployment_handoff import (
+    main,
+    render_managed_deployment_handoff,
+)
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _runtime_template() -> str:
+    return "\n".join(
+        [
+            "API_URL=",
+            "FRONTEND_URL=",
+            "CORS_ORIGINS=[]",
+            "DATABASE_URL=",
+            "REDIS_URL=",
+            "SUPABASE_URL=",
+            "SUPABASE_ANON_KEY=",
+            "SUPABASE_JWT_SECRET=",
+            "CSRF_SECRET_KEY=",
+            "ENCRYPTION_KEY=",
+            "KDF_SALT=",
+            "ADMIN_API_KEY=",
+            "INTERNAL_JOB_SECRET=",
+            "INTERNAL_METRICS_AUTH_TOKEN=",
+            "ENFORCEMENT_APPROVAL_TOKEN_SECRET=",
+            "ENFORCEMENT_EXPORT_SIGNING_SECRET=",
+            "LLM_PROVIDER=groq",
+            "GROQ_API_KEY=",
+            "PAYSTACK_SECRET_KEY=",
+            "PAYSTACK_PUBLIC_KEY=",
+            "SENTRY_DSN=",
+            "OTEL_EXPORTER_OTLP_ENDPOINT=",
+            "TRUSTED_PROXY_CIDRS=[]",
+            "",
+        ]
+    )
+
+
+def _build_bundle(
+    tmp_path: Path,
+    *,
+    environment: str,
+    release_ready: bool,
+) -> tuple[Path, Path, Path]:
+    template = tmp_path / ".env.example"
+    runtime_dir = tmp_path / ".runtime"
+    runtime_env = runtime_dir / f"{environment}.env"
+    runtime_report = runtime_dir / f"{environment}.report.json"
+    migrate_env = runtime_dir / f"{environment}.migrate.env"
+    migrate_report = runtime_dir / f"{environment}.migrate.report.json"
+    deploy_dir = runtime_dir / "deploy" / environment
+    deployment_report = deploy_dir / "deployment.report.json"
+    _write(template, _runtime_template())
+
+    runtime_kwargs = {
+        "template_path": template,
+        "output_path": runtime_env,
+        "report_path": runtime_report,
+        "environment": environment,
+    }
+    migration_kwargs = {
+        "output_path": migrate_env,
+        "report_path": migrate_report,
+        "environment": environment,
+    }
+    deployment_kwargs = {
+        "environment": environment,
+        "runtime_env_file": runtime_env,
+        "output_dir": deploy_dir,
+    }
+    if release_ready:
+        runtime_kwargs.update(
+            {
+                "api_url": "https://api.runtime.example",
+                "frontend_url": "https://app.runtime.example",
+                "database_url": (
+                    "postgresql+asyncpg://postgres:postgres@db.example.com:5432/postgres"
+                ),
+                "redis_url": "redis://redis.example.com:6379/0",
+                "supabase_url": "https://example.supabase.co",
+                "supabase_anon_key": "dashboard-anon-key",
+                "supabase_jwt_secret": "x" * 40,
+                "aws_assume_role_trust_principal_arn": (
+                    "arn:aws:iam::123456789012:role/ValdricsControlPlane"
+                ),
+                "llm_provider": "groq",
+                "llm_api_key": "gsk_test_runtime_key",
+                "paystack_secret_key": "sk_live_runtime_paystack_key",
+                "paystack_public_key": "pk_live_runtime_paystack_key",
+                "sentry_dsn": "https://key@example.com/1",
+                "otel_endpoint": "https://otel.example.com:4317",
+                "trusted_proxy_cidrs": ["203.0.113.10/32"],
+            }
+        )
+        migration_kwargs.update(
+            {
+                "database_url": (
+                    "postgresql+asyncpg://postgres:postgres@db.example.com:5432/postgres"
+                ),
+                "db_ssl_mode": "require",
+            }
+        )
+        deployment_kwargs.update(
+            {
+                "release_tag": "2026.03.26",
+                "api_image_digest": (
+                    "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                ),
+                "dashboard_image_digest": (
+                    "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                ),
+            }
+        )
+
+    generate_managed_runtime_env(**runtime_kwargs)
+    generate_managed_migration_env(**migration_kwargs)
+    generate_managed_deployment_artifacts(**deployment_kwargs)
+    return runtime_report, migrate_report, deployment_report
+
+
+def test_render_managed_deployment_handoff_renders_blocked_bundle_summary(
+    tmp_path: Path,
+) -> None:
+    runtime_report, migrate_report, deployment_report = _build_bundle(
+        tmp_path,
+        environment="staging",
+        release_ready=False,
+    )
+    output_path = tmp_path / ".runtime" / "deploy" / "staging" / "operator-handoff.md"
+
+    rendered_path = render_managed_deployment_handoff(
+        environment="staging",
+        runtime_report_path=runtime_report,
+        migration_report_path=migrate_report,
+        deployment_report_path=deployment_report,
+        output_path=output_path,
+    )
+
+    content = rendered_path.read_text(encoding="utf-8")
+    assert "Managed Deployment Handoff: staging" in content
+    assert "Runtime env validation: BLOCKED" in content
+    assert "Current supported profile (`Koyeb managed services with immutable image promotion`): BLOCKED" in content
+    assert "`API_URL`" in content
+    assert "`DATABASE_URL`" in content
+    assert "`PUBLIC_API_URL`" in content
+    assert "`release_tag`" in content
+    assert "`external_id`" in content
+    assert "`SUPABASE_URL`" in content
+
+
+def test_render_managed_deployment_handoff_marks_koyeb_release_ready(
+    tmp_path: Path,
+) -> None:
+    runtime_report, migrate_report, deployment_report = _build_bundle(
+        tmp_path,
+        environment="production",
+        release_ready=True,
+    )
+    output_path = tmp_path / ".runtime" / "deploy" / "production" / "operator-handoff.md"
+
+    render_managed_deployment_handoff(
+        environment="production",
+        runtime_report_path=runtime_report,
+        migration_report_path=migrate_report,
+        deployment_report_path=deployment_report,
+        output_path=output_path,
+    )
+
+    content = output_path.read_text(encoding="utf-8")
+    assert "Runtime env validation: READY" in content
+    assert "Migration env validation: READY" in content
+    assert "Current supported profile (`Koyeb managed services with immutable image promotion`): READY" in content
+    assert "Koyeb immutable release contract: READY" in content
+    assert "Future scale profile (`Helm + Terraform (AWS/EKS)`): BLOCKED" in content
+    assert "`secret_rotation_lambda_arn`" in content
+
+
+def test_render_managed_deployment_handoff_rejects_incoherent_bundle(
+    tmp_path: Path,
+) -> None:
+    runtime_report, migrate_report, deployment_report = _build_bundle(
+        tmp_path,
+        environment="production",
+        release_ready=True,
+    )
+    payload = json.loads(deployment_report.read_text(encoding="utf-8"))
+    payload["runtime_validation_blockers"] = ["DATABASE_URL"]
+    deployment_report.write_text(
+        json.dumps(payload, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="cannot render managed deployment handoff"):
+        render_managed_deployment_handoff(
+            environment="production",
+            runtime_report_path=runtime_report,
+            migration_report_path=migrate_report,
+            deployment_report_path=deployment_report,
+            output_path=tmp_path / "handoff.md",
+        )
+
+
+def test_main_resolves_default_paths_from_repo_root_when_run_outside_repo(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo_root = tmp_path / "repo"
+    runtime_report, migrate_report, deployment_report = _build_bundle(
+        repo_root,
+        environment="staging",
+        release_ready=False,
+    )
+
+    monkeypatch.setattr(managed_handoff, "_repo_root", lambda: repo_root)
+    monkeypatch.chdir(tmp_path)
+
+    assert main(["--environment", "staging"]) == 0
+    output_path = repo_root / ".runtime" / "deploy" / "staging" / "operator-handoff.md"
+    assert output_path.exists()
+    content = output_path.read_text(encoding="utf-8")
+    assert f"Runtime report: `{runtime_report}`" in content
+    assert f"Migration report: `{migrate_report}`" in content
+    assert f"Deployment report: `{deployment_report}`" in content

--- a/tests/unit/reporting/test_billing_api.py
+++ b/tests/unit/reporting/test_billing_api.py
@@ -190,11 +190,12 @@ async def test_load_billing_usage_returns_zeroes_without_tenant_context(mock_db)
 @pytest.mark.asyncio
 async def test_create_checkout_success(mock_db):
     with (
-        patch("app.modules.billing.api.v1.billing.settings") as mock_settings,
+        patch("app.modules.billing.api.v1.billing.get_settings") as mock_get_settings,
         patch(
             "app.modules.billing.domain.billing.paystack_billing.BillingService"
         ) as mock_service_cls,
     ):
+        mock_settings = mock_get_settings.return_value
         mock_settings.PAYSTACK_SECRET_KEY = "sk_test"
         mock_settings.FRONTEND_URL = "https://app"
         mock_service = mock_service_cls.return_value
@@ -209,7 +210,8 @@ async def test_create_checkout_success(mock_db):
 @pytest.mark.asyncio
 async def test_create_checkout_no_tenant(mock_user):
     mock_user.tenant_id = None
-    with patch("app.modules.billing.api.v1.billing.settings") as mock_settings:
+    with patch("app.modules.billing.api.v1.billing.get_settings") as mock_get_settings:
+        mock_settings = mock_get_settings.return_value
         mock_settings.PAYSTACK_SECRET_KEY = "sk_test"
         async with AsyncClient(transport=transport, base_url="https://test") as ac:
             response = await ac.post("/api/v1/billing/checkout", json={"tier": "pro"})
@@ -218,7 +220,8 @@ async def test_create_checkout_no_tenant(mock_user):
 
 @pytest.mark.asyncio
 async def test_create_checkout_error(mock_db):
-    with patch("app.modules.billing.api.v1.billing.settings") as mock_settings:
+    with patch("app.modules.billing.api.v1.billing.get_settings") as mock_get_settings:
+        mock_settings = mock_get_settings.return_value
         mock_settings.PAYSTACK_SECRET_KEY = "sk_test"
         mock_settings.FRONTEND_URL = "https://app.valdrics.test"
         mock_settings.CORS_ORIGINS = ["https://app.valdrics.test"]
@@ -239,7 +242,8 @@ async def test_create_checkout_error(mock_db):
 
 @pytest.mark.asyncio
 async def test_create_checkout_rate_unavailable_returns_503(mock_db):
-    with patch("app.modules.billing.api.v1.billing.settings") as mock_settings:
+    with patch("app.modules.billing.api.v1.billing.get_settings") as mock_get_settings:
+        mock_settings = mock_get_settings.return_value
         mock_settings.PAYSTACK_SECRET_KEY = "sk_test"
         mock_settings.FRONTEND_URL = "https://app.valdrics.test"
         mock_settings.CORS_ORIGINS = ["https://app.valdrics.test"]
@@ -489,7 +493,8 @@ async def test_handle_webhook_returns_accepted_when_payload_is_queued(mock_db):
 
 @pytest.mark.asyncio
 async def test_handle_webhook_unauthorized_ip():
-    with patch("app.modules.billing.api.v1.billing.settings") as mock_settings:
+    with patch("app.modules.billing.api.v1.billing.get_settings") as mock_get_settings:
+        mock_settings = mock_get_settings.return_value
         mock_settings.ENVIRONMENT = "production"
         async with AsyncClient(transport=transport, base_url="https://test") as ac:
             response = await ac.post(
@@ -500,7 +505,8 @@ async def test_handle_webhook_unauthorized_ip():
 
 @pytest.mark.asyncio
 async def test_handle_webhook_unauthorized_ip_staging():
-    with patch("app.modules.billing.api.v1.billing.settings") as mock_settings:
+    with patch("app.modules.billing.api.v1.billing.get_settings") as mock_get_settings:
+        mock_settings = mock_get_settings.return_value
         mock_settings.ENVIRONMENT = "staging"
         async with AsyncClient(transport=transport, base_url="https://test") as ac:
             response = await ac.post(
@@ -511,7 +517,8 @@ async def test_handle_webhook_unauthorized_ip_staging():
 
 @pytest.mark.asyncio
 async def test_handle_webhook_rightmost_forwarded_ip_is_used():
-    with patch("app.modules.billing.api.v1.billing.settings") as mock_settings:
+    with patch("app.modules.billing.api.v1.billing.get_settings") as mock_get_settings:
+        mock_settings = mock_get_settings.return_value
         mock_settings.ENVIRONMENT = "production"
         mock_settings.TRUST_PROXY_HEADERS = True
         mock_settings.TRUSTED_PROXY_HOPS = 1

--- a/tests/unit/services/adapters/test_cost_cache.py
+++ b/tests/unit/services/adapters/test_cost_cache.py
@@ -235,7 +235,8 @@ class TestCostCache:
 
 @pytest.mark.asyncio
 async def test_get_cost_cache_factory():
-    with patch("app.shared.adapters.cost_cache.settings") as mock_settings:
+    with patch("app.shared.adapters.cost_cache.get_settings") as mock_get_settings:
+        mock_settings = mock_get_settings.return_value
         mock_settings.REDIS_URL = None
         # Reset singleton for test
         with patch("app.shared.adapters.cost_cache._cache_instance", None):
@@ -269,16 +270,16 @@ async def test_get_cost_cache_factory():
 async def test_get_cost_cache_rebuilds_when_redis_url_changes_without_manual_reset():
     with patch("app.shared.adapters.cost_cache._cache_instance", None):
         with patch(
-            "app.shared.adapters.cost_cache.settings",
-            SimpleNamespace(REDIS_URL=None),
+            "app.shared.adapters.cost_cache.get_settings",
+            return_value=SimpleNamespace(REDIS_URL=None),
         ):
             cache = await get_cost_cache()
             assert isinstance(cache.backend, InMemoryCache)
 
         with (
             patch(
-                "app.shared.adapters.cost_cache.settings",
-                SimpleNamespace(REDIS_URL="redis://localhost"),
+                "app.shared.adapters.cost_cache.get_settings",
+                return_value=SimpleNamespace(REDIS_URL="redis://localhost"),
             ),
             patch("app.shared.adapters.cost_cache.RedisCache") as mock_redis_cls,
         ):

--- a/tests/unit/services/billing/test_paystack_billing.py
+++ b/tests/unit/services/billing/test_paystack_billing.py
@@ -2,6 +2,7 @@ import pytest
 import hmac
 import hashlib
 import json
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 from app.modules.billing.domain.billing.paystack_billing import (
@@ -37,6 +38,23 @@ def mock_settings():
 
 
 class TestPaystackClient:
+    def test_paystack_shared_settings_proxy_reads_live_settings(self):
+        from app.modules.billing.domain.billing import paystack_shared
+
+        with patch.object(
+            paystack_shared,
+            "get_settings",
+            return_value=SimpleNamespace(PAYSTACK_SECRET_KEY="sk_live_1"),
+        ):
+            assert paystack_shared.settings.PAYSTACK_SECRET_KEY == "sk_live_1"
+
+        with patch.object(
+            paystack_shared,
+            "get_settings",
+            return_value=SimpleNamespace(PAYSTACK_SECRET_KEY="sk_live_2"),
+        ):
+            assert paystack_shared.settings.PAYSTACK_SECRET_KEY == "sk_live_2"
+
     @pytest.mark.asyncio
     async def test_paystack_client_init_error(self):
         with patch("app.modules.billing.domain.billing.paystack_shared.settings") as m:

--- a/tests/unit/services/zombies/test_base.py
+++ b/tests/unit/services/zombies/test_base.py
@@ -2,6 +2,7 @@ import pytest
 from typing import Dict
 import asyncio
 from typing import List, Any
+from types import SimpleNamespace
 from unittest.mock import patch
 from app.modules.optimization.domain.ports import BaseZombieDetector
 from app.modules.optimization.domain.plugin import ZombiePlugin
@@ -123,3 +124,20 @@ async def test_base_detector_does_not_swallow_base_exceptions():
 
     with pytest.raises(FatalPluginFailure):
         await detector.scan_all()
+
+
+@pytest.mark.asyncio
+async def test_base_detector_uses_live_plugin_timeout_setting():
+    detector = MockDetector()
+    plugin = MockPlugin("slow_plugin", should_timeout=True)
+    live_settings = SimpleNamespace(ZOMBIE_PLUGIN_TIMEOUT_SECONDS=0.01)
+
+    with patch(
+        "app.modules.optimization.domain.ports.get_settings",
+        return_value=live_settings,
+    ):
+        category_key, items, metadata = await detector._run_plugin_with_timeout(plugin)
+
+    assert category_key == "slow_plugin"
+    assert items == []
+    assert metadata["status"] == "timeout"

--- a/tests/unit/test_main_coverage.py
+++ b/tests/unit/test_main_coverage.py
@@ -53,6 +53,7 @@ async def test_lifespan_flow(mock_lifespan_deps):
     from app.main import lifespan, app
 
     with (
+        patch("app.modules.governance.api.v1.health_dashboard.set_startup_time") as mock_startup,
         patch("app.main.should_bootstrap_local_sqlite", return_value=False),
         patch("app.main.dispose_db_runtime", new_callable=AsyncMock),
     ):
@@ -62,6 +63,7 @@ async def test_lifespan_flow(mock_lifespan_deps):
                 exist_ok=True,
             )
 
+    mock_startup.assert_called_once_with()
     mock_lifespan_deps["dispose"].assert_called_once()
 
 


### PR DESCRIPTION
## Summary
- categorize the full March 27 worktree in `docs/ops/all_changes_categorization_2026-03-27.md`
- consolidate backend runtime, dashboard product-surface, and deployment-handoff changes in one PR
- close the three track issues created for this batch

## Tracks
- closes #345
- closes #346
- closes #347

## Notes
- This is a consolidation PR across the current March 27 runtime and dashboard follow-up snapshot.
- I cleaned ignored local `__pycache__` files before packaging the batch.
- I did not run a fresh full local test suite in this batching turn before opening the PR.
