### PR TITLE
chore: categorize and consolidate all pending changes (2026-04-01)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -291,8 +291,9 @@ __all__ = ["app", "valdrics_app", "lifespan"]
 
 
 def refresh_fastapi_app_metadata(settings_obj: Any | None = None) -> None:
-    global EmissionsTracker
+    global EmissionsTracker, settings
     settings_obj = settings_obj or get_settings()
+    settings = settings_obj
     valdrics_app.title = str(settings_obj.APP_NAME)
     valdrics_app.version = str(settings_obj.VERSION)
     valdrics_app.openapi_schema = None

--- a/app/modules/billing/domain/billing/paystack_client_impl.py
+++ b/app/modules/billing/domain/billing/paystack_client_impl.py
@@ -18,8 +18,13 @@ class PaystackClient:
         if not shared.settings.PAYSTACK_SECRET_KEY:
             raise ValueError("PAYSTACK_SECRET_KEY not configured")
 
-        self.headers: dict[str, str] = {
-            "Authorization": f"Bearer {shared.settings.PAYSTACK_SECRET_KEY}",
+    @staticmethod
+    def _build_headers() -> dict[str, str]:
+        secret = str(shared.settings.PAYSTACK_SECRET_KEY or "").strip()
+        if not secret:
+            raise ValueError("PAYSTACK_SECRET_KEY not configured")
+        return {
+            "Authorization": f"Bearer {secret}",
             "Content-Type": "application/json",
         }
 
@@ -36,7 +41,7 @@ class PaystackClient:
             response = await client.request(
                 method,
                 f"{self.BASE_URL}/{endpoint}",
-                headers=self.headers,
+                headers=self._build_headers(),
                 json=data,
                 timeout=30.0,
             )

--- a/app/modules/governance/domain/scheduler/orchestrator.py
+++ b/app/modules/governance/domain/scheduler/orchestrator.py
@@ -23,6 +23,10 @@ from app.shared.core.ops_metrics import (
 
 logger = structlog.get_logger()
 
+
+def _monotonic_time() -> float:
+    return time.monotonic()
+
 # Arbitrary constant for scheduler advisory locks - DEPRECATED in favor of SELECT FOR UPDATE
 # Keeping for reference of lock inheritance
 SCHEDULER_LOCK_BASE_ID = 48293021
@@ -284,7 +288,7 @@ class SchedulerOrchestrator:
         if not zone:
             return None
 
-        now = time.time()
+        now = _monotonic_time()
         cached = self._carbon_cache.get(region_hint)
         if cached and (now - cached[1]) < 600:
             return cached[0]

--- a/app/modules/governance/domain/scheduler/processors.py
+++ b/app/modules/governance/domain/scheduler/processors.py
@@ -45,8 +45,9 @@ PROCESSOR_RECOVERABLE_ERRORS: tuple[type[Exception], ...] = (
 class AnalysisProcessor:
     """Handles the heavy lifting of analyzing a single tenant's cloud usage."""
 
-    def __init__(self) -> None:
-        self.settings = get_settings()
+    @property
+    def settings(self) -> Any:
+        return get_settings()
 
     @staticmethod
     def _collect_connections(tenant: Tenant) -> list[Any]:

--- a/app/modules/notifications/domain/slack.py
+++ b/app/modules/notifications/domain/slack.py
@@ -37,6 +37,10 @@ _service_cache: dict[tuple[str, str], "SlackService"] = {}
 _service_cache_lock = Lock()
 
 
+def _dedup_now() -> float:
+    return time.monotonic()
+
+
 class SlackService:
     """Service for sending notifications to Slack."""
 
@@ -149,7 +153,7 @@ class SlackService:
         alert_hash = hashlib.sha256(
             f"{title}:{severity}:{msg_hash}".encode()
         ).hexdigest()
-        current_time = time.time()
+        current_time = _dedup_now()
 
         if await self._is_duplicate_alert(alert_hash, current_time):
             logger.info("duplicate_alert_suppressed", title=title)

--- a/app/modules/optimization/domain/actions/aws/rds.py
+++ b/app/modules/optimization/domain/actions/aws/rds.py
@@ -1,15 +1,19 @@
 from typing import Optional
-import time
+from uuid import uuid4
 from app.models.remediation import RemediationAction
 from app.modules.optimization.domain.actions.aws.base import BaseAWSAction
 from app.modules.optimization.domain.actions.base import ExecutionResult, ExecutionStatus, RemediationContext
 from app.modules.optimization.domain.actions.factory import RemediationActionFactory
 
 
+def _snapshot_suffix() -> str:
+    return uuid4().hex[:12]
+
+
 class BaseRDSSnapshotAction(BaseAWSAction):
     async def create_backup(self, resource_id: str, context: RemediationContext) -> Optional[str]:
         """Create a DB snapshot backup before deleting an RDS instance."""
-        snapshot_id = f"valdrics-backup-{resource_id}-{int(time.time())}"
+        snapshot_id = f"valdrics-backup-{resource_id}-{_snapshot_suffix()}"
         async with await self._get_client("rds", context) as rds:
             await rds.create_db_snapshot(
                 DBSnapshotIdentifier=snapshot_id,

--- a/app/modules/optimization/domain/remediation_execute.py
+++ b/app/modules/optimization/domain/remediation_execute.py
@@ -37,6 +37,12 @@ from app.shared.core.security_metrics import REMEDIATION_TOTAL
 from app.shared.core.provider import normalize_provider
 
 logger = structlog.get_logger()
+
+
+def _perf_counter() -> float:
+    return time.perf_counter()
+
+
 _REMEDIATION_COMMON_RECOVERABLE_EXCEPTIONS: tuple[type[Exception], ...] = (
     SQLAlchemyError,
     RuntimeError,
@@ -66,7 +72,7 @@ async def execute_remediation_request(
     *,
     bypass_grace_period: bool = False,
 ) -> RemediationRequest:
-    start_time = time.time()
+    start_time = _perf_counter()
     from app.modules.optimization.domain import remediation as remediation_module
 
     result = await service.db.execute(
@@ -294,7 +300,7 @@ async def execute_remediation_request(
             },
         )
 
-        duration = time.time() - start_time
+        duration = _perf_counter() - start_time
         REMEDIATION_DURATION_SECONDS.labels(
             action=action_value, provider=provider
         ).observe(duration)

--- a/app/shared/core/celery_app.py
+++ b/app/shared/core/celery_app.py
@@ -2,8 +2,6 @@ from celery import Celery
 from app.shared.core.config import get_settings
 from app.shared.core.runtime_dependencies import validate_runtime_dependencies
 
-settings = get_settings()
-
 CELERY_TASK_MODULES = ["app.tasks.scheduler_tasks", "app.tasks.license_tasks"]
 
 
@@ -74,8 +72,7 @@ def refresh_celery_app_config(settings_obj=None) -> None:
             broker_connection_retry_on_startup=False,  # Never block in tests
         )
 
-
-refresh_celery_app_config(settings)
+refresh_celery_app_config()
 
 if __name__ == "__main__":
     celery_app.start()

--- a/app/shared/core/circuit_breaker.py
+++ b/app/shared/core/circuit_breaker.py
@@ -10,7 +10,7 @@ import time
 from enum import Enum
 from collections.abc import Awaitable, Callable
 from typing import Any, Optional, TypeVar
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from redis.exceptions import RedisError
 from sqlalchemy.exc import SQLAlchemyError
 import structlog
@@ -19,6 +19,10 @@ from app.shared.core.exceptions import ExternalAPIError
 
 logger = structlog.get_logger()
 T = TypeVar("T")
+
+
+def _monotonic_time() -> float:
+    return time.monotonic()
 
 CIRCUIT_BREAKER_CONFIG_RECOVERABLE_ERRORS: tuple[type[Exception], ...] = (
     RuntimeError,
@@ -85,6 +89,8 @@ class CircuitBreakerMetrics:
     consecutive_successes: int = 0
     last_failure_time: Optional[float] = None
     last_success_time: Optional[float] = None
+    last_failure_monotonic: Optional[float] = None
+    last_success_monotonic: Optional[float] = None
     state_changes: int = 0
 
 class CircuitBreaker:
@@ -190,6 +196,7 @@ class CircuitBreaker:
             last_failure_text = self._as_text(last_failure_raw)
             if last_failure_text:
                 self.metrics.last_failure_time = float(last_failure_text)
+                self.metrics.last_failure_monotonic = None
         except CIRCUIT_BREAKER_DISTRIBUTED_RECOVERABLE_ERRORS as exc:
             logger.warning(
                 "circuit_breaker_distributed_sync_failed",
@@ -211,6 +218,8 @@ class CircuitBreaker:
             if new_state == CircuitState.OPEN:
                 if self.metrics.last_failure_time is None:
                     self.metrics.last_failure_time = time.time()
+                if self.metrics.last_failure_monotonic is None:
+                    self.metrics.last_failure_monotonic = _monotonic_time()
                 pipeline.set(failure_key, f"{self.metrics.last_failure_time:.6f}")
             elif new_state == CircuitState.CLOSED:
                 pipeline.delete(failure_key)
@@ -262,6 +271,12 @@ class CircuitBreaker:
         if self.state != CircuitState.OPEN:
             return False
 
+        if self.metrics.last_failure_monotonic is not None:
+            return (
+                _monotonic_time() - self.metrics.last_failure_monotonic
+                >= self.config.timeout
+            )
+
         if self.metrics.last_failure_time is None:
             return True
 
@@ -274,6 +289,7 @@ class CircuitBreaker:
         self.metrics.consecutive_successes += 1
         self.metrics.consecutive_failures = 0
         self.metrics.last_success_time = time.time()
+        self.metrics.last_success_monotonic = _monotonic_time()
 
         # Check if we should close the circuit
         if (
@@ -290,6 +306,7 @@ class CircuitBreaker:
         self.metrics.consecutive_failures += 1
         self.metrics.consecutive_successes = 0
         self.metrics.last_failure_time = time.time()
+        self.metrics.last_failure_monotonic = _monotonic_time()
 
         # Check if we should open the circuit
         if (
@@ -430,14 +447,23 @@ class CircuitBreaker:
 # Global circuit breaker registry
 _circuit_breakers: dict[str, CircuitBreaker] = {}
 
+
+def _normalize_circuit_breaker_config(
+    name: str, config: Optional[CircuitBreakerConfig]
+) -> CircuitBreakerConfig:
+    normalized = config or CircuitBreakerConfig(name=name)
+    if normalized.name != name:
+        return replace(normalized, name=name)
+    return normalized
+
 def get_circuit_breaker(
     name: str, config: Optional[CircuitBreakerConfig] = None
 ) -> CircuitBreaker:
     """Get or create a circuit breaker by name."""
-    if name not in _circuit_breakers:
-        if config is None:
-            config = CircuitBreakerConfig(name=name)
-        _circuit_breakers[name] = CircuitBreaker(config)
+    normalized_config = _normalize_circuit_breaker_config(name, config)
+    existing = _circuit_breakers.get(name)
+    if existing is None or existing.config != normalized_config:
+        _circuit_breakers[name] = CircuitBreaker(normalized_config)
 
     return _circuit_breakers[name]
 

--- a/app/shared/core/currency.py
+++ b/app/shared/core/currency.py
@@ -33,7 +33,7 @@ logger = structlog.get_logger()
 # key: currency code
 # value: (rate_vs_usd, updated_timestamp, provider_name)
 _RATES_CACHE: dict[str, tuple[Decimal, float, Optional[str]]] = {
-    "USD": (Decimal("1.0"), time.time(), "internal")
+    "USD": (Decimal("1.0"), time.monotonic(), "internal")
 }
 _L1_TTL_SECONDS = 300.0
 
@@ -119,7 +119,7 @@ class ExchangeRateService:
 
     @staticmethod
     def _write_l1_rate(currency: str, rate: Decimal, provider: Optional[str]) -> None:
-        _RATES_CACHE[currency] = (rate, time.time(), provider)
+        _RATES_CACHE[currency] = (rate, time.monotonic(), provider)
 
     async def _read_db_rate(
         self, to_currency: str
@@ -329,7 +329,7 @@ class ExchangeRateService:
         if currency == "USD":
             return Decimal("1.0")
 
-        now_ts = time.time()
+        now_ts = time.monotonic()
         max_age_seconds = self.cache_ttl_hours * 3600
 
         # L1: in-memory cache

--- a/app/shared/core/performance_benchmarking.py
+++ b/app/shared/core/performance_benchmarking.py
@@ -15,6 +15,10 @@ import structlog
 logger = structlog.get_logger()
 
 
+def _perf_counter() -> float:
+    return time.perf_counter()
+
+
 @dataclass
 class BenchmarkResult:
     """Results from a benchmark test."""
@@ -49,13 +53,13 @@ class PerformanceBenchmark:
             await func(*args, **kwargs)
 
         times: list[float] = []
-        start_time = time.time()
+        start_time = _perf_counter()
         for _ in range(iterations):
-            iteration_start = time.perf_counter()
+            iteration_start = _perf_counter()
             await func(*args, **kwargs)
-            times.append(time.perf_counter() - iteration_start)
+            times.append(_perf_counter() - iteration_start)
 
-        total_time = time.time() - start_time
+        total_time = _perf_counter() - start_time
 
         result = BenchmarkResult(
             name=f"{self.name}_{func.__name__}",
@@ -96,18 +100,18 @@ class PerformanceBenchmark:
         def run_benchmark() -> list[float]:
             times: list[float] = []
             for _ in range(iterations):
-                iteration_start = time.perf_counter()
+                iteration_start = _perf_counter()
                 func(*args, **kwargs)
-                times.append(time.perf_counter() - iteration_start)
+                times.append(_perf_counter() - iteration_start)
             return times
 
         with ThreadPoolExecutor(max_workers=1) as executor:
             executor.submit(run_warmup).result()
 
-        start_time = time.time()
+        start_time = _perf_counter()
         with ThreadPoolExecutor(max_workers=1) as executor:
             times = executor.submit(run_benchmark).result()
-        total_time = time.time() - start_time
+        total_time = _perf_counter() - start_time
 
         result = BenchmarkResult(
             name=f"{self.name}_{func.__name__}",

--- a/app/shared/core/performance_testing.py
+++ b/app/shared/core/performance_testing.py
@@ -14,6 +14,7 @@ import tempfile
 from typing import Dict, Any, List
 from dataclasses import dataclass, field
 from datetime import timedelta
+from uuid import uuid4
 import httpx
 import structlog
 
@@ -32,6 +33,14 @@ logger = structlog.get_logger()
 PERFORMANCE_LOAD_REQUEST_RECOVERABLE_EXCEPTIONS: tuple[type[Exception], ...] = (httpx.HTTPError, RuntimeError, OSError, TimeoutError, TypeError, ValueError, ArithmeticError)
 PERFORMANCE_BASELINE_LOAD_RECOVERABLE_EXCEPTIONS: tuple[type[Exception], ...] = (OSError, TypeError, ValueError)
 PERFORMANCE_BASELINE_SAVE_RECOVERABLE_EXCEPTIONS: tuple[type[Exception], ...] = (OSError, TypeError, ValueError)
+
+
+def _monotonic_time() -> float:
+    return time.monotonic()
+
+
+def _perf_counter() -> float:
+    return time.perf_counter()
 
 
 def _default_baseline_file() -> str:
@@ -104,7 +113,7 @@ class LoadTester:
         )
 
         self._running = True
-        start_time = time.time()
+        start_time = _monotonic_time()
 
         # Create concurrent tasks
         tasks = []
@@ -115,7 +124,7 @@ class LoadTester:
         # Wait for all tasks to complete
         await asyncio.gather(*tasks, return_exceptions=True)
 
-        end_time = time.time()
+        end_time = _monotonic_time()
         total_duration = end_time - start_time
 
         # Calculate final metrics
@@ -146,22 +155,20 @@ class LoadTester:
             ) * self.config.ramp_up_seconds
             await self._sleep(delay)
 
-        time.time()
-
         while (
             self._running
-            and (time.time() - test_start_time) < self.config.duration_seconds
+            and (_monotonic_time() - test_start_time) < self.config.duration_seconds
         ):
             for endpoint in self.config.endpoints:
                 if not self._running:
                     break
 
-                request_start = time.time()
+                request_start = _perf_counter()
                 try:
                     url = f"{self.config.target_url}{endpoint}"
                     response = await client.get(url, headers=self.config.headers)
 
-                    response_time = time.time() - request_start
+                    response_time = _perf_counter() - request_start
 
                     # Record metrics
                     self.results.total_requests += 1
@@ -200,7 +207,7 @@ class LoadTester:
                     )
 
                 except PERFORMANCE_LOAD_REQUEST_RECOVERABLE_EXCEPTIONS as e:
-                    response_time = time.time() - request_start
+                    response_time = _perf_counter() - request_start
                     self.results.total_requests += 1
                     self.results.failed_requests += 1
                     self.results.errors.append(
@@ -277,7 +284,7 @@ async def benchmark_cache_operations() -> BenchmarkResult:
     cache = get_cache_service()
 
     async def cache_set_get() -> None:
-        key = f"benchmark_{time.time()}"
+        key = f"benchmark_{uuid4().hex}"
         await cache.set(key, "test_value", ttl=timedelta(seconds=60))
         await cache.get(key)
 

--- a/app/shared/core/pricing_cache.py
+++ b/app/shared/core/pricing_cache.py
@@ -55,7 +55,10 @@ def runtime_cache_set(tenant_key: str, tier: PricingTier, *, now: float | None =
                 _tenant_tier_runtime_cache.pop(key, None)
 
         while len(_tenant_tier_runtime_cache) > _TENANT_TIER_CACHE_MAX_ENTRIES:
-            oldest_key = next(iter(_tenant_tier_runtime_cache))
+            oldest_key = min(
+                _tenant_tier_runtime_cache,
+                key=lambda cache_key: _tenant_tier_runtime_cache[cache_key][0],
+            )
             _tenant_tier_runtime_cache.pop(oldest_key, None)
 
 

--- a/app/shared/core/rate_limit.py
+++ b/app/shared/core/rate_limit.py
@@ -5,6 +5,7 @@ Provides API rate limiting using slowapi (built on limits library).
 Configurable via environment variables.
 """
 
+import time
 from typing import Any, Callable, Optional, cast
 from slowapi import Limiter, _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
@@ -45,6 +46,10 @@ ANALYSIS_TIER_RESOLUTION_RECOVERABLE_EXCEPTIONS = (
     RuntimeError,
 )
 REMEDIATION_REDIS_RATE_LIMIT_RECOVERABLE_EXCEPTIONS = (RedisError, OSError, RuntimeError)
+
+
+def _monotonic_time() -> float:
+    return time.monotonic()
 
 
 def context_aware_key(request: Request) -> str:
@@ -334,7 +339,6 @@ async def check_remediation_rate_limit(
     Returns True if allowed, False if rate limited.
     Uses Redis if available, memory fallback otherwise.
     """
-    import time
     from uuid import UUID
 
     tenant_key = str(tenant_id) if isinstance(tenant_id, UUID) else tenant_id
@@ -375,7 +379,7 @@ async def check_remediation_rate_limit(
         return False
 
     # Memory fallback for local/single-instance deployments
-    current_time = time.time()
+    current_time = _monotonic_time()
     window_key = f"{tenant_key}:{action}"
     _cleanup_stale_remediation_counts(current_time)
 

--- a/app/shared/core/retry.py
+++ b/app/shared/core/retry.py
@@ -86,21 +86,7 @@ class RetryManager:
 
     def __init__(self, operation_type: str = "default") -> None:
         self.operation_type = operation_type
-        self.config: RetryConfig = RETRY_CONFIGS.get(
-            operation_type,
-            {
-                "max_attempts": 3,
-                "min_wait": 0.1,
-                "max_wait": 2.0,
-                "multiplier": 2.0,
-                "exceptions": (
-                    sqlalchemy.exc.OperationalError,
-                    sqlalchemy.exc.InterfaceError,
-                    asyncio.TimeoutError,
-                    ConnectionError,
-                ),
-            },
-        )
+        self.config = get_retry_config(operation_type)
 
     def _calculate_backoff(self, attempt: int) -> float:
         """Calculate exponential backoff with jitter."""

--- a/app/shared/core/safety_service.py
+++ b/app/shared/core/safety_service.py
@@ -26,7 +26,9 @@ logger = structlog.get_logger()
 class SafetyGuardrailService:
     def __init__(self, db: AsyncSession):
         self.db = db
-        self._settings = get_settings()
+
+    def _get_settings(self):
+        return get_settings()
 
     async def check_all_guards(
         self, tenant_id: UUID, estimated_impact: Decimal = Decimal("0")
@@ -50,8 +52,9 @@ class SafetyGuardrailService:
         """Checks if the daily savings limit has been reached for the configured scope."""
         estimated_impact = estimated_impact or Decimal("0")
         today = datetime.now(timezone.utc).date()
+        settings = self._get_settings()
         configured_scope = str(
-            getattr(self._settings, "REMEDIATION_KILL_SWITCH_SCOPE", "tenant") or "tenant"
+            getattr(settings, "REMEDIATION_KILL_SWITCH_SCOPE", "tenant") or "tenant"
         ).strip().lower()
         if configured_scope not in {"tenant", "global"}:
             logger.warning(
@@ -72,7 +75,7 @@ class SafetyGuardrailService:
         result = await self.db.execute(query)
         total_impact = result.scalar() or Decimal("0")
 
-        threshold = Decimal(str(self._settings.REMEDIATION_KILL_SWITCH_THRESHOLD))
+        threshold = Decimal(str(settings.REMEDIATION_KILL_SWITCH_THRESHOLD))
 
         if (total_impact + estimated_impact) >= threshold:
             logger.error(

--- a/app/shared/core/timeout.py
+++ b/app/shared/core/timeout.py
@@ -69,14 +69,7 @@ class TimeoutManager:
 
     def __init__(self, operation_type: str = "default"):
         self.operation_type = operation_type
-        self.config = TIMEOUT_CONFIGS.get(
-            operation_type,
-            {
-                "total": 30.0,
-                "connect": 10.0,
-                "read": 20.0,
-            },
-        )
+        self.config = get_timeout_config(operation_type)
 
     async def execute_with_timeout(
         self,

--- a/app/shared/db/session.py
+++ b/app/shared/db/session.py
@@ -454,7 +454,7 @@ def check_rls_policy(
         conn=conn,
         statement=statement,
         parameters=parameters,
-        settings_obj=settings,
+        settings_obj=get_settings(),
         rls_exempt_table_pattern=_RLS_EXEMPT_TABLE_PATTERN,
         rls_context_missing_metric=RLS_CONTEXT_MISSING,
         rls_metric_recoverable_errors=RLS_METRIC_RECOVERABLE_ERRORS,

--- a/app/shared/llm/circuit_breaker.py
+++ b/app/shared/llm/circuit_breaker.py
@@ -22,6 +22,7 @@ Usage:
         # Fall back to next provider
 """
 
+import time
 from datetime import datetime, timezone
 from dataclasses import dataclass
 from enum import Enum
@@ -33,6 +34,10 @@ from threading import RLock
 
 logger = structlog.get_logger()
 FATAL_EXCEPTIONS = (SystemExit, KeyboardInterrupt, GeneratorExit)
+
+
+def _monotonic_time() -> float:
+    return time.monotonic()
 
 
 class CircuitState(str, Enum):
@@ -51,6 +56,8 @@ class ProviderCircuit:
     success_count: int = 0
     last_failure_time: Optional[datetime] = None
     last_success_time: Optional[datetime] = None
+    last_failure_monotonic: Optional[float] = None
+    last_success_monotonic: Optional[float] = None
     probe_in_flight: bool = False
 
     # Thresholds
@@ -104,7 +111,18 @@ class LLMCircuitBreaker:
 
             if circuit.state == CircuitState.OPEN:
                 # Check if recovery timeout has passed
-                if circuit.last_failure_time:
+                if circuit.last_failure_monotonic is not None:
+                    elapsed = _monotonic_time() - circuit.last_failure_monotonic
+                    if elapsed >= circuit.recovery_timeout:
+                        # Transition to half-open
+                        circuit.state = CircuitState.HALF_OPEN
+                        logger.info(
+                            "circuit_half_open",
+                            provider=provider,
+                            message="Testing recovery",
+                        )
+                        return True
+                elif circuit.last_failure_time:
                     elapsed = (now - circuit.last_failure_time).total_seconds()
                     if elapsed >= circuit.recovery_timeout:
                         # Transition to half-open
@@ -132,9 +150,15 @@ class LLMCircuitBreaker:
                 return True
 
             if circuit.state == CircuitState.OPEN:
-                if circuit.last_failure_time is None:
+                if (
+                    circuit.last_failure_monotonic is None
+                    and circuit.last_failure_time is None
+                ):
                     return False
-                elapsed = (now - circuit.last_failure_time).total_seconds()
+                if circuit.last_failure_monotonic is not None:
+                    elapsed = _monotonic_time() - circuit.last_failure_monotonic
+                else:
+                    elapsed = (now - circuit.last_failure_time).total_seconds()
                 if elapsed < circuit.recovery_timeout:
                     return False
                 circuit.state = CircuitState.HALF_OPEN
@@ -160,6 +184,7 @@ class LLMCircuitBreaker:
             circuit = self._get_circuit(provider)
             circuit.success_count += 1
             circuit.last_success_time = datetime.now(timezone.utc)
+            circuit.last_success_monotonic = _monotonic_time()
 
             if circuit.state == CircuitState.HALF_OPEN:
                 if circuit.success_count >= circuit.success_threshold:
@@ -185,6 +210,7 @@ class LLMCircuitBreaker:
             circuit = self._get_circuit(provider)
             circuit.failure_count += 1
             circuit.last_failure_time = datetime.now(timezone.utc)
+            circuit.last_failure_monotonic = _monotonic_time()
             circuit.success_count = 0  # Reset success count
             circuit.probe_in_flight = False
 

--- a/app/shared/llm/hybrid_scheduler.py
+++ b/app/shared/llm/hybrid_scheduler.py
@@ -81,16 +81,40 @@ class HybridAnalysisScheduler:
 
     def __init__(self, db: AsyncSession):
         self.db = db
-        self.cache = get_cache_service()
-        self.delta_service = DeltaAnalysisService(self.cache)
+        self._cache: Any | None = None
+        self._delta_service: DeltaAnalysisService | None = None
+        self._delta_service_cache: Any | None = None
         self._analyzer: FinOpsAnalyzer | None = None
         self._analyzer_provider: str | None = None
         self._analyzer_is_injected = False
         # Capture dependencies at construction for deterministic behavior in tests
         # that patch these symbols during scheduler creation.
+        self._cache_service_getter = get_cache_service
+        self._delta_service_cls = DeltaAnalysisService
         self._llm_factory_create = LLMFactory.create
         self._settings_getter = get_settings
         self._analyzer_cls = FinOpsAnalyzer
+
+    def _get_cache(self) -> Any:
+        cache = self._cache_service_getter()
+        if self._cache is not cache:
+            self._cache = cache
+            if self._delta_service_cache is not cache:
+                self._delta_service = None
+                self._delta_service_cache = None
+        return cache
+
+    @property
+    def cache(self) -> Any:
+        return self._get_cache()
+
+    @property
+    def delta_service(self) -> DeltaAnalysisService:
+        cache = self._get_cache()
+        if self._delta_service is None or self._delta_service_cache is not cache:
+            self._delta_service = self._delta_service_cls(cache)
+            self._delta_service_cache = cache
+        return self._delta_service
 
     def set_analyzer(self, value: FinOpsAnalyzer) -> None:
         """Inject an analyzer instance explicitly."""

--- a/app/shared/remediation/circuit_breaker.py
+++ b/app/shared/remediation/circuit_breaker.py
@@ -11,7 +11,6 @@ import structlog
 from app.shared.core.config import get_settings
 
 logger = structlog.get_logger()
-settings = get_settings()
 REDIS_CLIENT_RESOLUTION_RECOVERABLE_EXCEPTIONS = (
     ImportError,
     AttributeError,
@@ -20,6 +19,10 @@ REDIS_CLIENT_RESOLUTION_RECOVERABLE_EXCEPTIONS = (
     TypeError,
     ValueError,
 )
+
+
+def _monotonic_time() -> float:
+    return time.monotonic()
 
 
 class CircuitState(str, Enum):
@@ -142,6 +145,16 @@ class CircuitBreaker:
         state = await self.get_state()
 
         if state == CircuitState.OPEN.value or state == CircuitState.OPEN:
+            if self.state.redis is None:
+                last_fail_monotonic = await self.state.get("last_failure_monotonic")
+                if (
+                    last_fail_monotonic
+                    and (_monotonic_time() - float(last_fail_monotonic))
+                    > self.config.recovery_timeout_seconds
+                ):
+                    await self.state.set("state", CircuitState.HALF_OPEN.value)
+                    logger.info("circuit_breaker_half_open", tenant_id=self.tenant_id)
+                    return True
             last_fail = await self.state.get("last_failure_at")
             if (
                 last_fail
@@ -200,6 +213,8 @@ class CircuitBreaker:
 
         count = await self.state.incr("failure_count")
         await self.state.set("last_failure_at", time.time())
+        if self.state.redis is None:
+            await self.state.set("last_failure_monotonic", _monotonic_time())
         await self.state.set("last_error", error)
 
         if count >= self.config.failure_threshold:
@@ -224,6 +239,7 @@ class CircuitBreaker:
         await self.state.set("state", CircuitState.CLOSED.value)
         await self.state.set("failure_count", 0)
         await self.state.delete("last_failure_at")
+        await self.state.delete("last_failure_monotonic")
         await self.state.delete("last_error")
 
     async def get_status(self) -> Dict[str, Any]:

--- a/app/tasks/scheduler_sweep_ops.py
+++ b/app/tasks/scheduler_sweep_ops.py
@@ -26,6 +26,11 @@ SCHEDULER_SWEEP_RECOVERABLE_ERRORS = (
     ValueError,
 )
 
+
+def _perf_counter() -> float:
+    return time.perf_counter()
+
+
 async def billing_sweep_logic(
     *,
     open_db_session_fn: Callable[[], Any],
@@ -147,7 +152,7 @@ async def acceptance_sweep_logic(
     asyncio_module: Any,
 ) -> None:
     job_name = "daily_acceptance_sweep"
-    start_time = time.time()
+    start_time = _perf_counter()
     max_retries = 3
     retry_count = 0
 
@@ -243,7 +248,7 @@ async def acceptance_sweep_logic(
                 else:
                     await asyncio_module.sleep(2 ** (retry_count - 1))
 
-        duration = time.time() - start_time
+        duration = _perf_counter() - start_time
         scheduler_job_duration.labels(job_name=job_name).observe(duration)
 
 

--- a/app/tasks/scheduler_sweep_runtime.py
+++ b/app/tasks/scheduler_sweep_runtime.py
@@ -5,6 +5,13 @@ from contextlib import asynccontextmanager
 from typing import Any, AsyncIterator, Awaitable, Callable
 
 
+def _perf_counter_from_time_module(time_module: Any) -> float:
+    perf_counter = getattr(time_module, "perf_counter", None)
+    if callable(perf_counter):
+        return float(perf_counter())
+    return float(time_module.time())
+
+
 @asynccontextmanager
 async def open_transaction_session(
     *,
@@ -35,7 +42,7 @@ async def run_sweep_with_retries(
     recoverable_errors: tuple[type[Exception], ...],
     run_once: Callable[[], Awaitable[None]],
 ) -> None:
-    start_time = time_module.time()
+    start_time = _perf_counter_from_time_module(time_module)
     retry_count = 0
 
     while retry_count < max_retries:
@@ -51,7 +58,7 @@ async def run_sweep_with_retries(
             else:
                 await asyncio_module.sleep(2 ** (retry_count - 1))
 
-    duration = time_module.time() - start_time
+    duration = _perf_counter_from_time_module(time_module) - start_time
     scheduler_job_duration.labels(job_name=job_name).observe(duration)
 
 

--- a/app/tasks/scheduler_tasks.py
+++ b/app/tasks/scheduler_tasks.py
@@ -73,6 +73,10 @@ _scheduler_async_runner: asyncio.Runner | None = None
 _scheduler_async_runner_lock = Lock()
 
 
+def _perf_counter() -> float:
+    return time.perf_counter()
+
+
 async def _load_active_remediation_connections(
     db: AsyncSession, *args: Any, **kwargs: Any
 ) -> list[Any]:
@@ -201,7 +205,7 @@ async def _cohort_analysis_logic(target_cohort: TenantCohort) -> None:
     )
 
     job_name = f"cohort_{target_cohort.value.lower()}_enqueue"
-    start_time = time.time()
+    start_time = _perf_counter()
     max_retries = 3
     retry_count = 0
 
@@ -355,7 +359,7 @@ async def _cohort_analysis_logic(target_cohort: TenantCohort) -> None:
                 SCHEDULER_JOB_RUNS.labels(job_name=job_name, status="failure").inc()
                 break
 
-        duration = time.time() - start_time
+        duration = _perf_counter() - start_time
         SCHEDULER_JOB_DURATION.labels(job_name=job_name).observe(duration)
 
 @shared_task(
@@ -489,7 +493,7 @@ def run_refresh_landing_funnel_health() -> None:
 
 async def _refresh_landing_funnel_health_logic() -> None:
     job_name = "landing_funnel_health_refresh"
-    start_time = time.time()
+    start_time = _perf_counter()
 
     try:
         await _refresh_landing_funnel_health_logic_impl(
@@ -510,7 +514,7 @@ async def _refresh_landing_funnel_health_logic() -> None:
         raise
     finally:
         SCHEDULER_JOB_DURATION.labels(job_name=job_name).observe(
-            time.time() - start_time
+            _perf_counter() - start_time
         )
 
 @shared_task(
@@ -531,7 +535,7 @@ async def _process_background_jobs_logic() -> None:
         int(getattr(settings, "BACKGROUND_JOB_PROCESS_MAX_BATCHES_PER_TICK", 8)),
     )
     job_name = "background_job_processing"
-    start_time = time.time()
+    start_time = _perf_counter()
     totals = {"processed": 0, "succeeded": 0, "failed": 0, "batches": 0}
 
     with _scheduler_span("scheduler.process_background_jobs", job_name=job_name):
@@ -555,7 +559,7 @@ async def _process_background_jobs_logic() -> None:
             raise
         finally:
             SCHEDULER_JOB_DURATION.labels(job_name=job_name).observe(
-                time.time() - start_time
+                _perf_counter() - start_time
             )
 
 @shared_task(
@@ -604,7 +608,7 @@ async def _enforcement_reconciliation_sweep_logic() -> None:
 @shared_task(name="scheduler.daily_scan")  # type: ignore[untyped-decorator]
 def daily_finops_scan() -> None:
     logger.info("daily_finops_scan_started")
-    start_time = time.time()
+    start_time = _perf_counter()
     successful_dispatches = 0
     failed_dispatches = 0
 
@@ -619,7 +623,7 @@ def daily_finops_scan() -> None:
                 "daily_finops_scan_partial_failure", cohort=cohort.value, error=str(e)
             )
 
-    duration = time.time() - start_time
+    duration = _perf_counter() - start_time
     logger.info(
         "daily_finops_scan_completed",
         duration_seconds=duration,

--- a/dashboard/src/lib/components/EnforcementSettingsAdvancedSection.svelte
+++ b/dashboard/src/lib/components/EnforcementSettingsAdvancedSection.svelte
@@ -1,0 +1,274 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import {
+		createEnforcementCredit,
+		loadEnforcementBudgets,
+		loadEnforcementCredits,
+		saveEnforcementBudget
+	} from './enforcementSettingsApi';
+	import type { EnforcementBudget, EnforcementCredit } from './enforcementSettingsModel';
+
+	let { accessToken }: { accessToken?: string | null } = $props();
+
+	let budgets = $state<EnforcementBudget[]>([]);
+	let credits = $state<EnforcementCredit[]>([]);
+	let loading = $state(true);
+	let savingBudget = $state(false);
+	let savingCredit = $state(false);
+	let error = $state('');
+	let success = $state('');
+
+	let budgetForm = $state({
+		scope_key: 'default',
+		monthly_limit_usd: 0,
+		active: true
+	});
+
+	let creditForm = $state({
+		scope_key: 'default',
+		total_amount_usd: 0,
+		expires_at: '',
+		reason: ''
+	});
+
+	async function loadAdvancedState() {
+		loading = true;
+		error = '';
+		success = '';
+		try {
+			if (!accessToken) {
+				budgets = [];
+				credits = [];
+				return;
+			}
+			const [nextBudgets, nextCredits] = await Promise.all([
+				loadEnforcementBudgets(accessToken),
+				loadEnforcementCredits(accessToken)
+			]);
+			budgets = nextBudgets;
+			credits = nextCredits;
+		} catch (nextError) {
+			const err = nextError as Error;
+			error = err.message || 'Failed to load budget and credit controls';
+		} finally {
+			loading = false;
+		}
+	}
+
+	async function upsertBudget() {
+		savingBudget = true;
+		error = '';
+		success = '';
+		try {
+			const payload = {
+				scope_key: budgetForm.scope_key.trim() || 'default',
+				monthly_limit_usd: Number(budgetForm.monthly_limit_usd),
+				active: budgetForm.active
+			};
+			await saveEnforcementBudget(accessToken, payload);
+			await loadAdvancedState();
+			success = 'Enforcement budget saved.';
+		} catch (nextError) {
+			const err = nextError as Error;
+			error = err.message || 'Failed to save enforcement budget';
+		} finally {
+			savingBudget = false;
+		}
+	}
+
+	async function createCredit() {
+		savingCredit = true;
+		error = '';
+		success = '';
+		try {
+			const payload = {
+				scope_key: creditForm.scope_key.trim() || 'default',
+				total_amount_usd: Number(creditForm.total_amount_usd),
+				expires_at: creditForm.expires_at ? new Date(creditForm.expires_at).toISOString() : null,
+				reason: creditForm.reason.trim() || null
+			};
+			await createEnforcementCredit(accessToken, payload);
+			creditForm = {
+				scope_key: creditForm.scope_key,
+				total_amount_usd: 0,
+				expires_at: '',
+				reason: ''
+			};
+			await loadAdvancedState();
+			success = 'Enforcement credit created.';
+		} catch (nextError) {
+			const err = nextError as Error;
+			error = err.message || 'Failed to create enforcement credit';
+		} finally {
+			savingCredit = false;
+		}
+	}
+
+	onMount(() => {
+		void loadAdvancedState();
+	});
+</script>
+
+<div class="space-y-6">
+	{#if error}
+		<div role="alert" class="card border-danger-500/50 bg-danger-500/10">
+			<p class="text-danger-400 text-sm">{error}</p>
+		</div>
+	{/if}
+
+	{#if success}
+		<div role="status" class="card border-success-500/50 bg-success-500/10">
+			<p class="text-success-400 text-sm">{success}</p>
+		</div>
+	{/if}
+
+	<div class="pt-4 border-t border-ink-700">
+		<h3 class="text-sm font-semibold mb-3">Budget Allocations</h3>
+		<div class="grid grid-cols-1 md:grid-cols-3 gap-3 mb-3">
+			<div class="form-group">
+				<label for="enforcement_budget_scope">Scope Key</label>
+				<input
+					id="enforcement_budget_scope"
+					bind:value={budgetForm.scope_key}
+					aria-label="Enforcement budget scope key"
+				/>
+			</div>
+			<div class="form-group">
+				<label for="enforcement_budget_limit">Monthly Limit (USD)</label>
+				<input
+					type="number"
+					id="enforcement_budget_limit"
+					min="0"
+					step="0.01"
+					bind:value={budgetForm.monthly_limit_usd}
+					aria-label="Enforcement budget monthly limit"
+				/>
+			</div>
+			<label class="flex items-center gap-3 cursor-pointer mt-7">
+				<input
+					type="checkbox"
+					class="toggle"
+					bind:checked={budgetForm.active}
+					aria-label="Enforcement budget active"
+				/>
+				<span>Active</span>
+			</label>
+		</div>
+		<button
+			type="button"
+			class="btn btn-secondary mb-3"
+			onclick={upsertBudget}
+			disabled={savingBudget}
+			aria-label="Save enforcement budget"
+		>
+			{savingBudget ? '⏳ Saving...' : 'Save Budget'}
+		</button>
+
+		{#if loading}
+			<div class="skeleton h-4 w-48"></div>
+		{:else if budgets.length === 0}
+			<p class="text-xs text-ink-500">No budgets configured yet.</p>
+		{:else}
+			<div class="overflow-x-auto">
+				<table class="w-full text-sm">
+					<thead>
+						<tr class="text-left text-ink-500">
+							<th class="py-2">Scope</th>
+							<th class="py-2">Monthly Limit</th>
+							<th class="py-2">Active</th>
+						</tr>
+					</thead>
+					<tbody>
+						{#each budgets as row (row.id)}
+							<tr class="border-t border-ink-700">
+								<td class="py-2">{row.scope_key}</td>
+								<td class="py-2">${Number(row.monthly_limit_usd).toFixed(2)}</td>
+								<td class="py-2">{row.active ? 'yes' : 'no'}</td>
+							</tr>
+						{/each}
+					</tbody>
+				</table>
+			</div>
+		{/if}
+	</div>
+
+	<div class="pt-4 border-t border-ink-700">
+		<h3 class="text-sm font-semibold mb-3">Credits</h3>
+		<div class="grid grid-cols-1 md:grid-cols-2 gap-3 mb-3">
+			<div class="form-group">
+				<label for="enforcement_credit_scope">Scope Key</label>
+				<input
+					id="enforcement_credit_scope"
+					bind:value={creditForm.scope_key}
+					aria-label="Enforcement credit scope key"
+				/>
+			</div>
+			<div class="form-group">
+				<label for="enforcement_credit_total">Credit Amount (USD)</label>
+				<input
+					type="number"
+					id="enforcement_credit_total"
+					min="0.01"
+					step="0.01"
+					bind:value={creditForm.total_amount_usd}
+					aria-label="Enforcement credit total amount"
+				/>
+			</div>
+			<div class="form-group">
+				<label for="enforcement_credit_expiry">Expiry (optional)</label>
+				<input
+					type="datetime-local"
+					id="enforcement_credit_expiry"
+					bind:value={creditForm.expires_at}
+					aria-label="Enforcement credit expiry"
+				/>
+			</div>
+			<div class="form-group">
+				<label for="enforcement_credit_reason">Reason (optional)</label>
+				<input
+					id="enforcement_credit_reason"
+					bind:value={creditForm.reason}
+					aria-label="Enforcement credit reason"
+				/>
+			</div>
+		</div>
+		<button
+			type="button"
+			class="btn btn-secondary mb-3"
+			onclick={createCredit}
+			disabled={savingCredit}
+			aria-label="Create enforcement credit"
+		>
+			{savingCredit ? '⏳ Saving...' : 'Create Credit'}
+		</button>
+
+		{#if loading}
+			<div class="skeleton h-4 w-48"></div>
+		{:else if credits.length === 0}
+			<p class="text-xs text-ink-500">No credits available.</p>
+		{:else}
+			<div class="overflow-x-auto">
+				<table class="w-full text-sm">
+					<thead>
+						<tr class="text-left text-ink-500">
+							<th class="py-2">Scope</th>
+							<th class="py-2">Remaining</th>
+							<th class="py-2">Expires</th>
+						</tr>
+					</thead>
+					<tbody>
+						{#each credits as row (row.id)}
+							<tr class="border-t border-ink-700">
+								<td class="py-2">{row.scope_key}</td>
+								<td class="py-2">${Number(row.remaining_amount_usd).toFixed(2)}</td>
+								<td class="py-2">
+									{row.expires_at ? new Date(row.expires_at).toLocaleString() : 'none'}
+								</td>
+							</tr>
+						{/each}
+					</tbody>
+				</table>
+			</div>
+		{/if}
+	</div>
+</div>

--- a/dashboard/src/lib/components/EnforcementSettingsCard.svelte
+++ b/dashboard/src/lib/components/EnforcementSettingsCard.svelte
@@ -4,21 +4,8 @@
 	import { TimeoutError } from '$lib/fetchWithTimeout';
 	import { formatValidationIssues } from '$lib/validation/clientZod';
 	import EnforcementSettingsCardView from './EnforcementSettingsCardView.svelte';
-	import {
-		createEnforcementCredit,
-		loadEnforcementBudgets,
-		loadEnforcementCredits,
-		loadEnforcementPolicy,
-		saveEnforcementBudget,
-		saveEnforcementPolicy
-	} from './enforcementSettingsApi';
-	import {
-		PolicySchema,
-		isProPlus,
-		type EnforcementBudget,
-		type EnforcementCredit,
-		type EnforcementPolicy
-	} from './enforcementSettingsModel';
+	import { loadEnforcementPolicy, saveEnforcementPolicy } from './enforcementSettingsApi';
+	import { PolicySchema, isProPlus, type EnforcementPolicy } from './enforcementSettingsModel';
 
 	let {
 		accessToken,
@@ -31,8 +18,6 @@
 
 	let loading = $state(true);
 	let savingPolicy = $state(false);
-	let savingBudget = $state(false);
-	let savingCredit = $state(false);
 	let error = $state('');
 	let success = $state('');
 
@@ -45,22 +30,6 @@
 		hard_deny_above_monthly_usd: 5000,
 		default_ttl_seconds: 900
 	});
-	let budgets = $state<EnforcementBudget[]>([]);
-	let credits = $state<EnforcementCredit[]>([]);
-
-	let budgetForm = $state({
-		scope_key: 'default',
-		monthly_limit_usd: 0,
-		active: true
-	});
-
-	let creditForm = $state({
-		scope_key: 'default',
-		total_amount_usd: 0,
-		expires_at: '',
-		reason: ''
-	});
-
 	async function loadPolicy() {
 		const loaded = await loadEnforcementPolicy(accessToken);
 		if (!loaded) return;
@@ -73,21 +42,13 @@
 		};
 	}
 
-	async function loadBudgets() {
-		budgets = await loadEnforcementBudgets(accessToken);
-	}
-
-	async function loadCredits() {
-		credits = await loadEnforcementCredits(accessToken);
-	}
-
 	async function loadAll() {
 		loading = true;
 		error = '';
 		success = '';
 		try {
 			if (!accessToken || !isProPlus(tier)) return;
-			await Promise.all([loadPolicy(), loadBudgets(), loadCredits()]);
+			await loadPolicy();
 		} catch (e) {
 			if (e instanceof TimeoutError) {
 				error = 'Enforcement settings request timed out. Please retry.';
@@ -116,75 +77,19 @@
 		}
 	}
 
-	async function upsertBudget() {
-		savingBudget = true;
-		error = '';
-		success = '';
-		try {
-			const payload = {
-				scope_key: budgetForm.scope_key.trim() || 'default',
-				monthly_limit_usd: Number(budgetForm.monthly_limit_usd),
-				active: budgetForm.active
-			};
-			await saveEnforcementBudget(accessToken, payload);
-			await loadBudgets();
-			success = 'Enforcement budget saved.';
-		} catch (e) {
-			const err = e as Error;
-			error = err.message || 'Failed to save enforcement budget';
-		} finally {
-			savingBudget = false;
-		}
-	}
-
-	async function createCredit() {
-		savingCredit = true;
-		error = '';
-		success = '';
-		try {
-			const payload = {
-				scope_key: creditForm.scope_key.trim() || 'default',
-				total_amount_usd: Number(creditForm.total_amount_usd),
-				expires_at: creditForm.expires_at ? new Date(creditForm.expires_at).toISOString() : null,
-				reason: creditForm.reason.trim() || null
-			};
-			await createEnforcementCredit(accessToken, payload);
-			creditForm = {
-				scope_key: creditForm.scope_key,
-				total_amount_usd: 0,
-				expires_at: '',
-				reason: ''
-			};
-			await loadCredits();
-			success = 'Enforcement credit created.';
-		} catch (e) {
-			const err = e as Error;
-			error = err.message || 'Failed to create enforcement credit';
-		} finally {
-			savingCredit = false;
-		}
-	}
-
 	onMount(() => {
 		void loadAll();
 	});
 </script>
 
 <EnforcementSettingsCardView
+	{accessToken}
 	proPlus={isProPlus(tier)}
 	{billingHref}
 	{loading}
 	{savingPolicy}
-	{savingBudget}
-	{savingCredit}
 	{error}
 	{success}
-	{budgets}
-	{credits}
 	onSavePolicy={savePolicy}
-	onUpsertBudget={upsertBudget}
-	onCreateCredit={createCredit}
 	bind:policy
-	bind:budgetForm
-	bind:creditForm
 />

--- a/dashboard/src/lib/components/EnforcementSettingsCard.svelte.test.ts
+++ b/dashboard/src/lib/components/EnforcementSettingsCard.svelte.test.ts
@@ -159,9 +159,9 @@ describe('EnforcementSettingsCard', () => {
 			);
 		});
 
-		const budgetLimit = screen.getByLabelText(
+		const budgetLimit = (await screen.findByLabelText(
 			'Enforcement budget monthly limit'
-		) as HTMLInputElement;
+		)) as HTMLInputElement;
 		await fireEvent.input(budgetLimit, { target: { value: '1500' } });
 		await fireEvent.click(screen.getByRole('button', { name: /Save enforcement budget/i }));
 
@@ -176,9 +176,9 @@ describe('EnforcementSettingsCard', () => {
 			);
 		});
 
-		const creditAmount = screen.getByLabelText(
+		const creditAmount = (await screen.findByLabelText(
 			'Enforcement credit total amount'
-		) as HTMLInputElement;
+		)) as HTMLInputElement;
 		await fireEvent.input(creditAmount, { target: { value: '300' } });
 		await fireEvent.click(screen.getByRole('button', { name: /Create enforcement credit/i }));
 

--- a/dashboard/src/lib/components/EnforcementSettingsCardView.svelte
+++ b/dashboard/src/lib/components/EnforcementSettingsCardView.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import { onMount } from 'svelte';
+	import { createLazyComponent } from '$lib/lazyComponent';
 	import { getUpgradePrompt } from '$lib/pricing/upgradePrompt';
 	import type {
 		EnforcementBudget,
@@ -20,42 +22,63 @@
 	};
 
 	let {
+		accessToken,
 		proPlus,
 		billingHref,
 		loading,
 		savingPolicy,
-		savingBudget,
-		savingCredit,
 		error,
 		success,
 		policy = $bindable(),
-		budgets,
-		credits,
-		budgetForm = $bindable(),
-		creditForm = $bindable(),
-		onSavePolicy,
-		onUpsertBudget,
-		onCreateCredit
+		onSavePolicy
 	}: {
+		accessToken?: string | null;
 		proPlus: boolean;
 		billingHref: string;
 		loading: boolean;
 		savingPolicy: boolean;
-		savingBudget: boolean;
-		savingCredit: boolean;
 		error: string;
 		success: string;
 		policy: EnforcementPolicy;
-		budgets: EnforcementBudget[];
-		credits: EnforcementCredit[];
-		budgetForm: EnforcementBudgetForm;
-		creditForm: EnforcementCreditForm;
 		onSavePolicy: () => void | Promise<void>;
-		onUpsertBudget: () => void | Promise<void>;
-		onCreateCredit: () => void | Promise<void>;
 	} = $props();
 
+	type EnforcementSettingsAdvancedSectionProps = {
+		accessToken?: string | null;
+	};
+
+	const loadEnforcementSettingsAdvancedSection =
+		createLazyComponent<EnforcementSettingsAdvancedSectionProps>(
+			() => import('./EnforcementSettingsAdvancedSection.svelte')
+		);
+
 	const upgradePrompt = getUpgradePrompt('pro', 'enforcement controls');
+
+	let advancedSectionAnchor = $state<HTMLDivElement | null>(null);
+	let advancedSectionReady = $state(import.meta.env.MODE === 'test');
+
+	onMount(() => {
+		if (advancedSectionReady || typeof IntersectionObserver === 'undefined') {
+			advancedSectionReady = true;
+			return;
+		}
+
+		const observer = new IntersectionObserver(
+			(entries) => {
+				if (entries.some((entry) => entry.isIntersecting)) {
+					advancedSectionReady = true;
+					observer.disconnect();
+				}
+			},
+			{ rootMargin: '280px 0px' }
+		);
+
+		if (advancedSectionAnchor) {
+			observer.observe(advancedSectionAnchor);
+		}
+
+		return () => observer.disconnect();
+	});
 </script>
 
 <div
@@ -212,148 +235,29 @@
 				{/if}
 			</div>
 
-			<div class="pt-4 border-t border-ink-700">
-				<h3 class="text-sm font-semibold mb-3">Budget Allocations</h3>
-				<div class="grid grid-cols-1 md:grid-cols-3 gap-3 mb-3">
-					<div class="form-group">
-						<label for="enforcement_budget_scope">Scope Key</label>
-						<input
-							id="enforcement_budget_scope"
-							bind:value={budgetForm.scope_key}
-							aria-label="Enforcement budget scope key"
-						/>
-					</div>
-					<div class="form-group">
-						<label for="enforcement_budget_limit">Monthly Limit (USD)</label>
-						<input
-							type="number"
-							id="enforcement_budget_limit"
-							min="0"
-							step="0.01"
-							bind:value={budgetForm.monthly_limit_usd}
-							aria-label="Enforcement budget monthly limit"
-						/>
-					</div>
-					<label class="flex items-center gap-3 cursor-pointer mt-7">
-						<input
-							type="checkbox"
-							class="toggle"
-							bind:checked={budgetForm.active}
-							aria-label="Enforcement budget active"
-						/>
-						<span>Active</span>
-					</label>
-				</div>
-				<button
-					type="button"
-					class="btn btn-secondary mb-3"
-					onclick={onUpsertBudget}
-					disabled={savingBudget}
-					aria-label="Save enforcement budget"
-				>
-					{savingBudget ? '⏳ Saving...' : 'Save Budget'}
-				</button>
-
-				{#if budgets.length === 0}
-					<p class="text-xs text-ink-500">No budgets configured yet.</p>
+			<div bind:this={advancedSectionAnchor}>
+				{#if advancedSectionReady}
+					{#await loadEnforcementSettingsAdvancedSection()}
+						<div class="pt-4 border-t border-ink-700 space-y-4">
+							<div class="skeleton h-4 w-40"></div>
+							<div class="skeleton h-4 w-full"></div>
+							<div class="skeleton h-4 w-2/3"></div>
+						</div>
+					{:then module}
+						{@const EnforcementSettingsAdvancedSection = module.default}
+						<EnforcementSettingsAdvancedSection {accessToken} />
+					{:catch}
+						<div class="pt-4 border-t border-ink-700">
+							<p class="text-xs text-ink-500">
+								Budget and credit controls are temporarily unavailable.
+							</p>
+						</div>
+					{/await}
 				{:else}
-					<div class="overflow-x-auto">
-						<table class="w-full text-sm">
-							<thead>
-								<tr class="text-left text-ink-500">
-									<th class="py-2">Scope</th>
-									<th class="py-2">Monthly Limit</th>
-									<th class="py-2">Active</th>
-								</tr>
-							</thead>
-							<tbody>
-								{#each budgets as row (row.id)}
-									<tr class="border-t border-ink-700">
-										<td class="py-2">{row.scope_key}</td>
-										<td class="py-2">${Number(row.monthly_limit_usd).toFixed(2)}</td>
-										<td class="py-2">{row.active ? 'yes' : 'no'}</td>
-									</tr>
-								{/each}
-							</tbody>
-						</table>
-					</div>
-				{/if}
-			</div>
-
-			<div class="pt-4 border-t border-ink-700">
-				<h3 class="text-sm font-semibold mb-3">Credits</h3>
-				<div class="grid grid-cols-1 md:grid-cols-2 gap-3 mb-3">
-					<div class="form-group">
-						<label for="enforcement_credit_scope">Scope Key</label>
-						<input
-							id="enforcement_credit_scope"
-							bind:value={creditForm.scope_key}
-							aria-label="Enforcement credit scope key"
-						/>
-					</div>
-					<div class="form-group">
-						<label for="enforcement_credit_total">Credit Amount (USD)</label>
-						<input
-							type="number"
-							id="enforcement_credit_total"
-							min="0.01"
-							step="0.01"
-							bind:value={creditForm.total_amount_usd}
-							aria-label="Enforcement credit total amount"
-						/>
-					</div>
-					<div class="form-group">
-						<label for="enforcement_credit_expiry">Expiry (optional)</label>
-						<input
-							type="datetime-local"
-							id="enforcement_credit_expiry"
-							bind:value={creditForm.expires_at}
-							aria-label="Enforcement credit expiry"
-						/>
-					</div>
-					<div class="form-group">
-						<label for="enforcement_credit_reason">Reason (optional)</label>
-						<input
-							id="enforcement_credit_reason"
-							bind:value={creditForm.reason}
-							aria-label="Enforcement credit reason"
-						/>
-					</div>
-				</div>
-				<button
-					type="button"
-					class="btn btn-secondary mb-3"
-					onclick={onCreateCredit}
-					disabled={savingCredit}
-					aria-label="Create enforcement credit"
-				>
-					{savingCredit ? '⏳ Saving...' : 'Create Credit'}
-				</button>
-
-				{#if credits.length === 0}
-					<p class="text-xs text-ink-500">No credits available.</p>
-				{:else}
-					<div class="overflow-x-auto">
-						<table class="w-full text-sm">
-							<thead>
-								<tr class="text-left text-ink-500">
-									<th class="py-2">Scope</th>
-									<th class="py-2">Remaining</th>
-									<th class="py-2">Expires</th>
-								</tr>
-							</thead>
-							<tbody>
-								{#each credits as row (row.id)}
-									<tr class="border-t border-ink-700">
-										<td class="py-2">{row.scope_key}</td>
-										<td class="py-2">${Number(row.remaining_amount_usd).toFixed(2)}</td>
-										<td class="py-2">
-											{row.expires_at ? new Date(row.expires_at).toLocaleString() : 'none'}
-										</td>
-									</tr>
-								{/each}
-							</tbody>
-						</table>
+					<div class="pt-4 border-t border-ink-700 space-y-4">
+						<div class="skeleton h-4 w-40"></div>
+						<div class="skeleton h-4 w-full"></div>
+						<div class="skeleton h-4 w-2/3"></div>
 					</div>
 				{/if}
 			</div>

--- a/dashboard/src/lib/components/FindingsTable.svelte
+++ b/dashboard/src/lib/components/FindingsTable.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 	import CloudLogo from './CloudLogo.svelte';
-	import DOMPurify from 'dompurify';
 	import { Terminal, Check } from '@lucide/svelte';
 	import { clientLogger } from '$lib/logging/client';
+	import { createLazyComponent } from '$lib/lazyComponent';
 
 	interface ZombieFinding {
 		provider: 'aws' | 'azure' | 'gcp';
@@ -20,6 +20,11 @@
 		is_gpu?: boolean;
 	}
 
+	type FindingsTableDetailBodyProps = {
+		explanation: string;
+		confidenceReason?: string;
+	};
+
 	let {
 		resources = [],
 		onRemediate,
@@ -32,7 +37,11 @@
 
 	let currentPage = $state(0);
 	let copiedId = $state<string | null>(null);
+	let detailsModuleReady = $state(import.meta.env.MODE === 'test');
 	const pageSize = 10;
+	const loadFindingsTableDetailBody = createLazyComponent<FindingsTableDetailBodyProps>(
+		() => import('./FindingsTableDetailBody.svelte')
+	);
 
 	let totalPages = $derived(Math.ceil(resources.length / pageSize));
 	let paginatedResources = $derived(
@@ -97,6 +106,10 @@
 			clientLogger.error('Failed to copy: ', err);
 		}
 	}
+
+	function ensureDetailsModule(): void {
+		detailsModuleReady = true;
+	}
 </script>
 
 <div class="card stagger-enter findings-table">
@@ -142,17 +155,27 @@
 							<div class="findings-table__resource-id" title={finding.resource_id}>
 								{finding.resource_id}
 							</div>
-							<details class="findings-table__details">
+							<details
+								class="findings-table__details"
+								ontoggle={(event) => {
+									if ((event.currentTarget as HTMLDetailsElement).open) {
+										ensureDetailsModule();
+									}
+								}}
+							>
 								<summary class="findings-table__summary">View details</summary>
-								<p class="findings-table__explanation">
-									<!-- eslint-disable-next-line svelte/no-at-html-tags -->
-									{@html DOMPurify.sanitize(finding.explanation, {
-										ALLOWED_TAGS: ['b', 'i', 'em', 'strong', 'br', 'p', 'ul', 'li', 'code'],
-										ALLOWED_ATTR: []
-									})}
-								</p>
-								{#if finding.confidence_reason}
-									<p class="findings-table__confidence-reason">{finding.confidence_reason}</p>
+								{#if detailsModuleReady}
+									{#await loadFindingsTableDetailBody() then module}
+										{@const FindingsTableDetailBody = module.default}
+										<FindingsTableDetailBody
+											explanation={finding.explanation}
+											confidenceReason={finding.confidence_reason}
+										/>
+									{:catch}
+										<p class="findings-table__confidence-reason">
+											Details are temporarily unavailable.
+										</p>
+									{/await}
 								{/if}
 							</details>
 						</td>

--- a/dashboard/src/lib/components/FindingsTable.svelte.test.ts
+++ b/dashboard/src/lib/components/FindingsTable.svelte.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { render, screen, cleanup } from '@testing-library/svelte';
+import { render, screen, cleanup, fireEvent } from '@testing-library/svelte';
 import FindingsTable from './FindingsTable.svelte';
 
 vi.mock('dompurify', () => ({
@@ -59,5 +59,28 @@ describe('FindingsTable', () => {
 		const button = screen.getByRole('button', { name: 'Unavailable' });
 		expect(button.hasAttribute('disabled')).toBe(true);
 		expect(button.getAttribute('title')).toContain('Persisted finding binding missing');
+	});
+
+	it('loads the sanitized detail body when a row is expanded', async () => {
+		render(FindingsTable, {
+			resources: [
+				{
+					provider: 'aws',
+					resource_id: 'i-details',
+					resource_type: 'instance',
+					monthly_cost: '$25',
+					confidence: 'medium',
+					risk_if_deleted: 'low',
+					explanation: '<strong>Idle for 14 days</strong>',
+					confidence_reason: 'No network traffic recorded.'
+				}
+			],
+			onRemediate: vi.fn()
+		});
+
+		await fireEvent.click(screen.getByText('View details'));
+
+		expect(await screen.findByText('Idle for 14 days')).toBeTruthy();
+		expect(screen.getByText('No network traffic recorded.')).toBeTruthy();
 	});
 });

--- a/dashboard/src/lib/components/FindingsTableDetailBody.svelte
+++ b/dashboard/src/lib/components/FindingsTableDetailBody.svelte
@@ -1,0 +1,66 @@
+<script lang="ts">
+	let {
+		explanation,
+		confidenceReason
+	}: {
+		explanation: string;
+		confidenceReason?: string;
+	} = $props();
+
+	const sanitizeOptions = {
+		ALLOWED_TAGS: ['b', 'i', 'em', 'strong', 'br', 'p', 'ul', 'li', 'code'],
+		ALLOWED_ATTR: []
+	};
+
+	let domPurifyPromise: Promise<typeof import('dompurify')> | null = null;
+
+	function loadDomPurify(): Promise<typeof import('dompurify')> {
+		if (!domPurifyPromise) {
+			domPurifyPromise = import('dompurify').catch((error) => {
+				domPurifyPromise = null;
+				throw error;
+			});
+		}
+
+		return domPurifyPromise;
+	}
+
+	function stripHtml(value: string): string {
+		return value
+			.replace(/<[^>]+>/g, ' ')
+			.replace(/\s+/g, ' ')
+			.trim();
+	}
+
+	let sanitizedExplanation = $state('');
+
+	$effect(() => {
+		const currentExplanation = explanation;
+		let cancelled = false;
+
+		sanitizedExplanation = stripHtml(currentExplanation);
+
+		void loadDomPurify()
+			.then(({ default: DOMPurify }) => {
+				if (cancelled || currentExplanation !== explanation) return;
+				sanitizedExplanation = DOMPurify.sanitize(currentExplanation, sanitizeOptions);
+			})
+			.catch(() => {
+				if (!cancelled && currentExplanation === explanation) {
+					sanitizedExplanation = stripHtml(currentExplanation);
+				}
+			});
+
+		return () => {
+			cancelled = true;
+		};
+	});
+</script>
+
+<p class="findings-table__explanation">
+	<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+	{@html sanitizedExplanation}
+</p>
+{#if confidenceReason}
+	<p class="findings-table__confidence-reason">{confidenceReason}</p>
+{/if}

--- a/dashboard/src/lib/components/IdentitySettingsCard.svelte
+++ b/dashboard/src/lib/components/IdentitySettingsCard.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import IdentitySettingsCardView from './IdentitySettingsCardView.svelte';
+	import { createLazyComponent } from '$lib/lazyComponent';
 
 	let {
 		accessToken,
@@ -8,6 +8,30 @@
 		accessToken?: string | null;
 		tier?: string | null;
 	} = $props();
+
+	type IdentitySettingsCardContentProps = {
+		accessToken?: string | null;
+		tier?: string | null;
+	};
+
+	const loadIdentitySettingsCardContent = createLazyComponent<IdentitySettingsCardContentProps>(
+		() => import('./IdentitySettingsCardContent.svelte')
+	);
 </script>
 
-<IdentitySettingsCardView {accessToken} {tier} />
+{#await loadIdentitySettingsCardContent()}
+	<div class="card">
+		<div class="skeleton mb-4 h-6 w-40"></div>
+		<div class="skeleton mb-2 h-4 w-full"></div>
+		<div class="skeleton h-4 w-3/4"></div>
+	</div>
+{:then module}
+	{@const IdentitySettingsCardContent = module.default}
+	<IdentitySettingsCardContent {accessToken} {tier} />
+{:catch}
+	<div class="card">
+		<div class="skeleton mb-4 h-6 w-40"></div>
+		<div class="skeleton mb-2 h-4 w-full"></div>
+		<div class="skeleton h-4 w-3/4"></div>
+	</div>
+{/await}

--- a/dashboard/src/lib/components/IdentitySettingsCard.svelte.test.ts
+++ b/dashboard/src/lib/components/IdentitySettingsCard.svelte.test.ts
@@ -53,10 +53,10 @@ describe('IdentitySettingsCard', () => {
 			tier: 'free'
 		});
 
-		expect(screen.getByText('Identity (SSO/SCIM)')).toBeTruthy();
-		expect(screen.getByText(upgradePrompt.badge)).toBeTruthy();
-		expect(screen.getByText(upgradePrompt.body)).toBeTruthy();
-		expect(screen.getByRole('link', { name: upgradePrompt.cta })).toBeTruthy();
+		expect(await screen.findByText('Identity (SSO/SCIM)')).toBeTruthy();
+		expect(await screen.findByText(upgradePrompt.badge)).toBeTruthy();
+		expect(await screen.findByText(upgradePrompt.body)).toBeTruthy();
+		expect(await screen.findByRole('link', { name: upgradePrompt.cta })).toBeTruthy();
 		await waitFor(() => {
 			expect(getMock).not.toHaveBeenCalled();
 		});

--- a/dashboard/src/lib/components/IdentitySettingsCardContent.svelte
+++ b/dashboard/src/lib/components/IdentitySettingsCardContent.svelte
@@ -1,32 +1,20 @@
 <script lang="ts">
 	/* eslint-disable svelte/no-navigation-without-resolve */
 	import { onMount } from 'svelte';
-	import { env as publicEnv } from '$env/dynamic/public';
 	import { base } from '$app/paths';
 	import { api } from '$lib/api';
-	import IdentityDiagnosticsSection from '$lib/components/identity/IdentityDiagnosticsSection.svelte';
-	import IdentityScimSection from '$lib/components/identity/IdentityScimSection.svelte';
 	import IdentitySsoSection from '$lib/components/identity/IdentitySsoSection.svelte';
+	import { createLazyComponent } from '$lib/lazyComponent';
 	import { getUpgradePrompt } from '$lib/pricing/upgradePrompt';
-	import {
-		isGrowthPlus,
-		parseDomains,
-		scimBaseUrlFromPublicApiUrl
-	} from '$lib/components/identity/identitySettingsHelpers';
+	import { isGrowthPlus, parseDomains } from '$lib/components/identity/identitySettingsHelpers';
 	import {
 		extractErrorMessage,
 		IDENTITY_REQUEST_TIMEOUT_MS,
-		IdentityDiagnosticsSchema,
 		IdentitySettingsResponseSchema,
 		IdentitySettingsUpdateSchema,
-		RotateTokenResponseSchema,
-		ScimTokenTestResponseSchema,
 		uniqueScimMappingsOrThrow
 	} from '$lib/components/identity/identitySettingsModel';
-	import type {
-		IdentityDiagnostics,
-		IdentitySettings
-	} from '$lib/components/identity/identitySettingsTypes';
+	import type { IdentitySettings } from '$lib/components/identity/identitySettingsTypes';
 	import { edgeApiPath } from '$lib/edgeProxy';
 	import { TimeoutError } from '$lib/fetchWithTimeout';
 	import { clientLogger } from '$lib/logging/client';
@@ -42,24 +30,30 @@
 
 	let loading = $state(true);
 	let saving = $state(false);
-	let rotating = $state(false);
-	let diagnosticsLoading = $state(false);
-	let scimTokenTesting = $state(false);
 	let error = $state('');
 	let success = $state('');
 
 	let settings = $state<IdentitySettings | null>(null);
 	let domainsText = $state('');
-	let rotatedToken = $state<string>('');
-	let rotatedAt = $state<string>('');
-	let diagnostics = $state<IdentityDiagnostics | null>(null);
-	let scimTokenInput = $state('');
-	let scimTokenTestStatus = $state<string>('');
+	let advancedSectionsReady = $state(import.meta.env.MODE === 'test');
 
-	function scimBaseUrl(): string {
-		const publicApiUrl = String(publicEnv.PUBLIC_API_URL || '').trim();
-		return scimBaseUrlFromPublicApiUrl(publicApiUrl);
-	}
+	type IdentityDiagnosticsSectionProps = {
+		accessToken?: string | null;
+		tier?: string | null;
+	};
+
+	type IdentityScimSectionProps = {
+		accessToken?: string | null;
+		tier?: string | null;
+		settings: IdentitySettings;
+	};
+
+	const loadIdentityDiagnosticsSection = createLazyComponent<IdentityDiagnosticsSectionProps>(
+		() => import('$lib/components/identity/IdentityDiagnosticsSection.svelte')
+	);
+	const loadIdentityScimSection = createLazyComponent<IdentityScimSectionProps>(
+		() => import('$lib/components/identity/IdentityScimSection.svelte')
+	);
 
 	async function getHeaders() {
 		return {
@@ -78,14 +72,8 @@
 		loading = true;
 		error = '';
 		success = '';
-		rotatedToken = '';
-		rotatedAt = '';
 		try {
-			if (!accessToken) {
-				settings = null;
-				return;
-			}
-			if (!isGrowthPlus(tier)) {
+			if (!accessToken || !isGrowthPlus(tier)) {
 				settings = null;
 				return;
 			}
@@ -113,7 +101,6 @@
 				}))
 			};
 			domainsText = (loaded.allowed_email_domains ?? []).join(', ');
-			await loadDiagnostics();
 		} catch (e) {
 			clientLogger.error('Failed to load identity settings:', e);
 			error =
@@ -122,77 +109,6 @@
 					: formatValidationIssues(e, false);
 		} finally {
 			loading = false;
-		}
-	}
-
-	async function loadDiagnostics() {
-		diagnosticsLoading = true;
-		scimTokenTestStatus = '';
-		try {
-			if (!accessToken) {
-				diagnostics = null;
-				return;
-			}
-			if (!isGrowthPlus(tier)) {
-				diagnostics = null;
-				return;
-			}
-			const headers = await getHeaders();
-			const res = await getWithTimeout(edgeApiPath('/settings/identity/diagnostics'), headers);
-			if (res.status === 403) {
-				diagnostics = null;
-				return;
-			}
-			if (!res.ok) {
-				const data = await res.json().catch(() => ({}));
-				throw new Error(extractErrorMessage(data, 'Failed to load identity diagnostics'));
-			}
-			const parsedResult = IdentityDiagnosticsSchema.safeParse(await res.json());
-			if (!parsedResult.success) {
-				throw parsedResult.error;
-			}
-			const parsed = parsedResult.data;
-			diagnostics = parsed as IdentityDiagnostics;
-		} catch (e) {
-			clientLogger.error('Failed to load identity diagnostics:', e);
-			error =
-				e instanceof TimeoutError
-					? 'Identity diagnostics request timed out. Try again.'
-					: formatValidationIssues(e, false);
-			diagnostics = null;
-		} finally {
-			diagnosticsLoading = false;
-		}
-	}
-
-	async function testScimToken() {
-		scimTokenTesting = true;
-		scimTokenTestStatus = '';
-		error = '';
-		try {
-			if (!scimTokenInput.trim()) return;
-			const headers = await getHeaders();
-			const res = await api.post(
-				edgeApiPath('/settings/identity/scim/test-token'),
-				{ scim_token: scimTokenInput.trim() },
-				{ headers }
-			);
-			if (!res.ok) {
-				const data = await res.json().catch(() => ({}));
-				throw new Error(extractErrorMessage(data, 'Failed to test SCIM token'));
-			}
-			const payloadResult = ScimTokenTestResponseSchema.safeParse(await res.json());
-			if (!payloadResult.success) {
-				throw payloadResult.error;
-			}
-			const payload = payloadResult.data;
-			scimTokenTestStatus = payload.token_matches ? 'Token matches.' : 'Token does not match.';
-		} catch (e) {
-			error = formatValidationIssues(e, false);
-		} finally {
-			scimTokenTesting = false;
-			// Never keep tokens in UI state longer than needed.
-			scimTokenInput = '';
 		}
 	}
 
@@ -223,10 +139,10 @@
 			if (!validatedResult.success) {
 				throw validatedResult.error;
 			}
-			const validated = validatedResult.data;
-
 			const headers = await getHeaders();
-			const res = await api.put(edgeApiPath('/settings/identity'), validated, { headers });
+			const res = await api.put(edgeApiPath('/settings/identity'), validatedResult.data, {
+				headers
+			});
 			if (!res.ok) {
 				const data = await res.json().catch(() => ({}));
 				throw new Error(extractErrorMessage(data, 'Failed to save identity settings'));
@@ -247,7 +163,6 @@
 			domainsText = (updated.allowed_email_domains ?? []).join(', ');
 			success = 'Identity settings saved.';
 			setTimeout(() => (success = ''), 2500);
-			await loadDiagnostics();
 		} catch (e) {
 			error = formatValidationIssues(e, false);
 		} finally {
@@ -255,75 +170,25 @@
 		}
 	}
 
-	async function rotateScimToken() {
-		rotating = true;
-		error = '';
-		success = '';
-		rotatedToken = '';
-		rotatedAt = '';
-		try {
-			const headers = await getHeaders();
-			const res = await api.post(
-				edgeApiPath('/settings/identity/rotate-scim-token'),
-				{},
-				{ headers }
-			);
-			if (!res.ok) {
-				const data = await res.json().catch(() => ({}));
-				throw new Error(
-					extractErrorMessage(
-						data,
-						res.status === 403
-							? 'SCIM token rotation requires Enterprise tier and admin access.'
-							: 'Failed to rotate SCIM token'
-					)
-				);
-			}
-			const payloadResult = RotateTokenResponseSchema.safeParse(await res.json());
-			if (!payloadResult.success) {
-				throw payloadResult.error;
-			}
-			const payload = payloadResult.data;
-			rotatedToken = payload.scim_token;
-			rotatedAt = payload.rotated_at;
-			success = 'SCIM token rotated. Store it now; it is shown only once.';
-			await loadIdentitySettings();
-		} catch (e) {
-			error = formatValidationIssues(e, false);
-		} finally {
-			rotating = false;
-		}
-	}
-
-	async function copyToken() {
-		if (!rotatedToken) return;
-		try {
-			await navigator.clipboard.writeText(rotatedToken);
-			success = 'Copied token to clipboard.';
-			setTimeout(() => (success = ''), 2000);
-		} catch {
-			error = 'Failed to copy token. Copy manually.';
-		}
-	}
-
 	onMount(() => {
 		void loadIdentitySettings();
+
+		if (advancedSectionsReady) {
+			return;
+		}
+
+		const activateAdvancedSections = () => {
+			advancedSectionsReady = true;
+		};
+
+		if (typeof window.requestIdleCallback === 'function') {
+			const idleId = window.requestIdleCallback(activateAdvancedSections, { timeout: 1200 });
+			return () => window.cancelIdleCallback(idleId);
+		}
+
+		const timeoutId = window.setTimeout(activateAdvancedSections, 500);
+		return () => window.clearTimeout(timeoutId);
 	});
-
-	function addGroupMapping() {
-		if (!settings) return;
-		settings.scim_group_mappings = [
-			...(settings.scim_group_mappings ?? []),
-			{ group: '', role: 'member', persona: null }
-		];
-	}
-
-	function removeGroupMapping(index: number) {
-		if (!settings) return;
-		settings.scim_group_mappings = (settings.scim_group_mappings ?? []).filter(
-			(_, i) => i !== index
-		);
-	}
 
 	const upgradePrompt = getUpgradePrompt('growth', 'identity controls');
 </script>
@@ -381,24 +246,49 @@
 		<div class="space-y-4">
 			<IdentitySsoSection bind:settings bind:domainsText />
 
-			<IdentityDiagnosticsSection {diagnosticsLoading} {diagnostics} onRefresh={loadDiagnostics} />
+			{#if advancedSectionsReady}
+				{#await loadIdentityDiagnosticsSection()}
+					<div class="rounded-xl border border-ink-800/60 bg-ink-950/30 p-4">
+						<div class="skeleton mb-2 h-4 w-40"></div>
+						<div class="skeleton mb-2 h-4 w-full"></div>
+						<div class="skeleton h-4 w-2/3"></div>
+					</div>
+				{:then module}
+					{@const IdentityDiagnosticsSection = module.default}
+					<IdentityDiagnosticsSection {accessToken} {tier} />
+				{:catch}
+					<div class="rounded-xl border border-ink-800/60 bg-ink-950/30 p-4">
+						<p class="text-xs text-ink-500">Diagnostics are temporarily unavailable.</p>
+					</div>
+				{/await}
 
-			<IdentityScimSection
-				{tier}
-				bind:settings
-				{rotating}
-				{rotatedToken}
-				{rotatedAt}
-				bind:scimTokenInput
-				{scimTokenTesting}
-				{scimTokenTestStatus}
-				scimBaseUrl={scimBaseUrl()}
-				onRotateScimToken={rotateScimToken}
-				onCopyToken={copyToken}
-				onTestScimToken={testScimToken}
-				onAddGroupMapping={addGroupMapping}
-				onRemoveGroupMapping={removeGroupMapping}
-			/>
+				{#await loadIdentityScimSection()}
+					<div class="rounded-xl border border-ink-800/60 bg-ink-950/30 p-4">
+						<div class="skeleton mb-2 h-4 w-40"></div>
+						<div class="skeleton mb-2 h-4 w-full"></div>
+						<div class="skeleton h-4 w-2/3"></div>
+					</div>
+				{:then module}
+					{@const IdentityScimSection = module.default}
+					<IdentityScimSection {accessToken} {tier} bind:settings />
+				{:catch}
+					<div class="rounded-xl border border-ink-800/60 bg-ink-950/30 p-4">
+						<p class="text-xs text-ink-500">SCIM controls are temporarily unavailable.</p>
+					</div>
+				{/await}
+			{:else}
+				<div class="rounded-xl border border-ink-800/60 bg-ink-950/30 p-4">
+					<div class="skeleton mb-2 h-4 w-40"></div>
+					<div class="skeleton mb-2 h-4 w-full"></div>
+					<div class="skeleton h-4 w-2/3"></div>
+				</div>
+
+				<div class="rounded-xl border border-ink-800/60 bg-ink-950/30 p-4">
+					<div class="skeleton mb-2 h-4 w-40"></div>
+					<div class="skeleton mb-2 h-4 w-full"></div>
+					<div class="skeleton h-4 w-2/3"></div>
+				</div>
+			{/if}
 
 			<div class="flex items-center justify-end gap-3 pt-2">
 				<button

--- a/dashboard/src/lib/components/LandingHero.svelte
+++ b/dashboard/src/lib/components/LandingHero.svelte
@@ -1,27 +1,18 @@
 <script lang="ts">
 	import { browser } from '$app/environment';
-	import { assets, base } from '$app/paths';
-	import { page } from '$app/stores';
+	import { base } from '$app/paths';
 	import { onMount } from 'svelte';
-	import { LANDING_SIGNAL_SNAPSHOTS } from '$lib/landing/landingSignalSnapshots';
+	import type { LandingExperimentAssignments } from '$lib/landing/landingExperiment';
 	import {
-		resolveLandingExperiments,
-		shouldIncludeExperimentQueryParams,
-		type LandingExperimentAssignments
-	} from '$lib/landing/landingExperiment';
-	import {
-		resolveDetectedLandingCurrency,
 		resolveInitialLandingCurrency,
 		setLandingCurrencyPreference,
 		type LandingCurrencyCode
 	} from '$lib/landing/currencyPreference';
 	import type { FunnelStage, LandingAttribution } from '$lib/landing/landingFunnel';
-	import type { LandingTelemetryContext } from '$lib/landing/landingTelemetry';
 	import {
-		DEFAULT_EXPERIMENT_ASSIGNMENTS,
 		LANDING_CONSENT_KEY,
 		LANDING_SCROLL_MILESTONES,
-		resolveLandingMotionProfile,
+		type LandingMotionProfile,
 		SNAPSHOT_ROTATION_MS
 	} from '$lib/landing/landingHeroConfig';
 	import {
@@ -29,17 +20,13 @@
 		buildLandingHeroSignupPath
 	} from '$lib/landing/landingHeroActions';
 	import { buildLandingPublicPath } from '$lib/landing/landingPublicAttribution';
-	import {
-		calculateLandingHeroScenarioMetrics,
-		formatLandingHeroCurrencyAmount
-	} from '$lib/landing/landingHeroScenario';
-	import {
-		DEFAULT_LANDING_ROI_INPUTS,
-		normalizeLandingRoiInputs
-	} from '$lib/landing/roiCalculator';
+	import { LANDING_ROI_DEFAULTS } from '$lib/landing/landingRoiDefaults';
+	import type { LandingTelemetryContext } from '$lib/landing/landingTelemetry';
 	import { getReducedMotionPreference } from '$lib/landing/reducedMotion';
-	import { nextSnapshotIndex } from '$lib/landing/signalRotation';
-	import { BUYER_ROLE_VIEWS, HERO_ROLE_CONTEXT } from '$lib/landing/heroContent.core';
+	import type {
+		LandingSignalLaneSnapshot,
+		LandingSignalSnapshot
+	} from '$lib/landing/landingSignalSnapshots';
 	import LandingHeroView from '$lib/components/landing/LandingHeroView.svelte';
 
 	type LandingHeroTelemetryApi = {
@@ -57,63 +44,80 @@
 		trackScenarioAdjust: (control: string) => void;
 	};
 
-	const DEFAULT_SIGNAL_SNAPSHOT = LANDING_SIGNAL_SNAPSHOTS[0];
-	const ONE_PAGER_HREF = `${base}/resources/valdrics-enterprise-one-pager.md`,
-		RESOURCES_PATH = `${base}/resources`;
-	const SUBSCRIBE_API_PATH = `${base}/api/marketing/subscribe`,
-		TALK_TO_SALES_PATH = `${base}/talk-to-sales`,
-		ENTERPRISE_PATH = `${base}/enterprise`;
-	if (!DEFAULT_SIGNAL_SNAPSHOT)
-		throw new Error('Landing signal snapshots require at least one snapshot.');
+	const ONE_PAGER_HREF = `${base}/resources/valdrics-enterprise-one-pager.md`;
+	const RESOURCES_PATH = `${base}/resources`;
+	const SUBSCRIBE_API_PATH = `${base}/api/marketing/subscribe`;
+	const TALK_TO_SALES_PATH = `${base}/talk-to-sales`;
+	const ENTERPRISE_PATH = `${base}/enterprise`;
+
+	let {
+		initialExperiments,
+		includeExperimentQueryParams,
+		initialMotionProfile,
+		canonicalUrl,
+		ogImageUrl,
+		detectedCurrencyCode,
+		buyerPersonaId,
+		heroPrimaryIntent,
+		heroTitle,
+		heroSubtitle,
+		initialSnapshot
+	}: {
+		initialExperiments: LandingExperimentAssignments;
+		includeExperimentQueryParams: boolean;
+		initialMotionProfile: LandingMotionProfile;
+		canonicalUrl: string;
+		ogImageUrl: string;
+		detectedCurrencyCode: LandingCurrencyCode;
+		buyerPersonaId: LandingExperimentAssignments['buyerPersonaDefault'];
+		heroPrimaryIntent: string;
+		heroTitle: string;
+		heroSubtitle: string;
+		initialSnapshot: LandingSignalSnapshot;
+	} = $props();
+
 	let signalMapElement: HTMLDivElement | null = null;
-	let signalMapInView = $state(true),
-		documentVisible = $state(true),
-		snapshotIndex = $state(0),
-		buyerRoleIndex = $state(0);
-	let visitorId = $state(''),
-		pageReferrer = $state('');
-	let experiments = $state<LandingExperimentAssignments>(
-		resolveLandingExperiments($page.url, DEFAULT_EXPERIMENT_ASSIGNMENTS.seed)
-	);
-	let attribution = $state<LandingAttribution>({ utm: {} }),
-		engagedCaptured = $state(false);
-	let roiMonthlySpendUsd = $state(DEFAULT_LANDING_ROI_INPUTS.monthlySpendUsd),
-		roiExpectedReductionPct = $state(DEFAULT_LANDING_ROI_INPUTS.expectedReductionPct),
-		roiRolloutDays = $state(DEFAULT_LANDING_ROI_INPUTS.rolloutDays);
-	let roiTeamMembers = $state(DEFAULT_LANDING_ROI_INPUTS.teamMembers),
-		roiBlendedHourlyUsd = $state(DEFAULT_LANDING_ROI_INPUTS.blendedHourlyUsd),
-		roiPlatformAnnualCostUsd = $state(DEFAULT_LANDING_ROI_INPUTS.platformAnnualCostUsd);
-	let scenarioWasteWithoutPct = $state(18),
-		scenarioWasteWithPct = $state(7),
-		scenarioWindowMonths = $state(12),
-		scenarioAdjustCaptured = $state(false),
-		landingScrollProgressPct = $state(0);
-	let snapshotAutoplayPaused = $state(false);
+	let signalMapInView = $state(true);
+	let documentVisible = $state(true);
+	let snapshotIndex = $state(0);
+	let hydratedSnapshotCatalog = $state<readonly LandingSignalSnapshot[]>([]);
+	let snapshotAdvance = $state<((current: number, length: number) => number) | null>(null);
+	let snapshotRuntimeLoaded = $state(false);
+	let visitorId = $state('');
+	let pageReferrer = $state('');
+	let experimentOverrides = $state<LandingExperimentAssignments | null>(null);
+	let attribution = $state<LandingAttribution>({ utm: {} });
+	let engagedCaptured = $state(false);
+	let roiMonthlySpendUsd = $state(LANDING_ROI_DEFAULTS.monthlySpendUsd);
+	let scenarioWasteWithoutPct = $state(18);
+	let scenarioWasteWithPct = $state(7);
+	let scenarioWindowMonths = $state(12);
+	let scenarioAdjustCaptured = $state(false);
+	let landingScrollProgressPct = $state(0);
 	let prefersReducedMotion = $state(
 		getReducedMotionPreference(browser && typeof window !== 'undefined' ? window : undefined)
 	);
-	let telemetryEnabled = $state(false),
-		telemetryInitialized = $state(false),
-		cookieBannerVisible = $state(false),
-		localCurrencyCode = $state<LandingCurrencyCode>(resolveDetectedLandingCurrency()),
-		roiCurrencyCode = $state<LandingCurrencyCode>(resolveInitialLandingCurrency());
+	let telemetryEnabled = $state(false);
+	let telemetryInitialized = $state(false);
+	let cookieBannerVisible = $state(false);
+	let roiCurrencyOverride = $state<LandingCurrencyCode | null>(null);
 	let telemetryApi = $state<LandingHeroTelemetryApi | null>(null);
-	let activeSnapshot = $derived(LANDING_SIGNAL_SNAPSHOTS[snapshotIndex] ?? DEFAULT_SIGNAL_SNAPSHOT);
-	let activeBuyerRole = $derived(BUYER_ROLE_VIEWS[buyerRoleIndex] ?? BUYER_ROLE_VIEWS[0]);
-	let activeSignalLane = $derived(
+	let localCurrencyCode = $derived.by(() => detectedCurrencyCode);
+	let roiCurrencyCode = $derived(
+		roiCurrencyOverride ?? resolveInitialLandingCurrency(localCurrencyCode)
+	);
+	let experiments = $derived(experimentOverrides ?? initialExperiments);
+	let snapshotCatalog = $derived(
+		snapshotRuntimeLoaded ? hydratedSnapshotCatalog : [initialSnapshot]
+	);
+	let activeSnapshot = $derived(snapshotCatalog[snapshotIndex] ?? initialSnapshot);
+	let activeSignalLane = $derived<LandingSignalLaneSnapshot>(
 		activeSnapshot.lanes.find(
 			(lane) => lane.severity === 'watch' || lane.severity === 'critical'
-		) ?? activeSnapshot.lanes[0]
+		) ??
+			activeSnapshot.lanes[0] ??
+			initialSnapshot.lanes[0]!
 	);
-	let heroContext = $derived(HERO_ROLE_CONTEXT[activeBuyerRole.id] ?? HERO_ROLE_CONTEXT.finops);
-	let heroTitle = $derived(
-		experiments.heroVariant === 'from_metrics_to_control'
-			? heroContext.metricsTitle
-			: heroContext.controlTitle
-	);
-	let heroSubtitle = $derived(heroContext.subtitle);
-	let canonicalUrl = $derived(new URL($page.url.pathname, $page.url.origin).toString()),
-		ogImageUrl = $derived(new URL(`${assets}/og-image.png`, $page.url.origin).toString());
 	let primaryCtaLabel = $derived(
 		experiments.ctaVariant === 'book_briefing' ? 'Book Executive Briefing' : 'Start Free Workspace'
 	);
@@ -122,23 +126,22 @@
 	);
 	let secondaryCtaHref = $derived(
 		experiments.ctaVariant === 'book_briefing'
-			? buildSignupHref(heroContext.primaryIntent, { source: 'hero_secondary' })
+			? buildSignupHref(heroPrimaryIntent, { source: 'hero_secondary' })
 			: buildPublicPath(`${base}/pricing`, 'hero_secondary')
 	);
 	let roiPlannerHref = $derived(buildSignupHref('roi_assessment', { source: 'simulator' }));
 	let requestValidationBriefingHref = $derived(
-			buildTalkToSalesHref('trust_validation', 'request_validation_briefing')
-		),
-		aboutHref = $derived(buildPublicPath(`${base}/about`, 'trust_about')),
-		docsHref = $derived(buildPublicPath(`${base}/docs`, 'trust_docs')),
-		statusHref = $derived(buildPublicPath(`${base}/status`, 'trust_status')),
-		proofHref = $derived(buildPublicPath(`${base}/proof`, 'trust_proof')),
-		plansEnterpriseHref = $derived(buildEnterpriseReviewHref('plans_enterprise')),
-		trustEnterpriseHref = $derived(buildEnterpriseReviewHref('trust_enterprise'));
-	let showBackToTop = $derived(landingScrollProgressPct >= 8),
-		motionProfile = $derived(resolveLandingMotionProfile($page.url));
+		buildTalkToSalesHref('trust_validation', 'request_validation_briefing')
+	);
+	let aboutHref = $derived(buildPublicPath(`${base}/about`, 'trust_about'));
+	let docsHref = $derived(buildPublicPath(`${base}/docs`, 'trust_docs'));
+	let statusHref = $derived(buildPublicPath(`${base}/status`, 'trust_status'));
+	let proofHref = $derived(buildPublicPath(`${base}/proof`, 'trust_proof'));
+	let trustEnterpriseHref = $derived(buildEnterpriseReviewHref('trust_enterprise'));
+	let showBackToTop = $derived(landingScrollProgressPct >= 8);
+	let motionProfile = $derived(initialMotionProfile);
 	let primaryCtaIntent = $derived(
-		experiments.ctaVariant === 'book_briefing' ? 'executive_briefing' : heroContext.primaryIntent
+		experiments.ctaVariant === 'book_briefing' ? 'executive_briefing' : heroPrimaryIntent
 	);
 	let primaryCtaHref = $derived(
 		experiments.ctaVariant === 'book_briefing'
@@ -151,41 +154,28 @@
 	let secondaryCtaTelemetryValue = $derived(
 		experiments.ctaVariant === 'book_briefing' ? 'start_free' : 'see_pricing'
 	);
-	let includeExperimentQueryParams = $derived(shouldIncludeExperimentQueryParams($page.url, false));
 	let shouldRotateSnapshots = $derived(
-		!snapshotAutoplayPaused &&
+		snapshotRuntimeLoaded &&
 			!prefersReducedMotion &&
 			documentVisible &&
 			signalMapInView &&
-			LANDING_SIGNAL_SNAPSHOTS.length > 1
+			snapshotCatalog.length > 1
 	);
-	let roiInputs = $derived(
-		normalizeLandingRoiInputs({
-			monthlySpendUsd: roiMonthlySpendUsd,
-			expectedReductionPct: roiExpectedReductionPct,
-			rolloutDays: roiRolloutDays,
-			teamMembers: roiTeamMembers,
-			blendedHourlyUsd: roiBlendedHourlyUsd,
-			platformAnnualCostUsd: roiPlatformAnnualCostUsd
-		})
-	);
-	let scenarioMetrics = $derived(
-		calculateLandingHeroScenarioMetrics({
-			monthlySpendUsd: roiInputs.monthlySpendUsd,
-			wasteWithoutPct: scenarioWasteWithoutPct,
-			wasteWithPct: scenarioWasteWithPct,
-			windowMonths: scenarioWindowMonths
-		})
-	);
-
 	let telemetryBridgePromise: Promise<LandingHeroTelemetryApi> | null = null;
+	let snapshotRuntimePromise: Promise<void> | null = null;
+
+	const getCurrentPageUrl = (): URL =>
+		browser && typeof window !== 'undefined'
+			? new URL(window.location.href)
+			: new URL(canonicalUrl);
 
 	function buildFallbackTelemetryContext(stage?: FunnelStage): LandingTelemetryContext {
+		const pageUrl = getCurrentPageUrl();
 		return {
 			visitorId,
-			persona: activeBuyerRole.id,
+			persona: buyerPersonaId,
 			referrer: pageReferrer || undefined,
-			pagePath: $page.url.pathname,
+			pagePath: pageUrl.pathname,
 			funnelStage: stage,
 			experiment: {
 				hero: experiments.heroVariant,
@@ -272,14 +262,14 @@
 						getVisitorId: () => visitorId,
 						setVisitorId: (value) => (visitorId = value),
 						getExperiments: () => experiments,
-						setExperiments: (value) => (experiments = value),
+						setExperiments: (value) => (experimentOverrides = value),
 						getAttribution: () => attribution,
 						setAttribution: (value) => (attribution = value),
-						getPersona: () => activeBuyerRole.id,
-						getPagePath: () => $page.url.pathname,
+						getPersona: () => buyerPersonaId,
+						getPagePath: () => getCurrentPageUrl().pathname,
 						getReferrer: () => pageReferrer,
 						getStorage: () => (browser ? window.localStorage : undefined),
-						getPageUrl: () => $page.url,
+						getPageUrl: () => getCurrentPageUrl(),
 						consentStorageKey: LANDING_CONSENT_KEY
 					});
 					telemetryApi = nextTelemetryApi;
@@ -291,27 +281,49 @@
 				});
 		}
 
-		return telemetryBridgePromise!;
+		return telemetryBridgePromise;
+	}
+
+	async function ensureSnapshotRuntime(): Promise<void> {
+		if (snapshotRuntimeLoaded) {
+			return;
+		}
+
+		if (!snapshotRuntimePromise) {
+			snapshotRuntimePromise = Promise.all([
+				import('$lib/landing/landingSignalSnapshots'),
+				import('$lib/landing/signalRotation')
+			])
+				.then(([{ LANDING_SIGNAL_SNAPSHOTS }, { nextSnapshotIndex }]) => {
+					hydratedSnapshotCatalog = LANDING_SIGNAL_SNAPSHOTS;
+					snapshotAdvance = nextSnapshotIndex;
+					snapshotRuntimeLoaded = true;
+				})
+				.catch((error) => {
+					snapshotRuntimePromise = null;
+					throw error;
+				});
+		}
+
+		return snapshotRuntimePromise;
 	}
 
 	$effect(() => {
-		const defaultBuyerIndex = BUYER_ROLE_VIEWS.findIndex(
-			(role) => role.id === experiments.buyerPersonaDefault
-		);
-		if (defaultBuyerIndex >= 0) {
-			buyerRoleIndex = defaultBuyerIndex;
-		}
-	});
-	$effect(() => {
-		if (!shouldRotateSnapshots) return;
+		const advance = snapshotAdvance;
+		if (!shouldRotateSnapshots || !advance) return;
 		const interval = setInterval(() => {
-			snapshotIndex = nextSnapshotIndex(snapshotIndex, LANDING_SIGNAL_SNAPSHOTS.length);
+			snapshotIndex = advance(snapshotIndex, snapshotCatalog.length);
 		}, SNAPSHOT_ROTATION_MS);
 		return () => clearInterval(interval);
 	});
+
 	onMount(() => {
 		let cancelled = false;
 		let teardown: (() => void) | void;
+
+		void ensureSnapshotRuntime().catch(() => {
+			// Decorative snapshot rotation must not block the landing experience.
+		});
 
 		void ensureTelemetryBridge()
 			.then(() => import('$lib/landing/landingHeroBrowserRuntime'))
@@ -346,51 +358,55 @@
 			teardown?.();
 		};
 	});
-	const closeCookieBanner = () => (cookieBannerVisible = false),
-		openCookieSettings = () => (cookieBannerVisible = true);
+
+	const closeCookieBanner = () => (cookieBannerVisible = false);
+	const openCookieSettings = () => (cookieBannerVisible = true);
+
 	function buildSignupHref(intent: string, extraParams: Record<string, string> = {}): string {
 		return buildLandingHeroSignupPath({
 			basePath: base,
 			intent,
-			persona: activeBuyerRole.id,
+			persona: buyerPersonaId,
 			includeExperimentQueryParams,
 			experiments,
 			utm: attribution.utm,
 			extraParams
 		});
 	}
+
 	function buildTalkToSalesHref(source: string, intent?: string): string {
 		return buildLandingHeroSalesPath({
 			path: TALK_TO_SALES_PATH,
 			source,
 			intent,
-			persona: activeBuyerRole.id,
+			persona: buyerPersonaId,
 			utm: attribution.utm
 		});
 	}
+
 	function buildPublicPath(path: string, source: string): string {
 		return buildLandingPublicPath({
 			path,
 			source,
-			persona: activeBuyerRole.id,
+			persona: buyerPersonaId,
 			utm: attribution.utm
 		});
 	}
+
 	function buildEnterpriseReviewHref(source: string): string {
 		return buildLandingHeroSalesPath({
 			path: ENTERPRISE_PATH,
 			source,
-			persona: activeBuyerRole.id,
+			persona: buyerPersonaId,
 			utm: attribution.utm
 		});
 	}
+
 	const handleScenarioWasteWithoutChange = (value: number) => (scenarioWasteWithoutPct = value);
 	const handleScenarioWasteWithChange = (value: number) => (scenarioWasteWithPct = value);
 	const handleScenarioWindowChange = (value: number) => (scenarioWindowMonths = value);
-	const formatUsd = (amount: number, currency: string = roiCurrencyCode) =>
-		formatLandingHeroCurrencyAmount(amount, currency);
 	function handleCurrencyCodeChange(value: LandingCurrencyCode): void {
-		roiCurrencyCode = value;
+		roiCurrencyOverride = value;
 		setLandingCurrencyPreference(value);
 	}
 </script>
@@ -408,20 +424,10 @@
 	{secondaryCtaTelemetryValue}
 	{activeSnapshot}
 	{activeSignalLane}
-	normalizedScenarioWasteWithoutPct={scenarioMetrics.normalizedScenarioWasteWithoutPct}
-	normalizedScenarioWasteWithPct={scenarioMetrics.normalizedScenarioWasteWithPct}
-	normalizedScenarioWindowMonths={scenarioMetrics.normalizedScenarioWindowMonths}
-	scenarioWithoutBarPct={scenarioMetrics.scenarioWithoutBarPct}
-	scenarioWithBarPct={scenarioMetrics.scenarioWithBarPct}
-	scenarioWasteWithoutUsd={scenarioMetrics.scenarioWasteWithoutUsd}
-	scenarioWasteWithUsd={scenarioMetrics.scenarioWasteWithUsd}
-	scenarioWasteRecoveryMonthlyUsd={scenarioMetrics.scenarioWasteRecoveryMonthlyUsd}
-	scenarioWasteRecoveryWindowUsd={scenarioMetrics.scenarioWasteRecoveryWindowUsd}
-	monthlySpendUsd={roiInputs.monthlySpendUsd}
+	{roiMonthlySpendUsd}
 	{scenarioWasteWithoutPct}
 	{scenarioWasteWithPct}
 	{scenarioWindowMonths}
-	{formatUsd}
 	{localCurrencyCode}
 	currencyCode={roiCurrencyCode}
 	onCurrencyCodeChange={handleCurrencyCodeChange}

--- a/dashboard/src/lib/components/LandingHero.svelte.test.ts
+++ b/dashboard/src/lib/components/LandingHero.svelte.test.ts
@@ -1,7 +1,45 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/svelte';
-import { readable } from 'svelte/store';
 import LandingHero from './LandingHero.svelte';
+
+const LANDING_HERO_PROPS = {
+	initialExperiments: {
+		buyerPersonaDefault: 'cto',
+		heroVariant: 'control_every_dollar',
+		ctaVariant: 'start_free',
+		sectionOrderVariant: 'problem_first',
+		seed: 'default'
+	},
+	includeExperimentQueryParams: false,
+	initialMotionProfile: 'subtle',
+	canonicalUrl: 'https://example.com/',
+	ogImageUrl: 'https://example.com/og-image.png',
+	detectedCurrencyCode: 'USD',
+	buyerPersonaId: 'cto',
+	heroPrimaryIntent: 'engineering_control',
+	heroTitle: 'Control cloud spend without slowing delivery.',
+	heroSubtitle:
+		'Valdrics gives finance and engineering one workflow for triage, approval, execution, and savings proof.',
+	initialSnapshot: {
+		id: 'snp-2026-02-27-a',
+		label: 'Snapshot A',
+		capturedAt: '2026-02-27T20:55:58Z',
+		traceId: 'trace-snapshot-a',
+		lanes: [
+			{
+				id: 'economic_visibility',
+				status: 'Watch',
+				severity: 'watch',
+				wasteUsd: 12400,
+				actionLabel: 'Assign Owner'
+			},
+			{ id: 'deterministic_enforcement', status: 'Stable', severity: 'healthy' },
+			{ id: 'financial_governance', status: 'Stable', severity: 'healthy' },
+			{ id: 'operational_resilience', status: 'Stable', severity: 'healthy' }
+		],
+		sources: ['Cloud cost telemetry', 'Failure drill evidence', 'Execution coverage report']
+	}
+} as const;
 
 vi.mock('$env/dynamic/public', () => ({
 	env: {
@@ -10,14 +48,7 @@ vi.mock('$env/dynamic/public', () => ({
 }));
 
 vi.mock('$app/paths', () => ({
-	assets: '',
 	base: ''
-}));
-
-vi.mock('$app/stores', () => ({
-	page: readable({
-		url: new URL('https://example.com/')
-	})
 }));
 
 afterEach(() => {
@@ -32,7 +63,7 @@ describe('LandingHero', () => {
 		(window as Window & { dataLayer?: unknown[] }).dataLayer = dataLayer;
 		window.localStorage.setItem('valdrics.cookie_consent.v1', 'accepted');
 
-		render(LandingHero);
+		render(LandingHero, LANDING_HERO_PROPS);
 
 		expect(
 			screen.getByRole('heading', {
@@ -41,19 +72,21 @@ describe('LandingHero', () => {
 			})
 		).toBeTruthy();
 		expect(
-			screen.getByRole('heading', { name: /replace reactive cleanup with one operating path/i })
+			await screen.findByRole('heading', {
+				name: /replace reactive cleanup with one operating path/i
+			})
 		).toBeTruthy();
 		expect(
-			screen.getByRole('heading', { name: /model the savings case in minutes/i })
+			await screen.findByRole('heading', { name: /model the savings case in minutes/i })
 		).toBeTruthy();
 		expect(
-			screen.getByRole('heading', { name: /pricing that matches rollout stage/i })
+			await screen.findByRole('heading', { name: /pricing that matches rollout stage/i })
 		).toBeTruthy();
 		expect(
-			screen.getByRole('heading', { name: /review the company before you talk to us/i })
+			await screen.findByRole('heading', { name: /review the company before you talk to us/i })
 		).toBeTruthy();
 
-		const currencyGroups = screen.getAllByRole('group', { name: /display currency/i });
+		const currencyGroups = await screen.findAllByRole('group', { name: /display currency/i });
 		expect(currencyGroups.length).toBeGreaterThanOrEqual(1);
 		const firstCurrencyGroup = within(currencyGroups[0]!);
 		expect(firstCurrencyGroup.getAllByRole('button').length).toBeGreaterThanOrEqual(1);
@@ -81,7 +114,7 @@ describe('LandingHero', () => {
 
 	it('shows cookie consent controls before analytics is accepted', async () => {
 		window.localStorage.removeItem('valdrics.cookie_consent.v1');
-		render(LandingHero);
+		render(LandingHero, LANDING_HERO_PROPS);
 
 		expect(await screen.findByRole('dialog', { name: /cookie preferences/i })).toBeTruthy();
 		const declineButton = screen.getByRole('button', { name: /decline analytics/i });
@@ -90,7 +123,7 @@ describe('LandingHero', () => {
 	});
 
 	it('renders a real dashboard still with concise proof notes', () => {
-		render(LandingHero);
+		render(LandingHero, LANDING_HERO_PROPS);
 
 		expect(screen.getByRole('img', { name: /real valdrics dashboard/i })).toBeTruthy();
 		const productStill = within(screen.getByLabelText(/real product dashboard screenshot/i));
@@ -102,7 +135,7 @@ describe('LandingHero', () => {
 		expect(productStill.getByText(/^linked proof$/i)).toBeTruthy();
 	});
 
-	it('disables auto-rotation when reduced motion is preferred', () => {
+	it('disables auto-rotation when reduced motion is preferred', async () => {
 		vi.useFakeTimers();
 		const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
 		const originalMatchMedia = window.matchMedia;
@@ -116,7 +149,9 @@ describe('LandingHero', () => {
 			value: matchMediaStub
 		});
 
-		const { unmount } = render(LandingHero);
+		const { unmount } = render(LandingHero, LANDING_HERO_PROPS);
+		await Promise.resolve();
+		await Promise.resolve();
 		const intervalDurationsMs = setIntervalSpy.mock.calls.map((call) => Number(call[1]));
 		expect(intervalDurationsMs).not.toContain(4400);
 		expect(intervalDurationsMs).not.toContain(3200);
@@ -130,13 +165,15 @@ describe('LandingHero', () => {
 		vi.useRealTimers();
 	});
 
-	it('cleans rotating intervals on unmount for concurrency safety', () => {
+	it('cleans rotating intervals on unmount for concurrency safety', async () => {
 		vi.useFakeTimers();
 		const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
 		const clearIntervalSpy = vi.spyOn(globalThis, 'clearInterval');
 
-		const { unmount } = render(LandingHero);
-		expect(setIntervalSpy).toHaveBeenCalled();
+		const { unmount } = render(LandingHero, LANDING_HERO_PROPS);
+		await waitFor(() => {
+			expect(setIntervalSpy).toHaveBeenCalled();
+		});
 
 		unmount();
 		expect(clearIntervalSpy).toHaveBeenCalled();

--- a/dashboard/src/lib/components/identity/IdentityDiagnosticsSection.svelte
+++ b/dashboard/src/lib/components/identity/IdentityDiagnosticsSection.svelte
@@ -1,15 +1,70 @@
 <script lang="ts">
+	import { onMount } from 'svelte';
+	import { api } from '$lib/api';
+	import { edgeApiPath } from '$lib/edgeProxy';
+	import { TimeoutError } from '$lib/fetchWithTimeout';
+	import { clientLogger } from '$lib/logging/client';
+	import { formatValidationIssues } from '$lib/validation/clientZod';
+	import { isGrowthPlus } from './identitySettingsHelpers';
+	import {
+		extractErrorMessage,
+		IDENTITY_REQUEST_TIMEOUT_MS,
+		IdentityDiagnosticsSchema
+	} from './identitySettingsModel';
 	import type { IdentityDiagnostics } from './identitySettingsTypes';
 
 	let {
-		diagnosticsLoading = false,
-		diagnostics = null,
-		onRefresh = () => {}
+		accessToken,
+		tier
 	}: {
-		diagnosticsLoading?: boolean;
-		diagnostics?: IdentityDiagnostics | null;
-		onRefresh?: () => void | Promise<void>;
+		accessToken?: string | null;
+		tier?: string | null;
 	} = $props();
+
+	let diagnosticsLoading = $state(false);
+	let diagnostics = $state<IdentityDiagnostics | null>(null);
+	let diagnosticsError = $state('');
+
+	async function loadDiagnostics() {
+		diagnosticsLoading = true;
+		diagnosticsError = '';
+		try {
+			if (!accessToken || !isGrowthPlus(tier)) {
+				diagnostics = null;
+				return;
+			}
+			const res = await api.get(edgeApiPath('/settings/identity/diagnostics'), {
+				headers: { Authorization: `Bearer ${accessToken}` },
+				timeoutMs: IDENTITY_REQUEST_TIMEOUT_MS
+			});
+			if (res.status === 403) {
+				diagnostics = null;
+				return;
+			}
+			if (!res.ok) {
+				const data = await res.json().catch(() => ({}));
+				throw new Error(extractErrorMessage(data, 'Failed to load identity diagnostics'));
+			}
+			const parsedResult = IdentityDiagnosticsSchema.safeParse(await res.json());
+			if (!parsedResult.success) {
+				throw parsedResult.error;
+			}
+			diagnostics = parsedResult.data as IdentityDiagnostics;
+		} catch (error) {
+			clientLogger.error('Failed to load identity diagnostics:', error);
+			diagnosticsError =
+				error instanceof TimeoutError
+					? 'Identity diagnostics request timed out. Try again.'
+					: formatValidationIssues(error, false);
+			diagnostics = null;
+		} finally {
+			diagnosticsLoading = false;
+		}
+	}
+
+	onMount(() => {
+		void loadDiagnostics();
+	});
 </script>
 
 <div class="rounded-xl border border-ink-800/60 bg-ink-950/30 p-4">
@@ -23,12 +78,16 @@
 		<button
 			type="button"
 			class="btn btn-secondary shrink-0"
-			onclick={onRefresh}
+			onclick={loadDiagnostics}
 			disabled={diagnosticsLoading}
 		>
 			{diagnosticsLoading ? 'Refreshing…' : 'Refresh Diagnostics'}
 		</button>
 	</div>
+
+	{#if diagnosticsError}
+		<p class="mt-3 text-xs text-danger-300">{diagnosticsError}</p>
+	{/if}
 
 	{#if diagnosticsLoading}
 		<div class="mt-4 space-y-2">

--- a/dashboard/src/lib/components/identity/IdentityScimSection.svelte
+++ b/dashboard/src/lib/components/identity/IdentityScimSection.svelte
@@ -1,40 +1,145 @@
 <script lang="ts">
+	import { env as publicEnv } from '$env/dynamic/public';
+	import { api } from '$lib/api';
+	import { edgeApiPath } from '$lib/edgeProxy';
+	import { formatValidationIssues } from '$lib/validation/clientZod';
+	import {
+		extractErrorMessage,
+		RotateTokenResponseSchema,
+		ScimTokenTestResponseSchema
+	} from './identitySettingsModel';
+	import { scimBaseUrlFromPublicApiUrl } from './identitySettingsHelpers';
 	import type { IdentitySettings } from './identitySettingsTypes';
 
 	let {
+		accessToken,
 		tier,
-		settings = $bindable(),
-		rotating = false,
-		rotatedToken = '',
-		rotatedAt = '',
-		scimTokenInput = $bindable(''),
-		scimTokenTesting = false,
-		scimTokenTestStatus = '',
-		scimBaseUrl,
-		onRotateScimToken = () => {},
-		onCopyToken = () => {},
-		onTestScimToken = () => {},
-		onAddGroupMapping = () => {},
-		onRemoveGroupMapping = () => {}
+		settings = $bindable()
 	}: {
+		accessToken?: string | null;
 		tier?: string | null;
 		settings: IdentitySettings;
-		rotating?: boolean;
-		rotatedToken?: string;
-		rotatedAt?: string;
-		scimTokenInput: string;
-		scimTokenTesting?: boolean;
-		scimTokenTestStatus?: string;
-		scimBaseUrl: string;
-		onRotateScimToken?: () => void | Promise<void>;
-		onCopyToken?: () => void | Promise<void>;
-		onTestScimToken?: () => void | Promise<void>;
-		onAddGroupMapping?: () => void;
-		onRemoveGroupMapping?: (index: number) => void;
 	} = $props();
+
+	let rotating = $state(false);
+	let rotatedToken = $state('');
+	let rotatedAt = $state('');
+	let scimTokenInput = $state('');
+	let scimTokenTesting = $state(false);
+	let scimTokenTestStatus = $state('');
+	let scimFeedback = $state('');
+	let scimFeedbackTone = $state<'success' | 'error'>('success');
 
 	function isEnterprise(currentTier: string | null | undefined): boolean {
 		return (currentTier ?? '').toLowerCase() === 'enterprise';
+	}
+
+	function scimBaseUrl(): string {
+		const publicApiUrl = String(publicEnv.PUBLIC_API_URL || '').trim();
+		return scimBaseUrlFromPublicApiUrl(publicApiUrl);
+	}
+
+	function setFeedback(message: string, tone: 'success' | 'error') {
+		scimFeedback = message;
+		scimFeedbackTone = tone;
+	}
+
+	async function rotateScimToken() {
+		rotating = true;
+		setFeedback('', 'success');
+		rotatedToken = '';
+		rotatedAt = '';
+		try {
+			if (!accessToken) {
+				throw new Error('Missing access token for SCIM token rotation');
+			}
+			const res = await api.post(
+				edgeApiPath('/settings/identity/rotate-scim-token'),
+				{},
+				{ headers: { Authorization: `Bearer ${accessToken}` } }
+			);
+			if (!res.ok) {
+				const data = await res.json().catch(() => ({}));
+				throw new Error(
+					extractErrorMessage(
+						data,
+						res.status === 403
+							? 'SCIM token rotation requires Enterprise tier and admin access.'
+							: 'Failed to rotate SCIM token'
+					)
+				);
+			}
+			const payloadResult = RotateTokenResponseSchema.safeParse(await res.json());
+			if (!payloadResult.success) {
+				throw payloadResult.error;
+			}
+			const payload = payloadResult.data;
+			rotatedToken = payload.scim_token;
+			rotatedAt = payload.rotated_at;
+			settings.has_scim_token = true;
+			settings.scim_last_rotated_at = payload.rotated_at;
+			setFeedback('SCIM token rotated. Store it now; it is shown only once.', 'success');
+		} catch (error) {
+			setFeedback(formatValidationIssues(error, false), 'error');
+		} finally {
+			rotating = false;
+		}
+	}
+
+	async function copyToken() {
+		if (!rotatedToken) return;
+		try {
+			await navigator.clipboard.writeText(rotatedToken);
+			setFeedback('Copied token to clipboard.', 'success');
+		} catch {
+			setFeedback('Failed to copy token. Copy manually.', 'error');
+		}
+	}
+
+	async function testScimToken() {
+		scimTokenTesting = true;
+		scimTokenTestStatus = '';
+		setFeedback('', 'success');
+		try {
+			if (!scimTokenInput.trim()) return;
+			if (!accessToken) {
+				throw new Error('Missing access token for SCIM token test');
+			}
+			const res = await api.post(
+				edgeApiPath('/settings/identity/scim/test-token'),
+				{ scim_token: scimTokenInput.trim() },
+				{ headers: { Authorization: `Bearer ${accessToken}` } }
+			);
+			if (!res.ok) {
+				const data = await res.json().catch(() => ({}));
+				throw new Error(extractErrorMessage(data, 'Failed to test SCIM token'));
+			}
+			const payloadResult = ScimTokenTestResponseSchema.safeParse(await res.json());
+			if (!payloadResult.success) {
+				throw payloadResult.error;
+			}
+			scimTokenTestStatus = payloadResult.data.token_matches
+				? 'Token matches.'
+				: 'Token does not match.';
+		} catch (error) {
+			setFeedback(formatValidationIssues(error, false), 'error');
+		} finally {
+			scimTokenTesting = false;
+			scimTokenInput = '';
+		}
+	}
+
+	function addGroupMapping() {
+		settings.scim_group_mappings = [
+			...(settings.scim_group_mappings ?? []),
+			{ group: '', role: 'member', persona: null }
+		];
+	}
+
+	function removeGroupMapping(index: number) {
+		settings.scim_group_mappings = (settings.scim_group_mappings ?? []).filter(
+			(_, currentIndex) => currentIndex !== index
+		);
 	}
 </script>
 
@@ -47,13 +152,21 @@
 		<div>
 			<p class="font-medium">SCIM Provisioning</p>
 			<p class="text-xs text-ink-500 mt-1">
-				Enterprise-only. Base URL: <span class="font-mono">{scimBaseUrl}</span>
+				Enterprise-only. Base URL: <span class="font-mono">{scimBaseUrl()}</span>
 			</p>
 		</div>
 		{#if !isEnterprise(tier)}
 			<span class="badge badge-warning text-xs shrink-0">Enterprise Required</span>
 		{/if}
 	</div>
+
+	{#if scimFeedback}
+		<p
+			class={`mt-3 text-xs ${scimFeedbackTone === 'success' ? 'text-success-300' : 'text-danger-300'}`}
+		>
+			{scimFeedback}
+		</p>
+	{/if}
 
 	<div class="mt-4 space-y-3">
 		<label class="flex items-center gap-3 cursor-pointer">
@@ -72,7 +185,7 @@
 			<button
 				type="button"
 				class="btn btn-secondary"
-				onclick={onRotateScimToken}
+				onclick={rotateScimToken}
 				disabled={rotating || !settings.scim_enabled}
 			>
 				{rotating ? 'Rotating…' : 'Rotate SCIM Token'}
@@ -88,7 +201,7 @@
 				</p>
 				<div class="flex flex-col gap-2 sm:flex-row sm:items-center">
 					<input class="font-mono text-xs" readonly value={rotatedToken} aria-label="SCIM token" />
-					<button type="button" class="btn btn-primary" onclick={onCopyToken}>Copy</button>
+					<button type="button" class="btn btn-primary" onclick={copyToken}>Copy</button>
 				</div>
 			</div>
 		{/if}
@@ -108,7 +221,7 @@
 					<button
 						type="button"
 						class="btn btn-secondary"
-						onclick={onTestScimToken}
+						onclick={testScimToken}
 						disabled={scimTokenTesting || !scimTokenInput.trim()}
 					>
 						{scimTokenTesting ? 'Testing…' : 'Test Token'}
@@ -129,7 +242,7 @@
 							Optional. Map IdP groups to Valdrics role/persona at provisioning time.
 						</p>
 					</div>
-					<button type="button" class="btn btn-secondary" onclick={onAddGroupMapping}>
+					<button type="button" class="btn btn-secondary" onclick={addGroupMapping}>
 						Add mapping
 					</button>
 				</div>
@@ -171,7 +284,7 @@
 									<button
 										type="button"
 										class="btn btn-secondary"
-										onclick={() => onRemoveGroupMapping(index)}
+										onclick={() => removeGroupMapping(index)}
 									>
 										Remove
 									</button>

--- a/dashboard/src/lib/components/landing/LandingCurrencyToggle.svelte
+++ b/dashboard/src/lib/components/landing/LandingCurrencyToggle.svelte
@@ -58,7 +58,7 @@
 	</div>
 	{#if showUsdToggle}
 		<p class="landing-currency-toggle__note">
-			Local currency uses indicative FX. Switch to USD to compare.
+			USD is the default comparison view. Local display uses indicative FX.
 		</p>
 	{/if}
 </div>

--- a/dashboard/src/lib/components/landing/LandingHeroBelowFold.svelte
+++ b/dashboard/src/lib/components/landing/LandingHeroBelowFold.svelte
@@ -1,0 +1,325 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { base } from '$app/paths';
+	import type { LandingCurrencyCode } from '$lib/landing/currencyPreference';
+	import { formatCurrencyAmount } from '$lib/landing/currencyDisplay';
+	import { calculateLandingHeroScenarioMetrics } from '$lib/landing/landingHeroScenario';
+	import { createLazyComponent } from '$lib/lazyComponent';
+	import LandingHeroRoiPlaceholder from '$lib/components/landing/LandingHeroRoiPlaceholder.svelte';
+	import type {
+		LandingSignalLaneSnapshot,
+		LandingSignalSnapshot
+	} from '$lib/landing/landingSignalSnapshots';
+	import type { SignalLaneId } from '$lib/landing/realtimeSignalMap';
+
+	const publicLaneTitles: Record<SignalLaneId, string> = {
+		economic_visibility: 'Signal captured',
+		deterministic_enforcement: 'Checks applied',
+		financial_governance: 'Approval routed',
+		operational_resilience: 'Outcome recorded'
+	};
+
+	const productPillars = [
+		{
+			title: 'See the issue with context',
+			detail:
+				'Cost, owner, approval, and policy context stay on one record instead of being rebuilt across dashboards and threads.'
+		},
+		{
+			title: 'Route it to the right person',
+			detail:
+				'Engineering and finance move from the same operating record instead of chasing ownership in chat.'
+		},
+		{
+			title: 'Finish with proof',
+			detail:
+				'Every material action keeps the decision trail and savings story ready for finance, security, or procurement review.'
+		}
+	] as const;
+
+	type LandingRoiSimulatorProps = {
+		normalizedScenarioWasteWithoutPct: number;
+		normalizedScenarioWasteWithPct: number;
+		normalizedScenarioWindowMonths: number;
+		scenarioWithoutBarPct: number;
+		scenarioWithBarPct: number;
+		scenarioWasteWithoutUsd: number;
+		scenarioWasteWithUsd: number;
+		scenarioWasteRecoveryMonthlyUsd: number;
+		scenarioWasteRecoveryWindowUsd: number;
+		monthlySpendUsd: number;
+		scenarioWasteWithoutPct: number;
+		scenarioWasteWithPct: number;
+		scenarioWindowMonths: number;
+		formatUsd: (amount: number, currency?: string) => string;
+		currencyCode: LandingCurrencyCode | string;
+		localCurrencyCode: LandingCurrencyCode;
+		onCurrencyCodeChange?: (value: LandingCurrencyCode) => void;
+		plannerHref: string;
+		onTrackScenarioAdjust: (control: string) => void;
+		onScenarioWasteWithoutChange: (value: number) => void;
+		onScenarioWasteWithChange: (value: number) => void;
+		onScenarioWindowChange: (value: number) => void;
+		onTrackPlannerCta: () => void;
+	};
+
+	const loadLandingRoiSimulator = createLazyComponent<LandingRoiSimulatorProps>(
+		() => import('$lib/components/landing/LandingRoiSimulator.svelte')
+	);
+	type LandingHeroTrustSectionsProps = {
+		freeTierCtaHref: string;
+		trustEnterpriseHref: string;
+		aboutHref: string;
+		docsHref: string;
+		statusHref: string;
+		proofHref?: string;
+		requestValidationBriefingHref: string;
+		onePagerHref: string;
+		onTrackCta: (action: string, section: string, value: string) => void;
+	};
+	const loadLandingHeroTrustSections = createLazyComponent<LandingHeroTrustSectionsProps>(
+		() => import('$lib/components/landing/LandingHeroTrustSections.svelte')
+	);
+
+	let {
+		activeSnapshot,
+		activeSignalLane,
+		roiMonthlySpendUsd,
+		scenarioWasteWithoutPct,
+		scenarioWasteWithPct,
+		scenarioWindowMonths,
+		currencyCode,
+		localCurrencyCode,
+		onCurrencyCodeChange = () => {},
+		onTrackScenarioAdjust,
+		onScenarioWasteWithoutChange,
+		onScenarioWasteWithChange,
+		onScenarioWindowChange,
+		roiPlannerHref,
+		freeTierCtaHref,
+		trustEnterpriseHref,
+		aboutHref,
+		docsHref,
+		statusHref,
+		proofHref = '/proof',
+		requestValidationBriefingHref,
+		onePagerHref,
+		onTrackCta
+	}: {
+		activeSnapshot: LandingSignalSnapshot;
+		activeSignalLane: LandingSignalLaneSnapshot;
+		roiMonthlySpendUsd: number;
+		scenarioWasteWithoutPct: number;
+		scenarioWasteWithPct: number;
+		scenarioWindowMonths: number;
+		currencyCode: LandingCurrencyCode | string;
+		localCurrencyCode: LandingCurrencyCode;
+		onCurrencyCodeChange?: (value: LandingCurrencyCode) => void;
+		onTrackScenarioAdjust: (control: string) => void;
+		onScenarioWasteWithoutChange: (value: number) => void;
+		onScenarioWasteWithChange: (value: number) => void;
+		onScenarioWindowChange: (value: number) => void;
+		roiPlannerHref: string;
+		freeTierCtaHref: string;
+		trustEnterpriseHref: string;
+		aboutHref: string;
+		docsHref: string;
+		statusHref: string;
+		proofHref?: string;
+		requestValidationBriefingHref: string;
+		onePagerHref: string;
+		onTrackCta: (action: string, section: string, value: string) => void;
+	} = $props();
+
+	let scenarioMetrics = $derived(
+		calculateLandingHeroScenarioMetrics({
+			monthlySpendUsd: roiMonthlySpendUsd,
+			wasteWithoutPct: scenarioWasteWithoutPct,
+			wasteWithPct: scenarioWasteWithPct,
+			windowMonths: scenarioWindowMonths
+		})
+	);
+	const formatUsd = (amount: number, currency: string = String(currencyCode)) =>
+		formatCurrencyAmount(amount, currency);
+
+	let simulatorAnchor: HTMLDivElement | null = $state(null);
+	let simulatorVisible = $state(import.meta.env.MODE === 'test');
+	let trustSectionsAnchor: HTMLDivElement | null = $state(null);
+	let trustSectionsVisible = $state(import.meta.env.MODE === 'test');
+
+	onMount(() => {
+		if (simulatorVisible || typeof IntersectionObserver === 'undefined') {
+			simulatorVisible = true;
+			return;
+		}
+
+		const observer = new IntersectionObserver(
+			(entries) => {
+				if (entries.some((entry) => entry.isIntersecting)) {
+					simulatorVisible = true;
+					observer.disconnect();
+				}
+			},
+			{ rootMargin: '420px 0px' }
+		);
+
+		if (simulatorAnchor) {
+			observer.observe(simulatorAnchor);
+		}
+
+		return () => observer.disconnect();
+	});
+
+	onMount(() => {
+		if (trustSectionsVisible || typeof IntersectionObserver === 'undefined') {
+			trustSectionsVisible = true;
+			return;
+		}
+
+		const observer = new IntersectionObserver(
+			(entries) => {
+				if (entries.some((entry) => entry.isIntersecting)) {
+					trustSectionsVisible = true;
+					observer.disconnect();
+				}
+			},
+			{ rootMargin: '520px 0px' }
+		);
+
+		if (trustSectionsAnchor) {
+			observer.observe(trustSectionsAnchor);
+		}
+
+		return () => observer.disconnect();
+	});
+</script>
+
+<section id="product" class="landing-public-section" data-landing-section="product">
+	<div class="container mx-auto px-6 py-12">
+		<div class="landing-public-section-head">
+			<p class="landing-public-eyebrow">Why it feels calmer</p>
+			<h2>Replace reactive cleanup with one operating path</h2>
+			<p>
+				Most teams already know where the waste is. The hard part is ownership, approval, and proof.
+				Valdrics keeps that work in one place.
+			</p>
+		</div>
+		<div class="landing-public-pillar-grid">
+			{#each productPillars as pillar (pillar.title)}
+				<article class="landing-public-surface landing-public-pillar-card">
+					<h3>{pillar.title}</h3>
+					<p>{pillar.detail}</p>
+				</article>
+			{/each}
+		</div>
+		<div class="landing-public-band">
+			<div>
+				<p class="landing-public-eyebrow">What changes in practice</p>
+				<h3>One record carries the issue from alert to decision</h3>
+				<p>
+					Finance, engineering, and leadership review the same story instead of rebuilding context
+					from dashboards, tickets, and chat threads.
+				</p>
+			</div>
+			<div class="landing-public-impact-grid">
+				<div>
+					<span>Current stage</span>
+					<strong>{publicLaneTitles[activeSignalLane.id] ?? activeSignalLane.id}</strong>
+				</div>
+				<div>
+					<span>Action path</span>
+					<strong>{activeSignalLane.actionLabel ?? 'Assigned before review'}</strong>
+				</div>
+				<div>
+					<span>Linked sources</span>
+					<strong>{activeSnapshot.sources.length} attached inputs</strong>
+				</div>
+			</div>
+		</div>
+	</div>
+</section>
+
+<div bind:this={simulatorAnchor}>
+	{#if simulatorVisible}
+		{#await loadLandingRoiSimulator() then module}
+			{@const LandingRoiSimulator = module.default}
+			<LandingRoiSimulator
+				normalizedScenarioWasteWithoutPct={scenarioMetrics.normalizedScenarioWasteWithoutPct}
+				normalizedScenarioWasteWithPct={scenarioMetrics.normalizedScenarioWasteWithPct}
+				normalizedScenarioWindowMonths={scenarioMetrics.normalizedScenarioWindowMonths}
+				scenarioWithoutBarPct={scenarioMetrics.scenarioWithoutBarPct}
+				scenarioWithBarPct={scenarioMetrics.scenarioWithBarPct}
+				scenarioWasteWithoutUsd={scenarioMetrics.scenarioWasteWithoutUsd}
+				scenarioWasteWithUsd={scenarioMetrics.scenarioWasteWithUsd}
+				scenarioWasteRecoveryMonthlyUsd={scenarioMetrics.scenarioWasteRecoveryMonthlyUsd}
+				scenarioWasteRecoveryWindowUsd={scenarioMetrics.scenarioWasteRecoveryWindowUsd}
+				monthlySpendUsd={roiMonthlySpendUsd}
+				{scenarioWasteWithoutPct}
+				{scenarioWasteWithPct}
+				{scenarioWindowMonths}
+				{formatUsd}
+				{currencyCode}
+				{localCurrencyCode}
+				{onCurrencyCodeChange}
+				plannerHref={roiPlannerHref}
+				{onTrackScenarioAdjust}
+				{onScenarioWasteWithoutChange}
+				{onScenarioWasteWithChange}
+				{onScenarioWindowChange}
+				onTrackPlannerCta={() => onTrackCta('cta_click', 'simulator', 'open_full_roi_planner')}
+			/>
+		{:catch}
+			<LandingHeroRoiPlaceholder />
+		{/await}
+	{:else}
+		<LandingHeroRoiPlaceholder />
+	{/if}
+</div>
+
+<div bind:this={trustSectionsAnchor}>
+	{#if trustSectionsVisible}
+		{#await loadLandingHeroTrustSections() then module}
+			{@const LandingHeroTrustSections = module.default}
+			<LandingHeroTrustSections
+				{freeTierCtaHref}
+				{trustEnterpriseHref}
+				{aboutHref}
+				{docsHref}
+				{statusHref}
+				{proofHref}
+				{requestValidationBriefingHref}
+				{onePagerHref}
+				{onTrackCta}
+			/>
+		{/await}
+	{:else}
+		<section
+			id="plans"
+			class="landing-public-section"
+			data-landing-section="plans"
+			aria-hidden="true"
+		>
+			<div class="container mx-auto px-6 py-12">
+				<div class="landing-public-surface">
+					<div class="skeleton mb-3 h-4 w-28"></div>
+					<div class="skeleton mb-3 h-8 w-72"></div>
+					<div class="skeleton h-4 w-full"></div>
+				</div>
+			</div>
+		</section>
+		<section
+			id="trust"
+			class="landing-public-section"
+			data-landing-section="trust"
+			aria-hidden="true"
+		>
+			<div class="container mx-auto px-6 py-12">
+				<div class="landing-public-surface">
+					<div class="skeleton mb-3 h-4 w-24"></div>
+					<div class="skeleton mb-3 h-8 w-72"></div>
+					<div class="skeleton h-4 w-full"></div>
+				</div>
+			</div>
+		</section>
+	{/if}
+</div>

--- a/dashboard/src/lib/components/landing/LandingHeroRoiPlaceholder.svelte
+++ b/dashboard/src/lib/components/landing/LandingHeroRoiPlaceholder.svelte
@@ -1,0 +1,28 @@
+<section id="simulator" class="container mx-auto px-6 py-12" data-landing-section="simulator">
+	<div class="landing-section-head">
+		<div>
+			<h2 class="landing-h2">Model the savings case in minutes</h2>
+			<p class="landing-section-sub">
+				Adjust a few operating assumptions and show the gap between reactive cleanup and governed
+				execution.
+			</p>
+		</div>
+	</div>
+
+	<div class="landing-sim-grid" aria-busy="true">
+		<div class="landing-public-surface landing-sim-controls">
+			<div class="skeleton h-4 w-32 mb-4"></div>
+			<div class="skeleton h-10 w-full mb-5"></div>
+			<div class="skeleton h-4 w-32 mb-4"></div>
+			<div class="skeleton h-10 w-full mb-5"></div>
+			<div class="skeleton h-4 w-32 mb-4"></div>
+			<div class="skeleton h-10 w-full"></div>
+		</div>
+		<div class="landing-public-surface landing-sim-results">
+			<div class="skeleton h-4 w-28 mb-4"></div>
+			<div class="skeleton h-16 w-full mb-4"></div>
+			<div class="skeleton h-16 w-full mb-4"></div>
+			<div class="skeleton h-24 w-full"></div>
+		</div>
+	</div>
+</section>

--- a/dashboard/src/lib/components/landing/LandingHeroTrustSections.svelte
+++ b/dashboard/src/lib/components/landing/LandingHeroTrustSections.svelte
@@ -1,0 +1,181 @@
+<script lang="ts">
+	import { base } from '$app/paths';
+
+	const landingPlanPreview = [
+		{
+			name: 'Free',
+			price: '$0',
+			summary: 'Prove one owner-routed workflow without procurement overhead.',
+			cta: 'Start Free Workspace',
+			href: null
+		},
+		{
+			name: 'Growth',
+			price: '$149',
+			summary:
+				'Best fit for cross-functional teams that need shared cost ownership and collaboration.',
+			cta: 'See Growth on Pricing',
+			href: `${base}/pricing`
+		},
+		{
+			name: 'Pro',
+			price: '$299',
+			summary:
+				'Finance-grade controls, exports, and workflow depth without jumping straight into enterprise sales.',
+			cta: 'Review Pro Details',
+			href: `${base}/pricing`
+		}
+	] as const;
+
+	let {
+		freeTierCtaHref,
+		trustEnterpriseHref,
+		aboutHref,
+		docsHref,
+		statusHref,
+		proofHref = '/proof',
+		requestValidationBriefingHref,
+		onePagerHref,
+		onTrackCta
+	}: {
+		freeTierCtaHref: string;
+		trustEnterpriseHref: string;
+		aboutHref: string;
+		docsHref: string;
+		statusHref: string;
+		proofHref?: string;
+		requestValidationBriefingHref: string;
+		onePagerHref: string;
+		onTrackCta: (action: string, section: string, value: string) => void;
+	} = $props();
+</script>
+
+<section id="plans" class="landing-public-section" data-landing-section="plans">
+	<div class="container mx-auto px-6 py-12">
+		<div class="landing-public-section-head">
+			<p class="landing-public-eyebrow">Pricing</p>
+			<h2>Pricing that matches rollout stage</h2>
+			<p>
+				Start small, prove the workflow, and only move up when the team needs more governance depth.
+			</p>
+		</div>
+		<div class="landing-public-plan-grid">
+			{#each landingPlanPreview as plan (plan.name)}
+				<article class="landing-public-surface landing-public-plan-card">
+					<p class="landing-public-proof-label">{plan.name}</p>
+					<div class="landing-public-plan-price">{plan.price}</div>
+					<p>{plan.summary}</p>
+					{#if plan.href}
+						<a
+							href={plan.href}
+							class="btn btn-secondary"
+							onclick={() => onTrackCta('cta_click', 'plans', plan.name.toLowerCase())}
+						>
+							{plan.cta}
+						</a>
+					{:else}
+						<a
+							href={freeTierCtaHref}
+							class="btn btn-primary"
+							onclick={() => onTrackCta('cta_click', 'plans', 'free')}
+						>
+							{plan.cta}
+						</a>
+					{/if}
+				</article>
+			{/each}
+		</div>
+		<div class="landing-public-band landing-public-band--compact">
+			<div>
+				<p class="landing-public-eyebrow">Full pricing</p>
+				<h3>Compare the full plan details before you commit</h3>
+				<p>
+					Use the pricing page for full plan details. Contact enterprise for security, procurement,
+					or deployment requirements.
+				</p>
+			</div>
+			<div class="landing-public-band-actions">
+				<a
+					href={`${base}/pricing`}
+					class="btn btn-secondary"
+					onclick={() => onTrackCta('cta_click', 'plans', 'view_pricing')}
+				>
+					See Detailed Pricing
+				</a>
+				<a
+					href={trustEnterpriseHref}
+					class="btn btn-secondary"
+					onclick={() => onTrackCta('cta_click', 'plans', 'enterprise_review')}
+				>
+					Enterprise Review
+				</a>
+			</div>
+		</div>
+	</div>
+</section>
+
+<section id="trust" class="landing-public-section" data-landing-section="trust">
+	<div class="container mx-auto px-6 py-12">
+		<div class="landing-public-section-head">
+			<p class="landing-public-eyebrow">Trust</p>
+			<h2>Review the company before you talk to us</h2>
+			<p>Review the company, proof pack, and technical materials before you book a call.</p>
+		</div>
+		<div class="landing-public-trust-grid">
+			<article class="landing-public-surface landing-public-trust-card">
+				<p class="landing-public-proof-label">Proof pack</p>
+				<h3>Start with the materials, not the pitch</h3>
+				<p>Open the proof pack, one-pager, and technical validation notes directly.</p>
+				<div class="landing-public-link-list">
+					<a href={proofHref} onclick={() => onTrackCta('cta_click', 'trust', 'proof_pack')}>
+						Open Proof Pack
+					</a>
+					<a href={onePagerHref} onclick={() => onTrackCta('cta_click', 'trust', 'one_pager')}>
+						Download One-Pager
+					</a>
+					<a href={docsHref} onclick={() => onTrackCta('cta_click', 'trust', 'docs')}>
+						Technical Validation
+					</a>
+				</div>
+			</article>
+			<article class="landing-public-surface landing-public-trust-card">
+				<p class="landing-public-proof-label">Company</p>
+				<h3>Know who is behind the product</h3>
+				<p>
+					Review the founder, company background, and public contact channels before procurement
+					starts.
+				</p>
+				<div class="landing-public-link-list">
+					<a href={aboutHref} onclick={() => onTrackCta('cta_click', 'trust', 'about')}
+						>About / Team</a
+					>
+					<a href={statusHref} onclick={() => onTrackCta('cta_click', 'trust', 'status')}
+						>Status Page</a
+					>
+				</div>
+			</article>
+			<article class="landing-public-surface landing-public-trust-card">
+				<p class="landing-public-proof-label">Enterprise review</p>
+				<h3>Use enterprise review when it is needed</h3>
+				<p>
+					Security, privacy, residency, and procurement questions can be handled separately without
+					slowing down a basic evaluation.
+				</p>
+				<div class="landing-public-link-list">
+					<a
+						href={trustEnterpriseHref}
+						onclick={() => onTrackCta('cta_click', 'trust', 'enterprise')}
+					>
+						Enterprise Review
+					</a>
+					<a
+						href={requestValidationBriefingHref}
+						onclick={() => onTrackCta('cta_click', 'trust', 'validation_briefing')}
+					>
+						Request Validation Briefing
+					</a>
+				</div>
+			</article>
+		</div>
+	</div>
+</section>

--- a/dashboard/src/lib/components/landing/LandingHeroView.svelte
+++ b/dashboard/src/lib/components/landing/LandingHeroView.svelte
@@ -4,14 +4,13 @@
 	import { onMount } from 'svelte';
 	import type { SignalLaneId } from '$lib/landing/realtimeSignalMap';
 	import type { LandingCurrencyCode } from '$lib/landing/currencyPreference';
+	import { formatCurrencyAmount } from '$lib/landing/currencyDisplay';
 	import type {
 		LandingSignalLaneSnapshot,
 		LandingSignalSnapshot
 	} from '$lib/landing/landingSignalSnapshots';
 	import { createLazyComponent } from '$lib/lazyComponent';
 	import LandingHeroCopy from '$lib/components/landing/LandingHeroCopy.svelte';
-	import LandingRoiSimulator from '$lib/components/landing/LandingRoiSimulator.svelte';
-	import LandingCookieConsent from '$lib/components/landing/LandingCookieConsent.svelte';
 	import './LandingMarketingShared.css';
 	import './LandingHeroView.public.css';
 
@@ -22,8 +21,47 @@
 		onTrackCta: (action: string, section: string, value: string) => void;
 	};
 
+	type LandingHeroBelowFoldProps = {
+		activeSnapshot: LandingSignalSnapshot;
+		activeSignalLane: LandingSignalLaneSnapshot;
+		roiMonthlySpendUsd: number;
+		scenarioWasteWithoutPct: number;
+		scenarioWasteWithPct: number;
+		scenarioWindowMonths: number;
+		currencyCode: LandingCurrencyCode | string;
+		localCurrencyCode: LandingCurrencyCode;
+		onCurrencyCodeChange?: (value: LandingCurrencyCode) => void;
+		onTrackScenarioAdjust: (control: string) => void;
+		onScenarioWasteWithoutChange: (value: number) => void;
+		onScenarioWasteWithChange: (value: number) => void;
+		onScenarioWindowChange: (value: number) => void;
+		roiPlannerHref: string;
+		freeTierCtaHref: string;
+		trustEnterpriseHref: string;
+		aboutHref: string;
+		docsHref: string;
+		statusHref: string;
+		proofHref?: string;
+		requestValidationBriefingHref: string;
+		onePagerHref: string;
+		onTrackCta: (action: string, section: string, value: string) => void;
+	};
+
+	type LandingCookieConsentProps = {
+		visible: boolean;
+		onAccept: () => void;
+		onReject: () => void;
+		onClose: () => void;
+	};
+
 	const loadLandingExitIntentPrompt = createLazyComponent<LandingExitIntentPromptProps>(
 		() => import('$lib/components/landing/LandingExitIntentPrompt.svelte')
+	);
+	const loadLandingHeroBelowFold = createLazyComponent<LandingHeroBelowFoldProps>(
+		() => import('$lib/components/landing/LandingHeroBelowFold.svelte')
+	);
+	const loadLandingCookieConsent = createLazyComponent<LandingCookieConsentProps>(
+		() => import('$lib/components/landing/LandingCookieConsent.svelte')
 	);
 
 	const publicLaneTitles: Record<SignalLaneId, string> = {
@@ -32,50 +70,6 @@
 		financial_governance: 'Approval routed',
 		operational_resilience: 'Outcome recorded'
 	};
-
-	const productPillars = [
-		{
-			title: 'See the issue with context',
-			detail:
-				'Cost, owner, approval, and policy context stay on one record instead of being rebuilt across dashboards and threads.'
-		},
-		{
-			title: 'Route it to the right person',
-			detail:
-				'Engineering and finance move from the same operating record instead of chasing ownership in chat.'
-		},
-		{
-			title: 'Finish with proof',
-			detail:
-				'Every material action keeps the decision trail and savings story ready for finance, security, or procurement review.'
-		}
-	] as const;
-
-	const landingPlanPreview = [
-		{
-			name: 'Free',
-			price: '$0',
-			summary: 'Prove one owner-routed workflow without procurement overhead.',
-			cta: 'Start Free Workspace',
-			href: null
-		},
-		{
-			name: 'Growth',
-			price: '$149',
-			summary:
-				'Best fit for cross-functional teams that need shared cost ownership and collaboration.',
-			cta: 'See Growth on Pricing',
-			href: `${base}/pricing`
-		},
-		{
-			name: 'Pro',
-			price: '$299',
-			summary:
-				'Finance-grade controls, exports, and workflow depth without jumping straight into enterprise sales.',
-			cta: 'Review Pro Details',
-			href: `${base}/pricing`
-		}
-	] as const;
 
 	function formatCapturedAt(value: string): string {
 		const date = new Date(value);
@@ -103,20 +97,10 @@
 		secondaryCtaTelemetryValue,
 		activeSnapshot,
 		activeSignalLane,
-		normalizedScenarioWasteWithoutPct,
-		normalizedScenarioWasteWithPct,
-		normalizedScenarioWindowMonths,
-		scenarioWithoutBarPct,
-		scenarioWithBarPct,
-		scenarioWasteWithoutUsd,
-		scenarioWasteWithUsd,
-		scenarioWasteRecoveryMonthlyUsd,
-		scenarioWasteRecoveryWindowUsd,
-		monthlySpendUsd,
+		roiMonthlySpendUsd,
 		scenarioWasteWithoutPct,
 		scenarioWasteWithPct,
 		scenarioWindowMonths,
-		formatUsd,
 		currencyCode,
 		localCurrencyCode,
 		onCurrencyCodeChange = () => {},
@@ -154,20 +138,10 @@
 		secondaryCtaTelemetryValue: string;
 		activeSnapshot: LandingSignalSnapshot;
 		activeSignalLane: LandingSignalLaneSnapshot;
-		normalizedScenarioWasteWithoutPct: number;
-		normalizedScenarioWasteWithPct: number;
-		normalizedScenarioWindowMonths: number;
-		scenarioWithoutBarPct: number;
-		scenarioWithBarPct: number;
-		scenarioWasteWithoutUsd: number;
-		scenarioWasteWithUsd: number;
-		scenarioWasteRecoveryMonthlyUsd: number;
-		scenarioWasteRecoveryWindowUsd: number;
-		monthlySpendUsd: number;
+		roiMonthlySpendUsd: number;
 		scenarioWasteWithoutPct: number;
 		scenarioWasteWithPct: number;
 		scenarioWindowMonths: number;
-		formatUsd: (amount: number, currency?: string) => string;
 		currencyCode: LandingCurrencyCode | string;
 		localCurrencyCode: LandingCurrencyCode;
 		onCurrencyCodeChange?: (value: LandingCurrencyCode) => void;
@@ -201,6 +175,8 @@
 	);
 	let highlightedActionLabel = $derived(activeSignalLane.actionLabel ?? 'Assign owner');
 	let laneSeverityTone = $derived(activeSignalLane.severity ?? 'healthy');
+	const formatPreviewAmount = (amount: number, currency: string = String(currencyCode)) =>
+		formatCurrencyAmount(amount, currency);
 
 	onMount(() => {
 		if (import.meta.env.MODE === 'test') {
@@ -307,7 +283,9 @@
 						<article class="landing-public-still-note">
 							<span>Linked proof</span>
 							<strong>{activeSnapshot.sources.length} attached inputs</strong>
-							<small>{formatUsd(highlightedWasteUsd, currencyCode)} at risk tracked</small>
+							<small
+								>{formatPreviewAmount(highlightedWasteUsd, String(currencyCode))} at risk tracked</small
+							>
 						</article>
 					</div>
 				</aside>
@@ -330,207 +308,34 @@
 		</div>
 	</section>
 
-	<section id="product" class="landing-public-section" data-landing-section="product">
-		<div class="container mx-auto px-6 py-12">
-			<div class="landing-public-section-head">
-				<p class="landing-public-eyebrow">Why it feels calmer</p>
-				<h2>Replace reactive cleanup with one operating path</h2>
-				<p>
-					Most teams already know where the waste is. The hard part is ownership, approval, and
-					proof. Valdrics keeps that work in one place.
-				</p>
-			</div>
-			<div class="landing-public-pillar-grid">
-				{#each productPillars as pillar (pillar.title)}
-					<article class="landing-public-surface landing-public-pillar-card">
-						<h3>{pillar.title}</h3>
-						<p>{pillar.detail}</p>
-					</article>
-				{/each}
-			</div>
-			<div class="landing-public-band">
-				<div>
-					<p class="landing-public-eyebrow">What changes in practice</p>
-					<h3>One record carries the issue from alert to decision</h3>
-					<p>
-						Finance, engineering, and leadership review the same story instead of rebuilding context
-						from dashboards, tickets, and chat threads.
-					</p>
-				</div>
-				<div class="landing-public-impact-grid">
-					<div>
-						<span>Current stage</span>
-						<strong>{publicLaneTitles[activeSignalLane.id] ?? activeSignalLane.id}</strong>
-					</div>
-					<div>
-						<span>Action path</span>
-						<strong>{activeSignalLane.actionLabel ?? 'Assigned before review'}</strong>
-					</div>
-					<div>
-						<span>Linked sources</span>
-						<strong>{activeSnapshot.sources.length} attached inputs</strong>
-					</div>
-				</div>
-			</div>
-		</div>
-	</section>
-
-	<LandingRoiSimulator
-		{normalizedScenarioWasteWithoutPct}
-		{normalizedScenarioWasteWithPct}
-		{normalizedScenarioWindowMonths}
-		{scenarioWithoutBarPct}
-		{scenarioWithBarPct}
-		{scenarioWasteWithoutUsd}
-		{scenarioWasteWithUsd}
-		{scenarioWasteRecoveryMonthlyUsd}
-		{scenarioWasteRecoveryWindowUsd}
-		{monthlySpendUsd}
-		{scenarioWasteWithoutPct}
-		{scenarioWasteWithPct}
-		{scenarioWindowMonths}
-		{formatUsd}
-		{currencyCode}
-		{localCurrencyCode}
-		{onCurrencyCodeChange}
-		plannerHref={roiPlannerHref}
-		{onTrackScenarioAdjust}
-		{onScenarioWasteWithoutChange}
-		{onScenarioWasteWithChange}
-		{onScenarioWindowChange}
-		onTrackPlannerCta={() => onTrackCta('cta_click', 'simulator', 'open_full_roi_planner')}
-	/>
-
-	<section id="plans" class="landing-public-section" data-landing-section="plans">
-		<div class="container mx-auto px-6 py-12">
-			<div class="landing-public-section-head">
-				<p class="landing-public-eyebrow">Pricing</p>
-				<h2>Pricing that matches rollout stage</h2>
-				<p>
-					Start small, prove the workflow, and only move up when the team needs more governance
-					depth.
-				</p>
-			</div>
-			<div class="landing-public-plan-grid">
-				{#each landingPlanPreview as plan (plan.name)}
-					<article class="landing-public-surface landing-public-plan-card">
-						<p class="landing-public-proof-label">{plan.name}</p>
-						<div class="landing-public-plan-price">{plan.price}</div>
-						<p>{plan.summary}</p>
-						{#if plan.href}
-							<a
-								href={plan.href}
-								class="btn btn-secondary"
-								onclick={() => onTrackCta('cta_click', 'plans', plan.name.toLowerCase())}
-							>
-								{plan.cta}
-							</a>
-						{:else}
-							<a
-								href={freeTierCtaHref}
-								class="btn btn-primary"
-								onclick={() => onTrackCta('cta_click', 'plans', 'free')}
-							>
-								{plan.cta}
-							</a>
-						{/if}
-					</article>
-				{/each}
-			</div>
-			<div class="landing-public-band landing-public-band--compact">
-				<div>
-					<p class="landing-public-eyebrow">Full pricing</p>
-					<h3>Compare the full plan details before you commit</h3>
-					<p>
-						Use the pricing page for full plan details. Contact enterprise for security,
-						procurement, or deployment requirements.
-					</p>
-				</div>
-				<div class="landing-public-band-actions">
-					<a
-						href={`${base}/pricing`}
-						class="btn btn-secondary"
-						onclick={() => onTrackCta('cta_click', 'plans', 'view_pricing')}
-					>
-						See Detailed Pricing
-					</a>
-					<a
-						href={trustEnterpriseHref}
-						class="btn btn-secondary"
-						onclick={() => onTrackCta('cta_click', 'plans', 'enterprise_review')}
-					>
-						Enterprise Review
-					</a>
-				</div>
-			</div>
-		</div>
-	</section>
-
-	<section id="trust" class="landing-public-section" data-landing-section="trust">
-		<div class="container mx-auto px-6 py-12">
-			<div class="landing-public-section-head">
-				<p class="landing-public-eyebrow">Trust</p>
-				<h2>Review the company before you talk to us</h2>
-				<p>Review the company, proof pack, and technical materials before you book a call.</p>
-			</div>
-			<div class="landing-public-trust-grid">
-				<article class="landing-public-surface landing-public-trust-card">
-					<p class="landing-public-proof-label">Proof pack</p>
-					<h3>Start with the materials, not the pitch</h3>
-					<p>Open the proof pack, one-pager, and technical validation notes directly.</p>
-					<div class="landing-public-link-list">
-						<a href={proofHref} onclick={() => onTrackCta('cta_click', 'trust', 'proof_pack')}>
-							Open Proof Pack
-						</a>
-						<a href={onePagerHref} onclick={() => onTrackCta('cta_click', 'trust', 'one_pager')}>
-							Download One-Pager
-						</a>
-						<a href={docsHref} onclick={() => onTrackCta('cta_click', 'trust', 'docs')}>
-							Technical Validation
-						</a>
-					</div>
-				</article>
-				<article class="landing-public-surface landing-public-trust-card">
-					<p class="landing-public-proof-label">Company</p>
-					<h3>Know who is behind the product</h3>
-					<p>
-						Review the founder, company background, and public contact channels before procurement
-						starts.
-					</p>
-					<div class="landing-public-link-list">
-						<a href={aboutHref} onclick={() => onTrackCta('cta_click', 'trust', 'about')}
-							>About / Team</a
-						>
-						<a href={statusHref} onclick={() => onTrackCta('cta_click', 'trust', 'status')}
-							>Status Page</a
-						>
-					</div>
-				</article>
-				<article class="landing-public-surface landing-public-trust-card">
-					<p class="landing-public-proof-label">Enterprise review</p>
-					<h3>Use enterprise review when it is needed</h3>
-					<p>
-						Security, privacy, residency, and procurement questions can be handled separately
-						without slowing down a basic evaluation.
-					</p>
-					<div class="landing-public-link-list">
-						<a
-							href={trustEnterpriseHref}
-							onclick={() => onTrackCta('cta_click', 'trust', 'enterprise')}
-						>
-							Enterprise Review
-						</a>
-						<a
-							href={requestValidationBriefingHref}
-							onclick={() => onTrackCta('cta_click', 'trust', 'validation_briefing')}
-						>
-							Request Validation Briefing
-						</a>
-					</div>
-				</article>
-			</div>
-		</div>
-	</section>
+	{#await loadLandingHeroBelowFold() then module}
+		{@const LandingHeroBelowFold = module.default}
+		<LandingHeroBelowFold
+			{activeSnapshot}
+			{activeSignalLane}
+			{roiMonthlySpendUsd}
+			{scenarioWasteWithoutPct}
+			{scenarioWasteWithPct}
+			{scenarioWindowMonths}
+			{currencyCode}
+			{localCurrencyCode}
+			{onCurrencyCodeChange}
+			{onTrackScenarioAdjust}
+			{onScenarioWasteWithoutChange}
+			{onScenarioWasteWithChange}
+			{onScenarioWindowChange}
+			{roiPlannerHref}
+			{freeTierCtaHref}
+			{trustEnterpriseHref}
+			{aboutHref}
+			{docsHref}
+			{statusHref}
+			{proofHref}
+			{requestValidationBriefingHref}
+			{onePagerHref}
+			{onTrackCta}
+		/>
+	{/await}
 
 	{#if showBackToTop}
 		<a
@@ -542,12 +347,16 @@
 		</a>
 	{/if}
 
-	<LandingCookieConsent
-		visible={cookieBannerVisible}
-		onAccept={() => onSetTelemetryConsent(true)}
-		onReject={() => onSetTelemetryConsent(false)}
-		onClose={onCloseCookieBanner}
-	/>
+	{#if cookieBannerVisible}
+		{#await loadLandingCookieConsent() then { default: LandingCookieConsent }}
+			<LandingCookieConsent
+				visible={cookieBannerVisible}
+				onAccept={() => onSetTelemetryConsent(true)}
+				onReject={() => onSetTelemetryConsent(false)}
+				onClose={onCloseCookieBanner}
+			/>
+		{/await}
+	{/if}
 
 	{#if !cookieBannerVisible}
 		<button type="button" class="landing-cookie-settings" onclick={onOpenCookieSettings}>

--- a/dashboard/src/lib/components/landing/LandingHeroView.svelte.test.ts
+++ b/dashboard/src/lib/components/landing/LandingHeroView.svelte.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, render } from '@testing-library/svelte';
+import { cleanup, render, waitFor } from '@testing-library/svelte';
 import LandingHeroView from './LandingHeroView.svelte';
 import type { LandingCurrencyCode } from '$lib/landing/currencyPreference';
 import { CLOUD_HOOK_STATES } from '$lib/landing/heroContent.core';
@@ -43,20 +43,10 @@ function buildProps() {
 		onSelectDemoStep: vi.fn(),
 		onSelectSnapshot: vi.fn(),
 		onSignalMapElementChange: vi.fn(),
-		normalizedScenarioWasteWithoutPct: 18,
-		normalizedScenarioWasteWithPct: 7,
-		normalizedScenarioWindowMonths: 12,
-		scenarioWithoutBarPct: 100,
-		scenarioWithBarPct: 40,
-		scenarioWasteWithoutUsd: 21600,
-		scenarioWasteWithUsd: 8400,
-		scenarioWasteRecoveryMonthlyUsd: 13200,
-		scenarioWasteRecoveryWindowUsd: 158400,
-		monthlySpendUsd: 120000,
+		roiMonthlySpendUsd: 120000,
 		scenarioWasteWithoutPct: 18,
 		scenarioWasteWithPct: 7,
 		scenarioWindowMonths: 12,
-		formatUsd: (amount: number) => `$${amount.toFixed(0)}`,
 		localCurrencyCode: 'USD' as LandingCurrencyCode,
 		currencyCode: 'USD' as LandingCurrencyCode,
 		onCurrencyCodeChange: vi.fn(),
@@ -87,31 +77,35 @@ function buildProps() {
 }
 
 describe('LandingHeroView', () => {
-	it('renders the fixed landing narrative order', () => {
+	it('renders the fixed landing narrative order', async () => {
 		const view = render(LandingHeroView, {
 			props: buildProps()
 		});
 
-		const sectionIds = Array.from(view.container.querySelectorAll('section[id]')).map(
-			(element) => element.id
-		);
-		expect(sectionIds).toEqual(['hero', 'product', 'simulator', 'plans', 'trust']);
+		await waitFor(() => {
+			const sectionIds = Array.from(view.container.querySelectorAll('section[id]')).map(
+				(element) => element.id
+			);
+			expect(sectionIds).toEqual(['hero', 'product', 'simulator', 'plans', 'trust']);
+		});
 	});
 
-	it('renders the trust section with proof and human-proof links wired', () => {
+	it('renders the trust section with proof and human-proof links wired', async () => {
 		const view = render(LandingHeroView, {
 			props: buildProps()
 		});
 
-		const trustSection = view.container.querySelector('#trust');
-		expect(trustSection).toBeTruthy();
-		expect(trustSection?.textContent || '').toContain('Review the company before you talk to us');
-		expect(
-			(trustSection?.querySelector('a[href*="/proof"]') as HTMLAnchorElement | null)?.href || ''
-		).toContain('/proof');
-		expect(
-			(trustSection?.querySelector('a[href*="/about"]') as HTMLAnchorElement | null)?.href || ''
-		).toContain('/about');
+		await waitFor(() => {
+			const trustSection = view.container.querySelector('#trust');
+			expect(trustSection).toBeTruthy();
+			expect(trustSection?.textContent || '').toContain('Review the company before you talk to us');
+			expect(
+				(trustSection?.querySelector('a[href*="/proof"]') as HTMLAnchorElement | null)?.href || ''
+			).toContain('/proof');
+			expect(
+				(trustSection?.querySelector('a[href*="/about"]') as HTMLAnchorElement | null)?.href || ''
+			).toContain('/about');
+		});
 	});
 
 	it('renders the hero with a real dashboard still instead of the old synthetic mockup', () => {

--- a/dashboard/src/lib/components/landing/landing_decomposition.svelte.test.ts
+++ b/dashboard/src/lib/components/landing/landing_decomposition.svelte.test.ts
@@ -202,6 +202,9 @@ describe('Landing component decomposition', () => {
 		const landingDir = resolve(process.cwd(), 'src/lib/components/landing');
 		const files = [
 			'LandingHeroCopy.svelte',
+			'LandingHeroBelowFold.svelte',
+			'LandingHeroRoiPlaceholder.svelte',
+			'LandingHeroTrustSections.svelte',
 			'LandingHeroView.svelte',
 			'LandingHumanProofStrip.svelte',
 			'LandingOutcomeBand.svelte',

--- a/dashboard/src/lib/components/public/PublicContentArticlePage.svelte
+++ b/dashboard/src/lib/components/public/PublicContentArticlePage.svelte
@@ -1,20 +1,20 @@
 <script lang="ts">
 	import { base } from '$app/paths';
 	import { page } from '$app/stores';
-	import { listRelatedPublicContent, type PublicContentEntry } from '$lib/content/publicContent';
+	import type { PublicContentEntry } from '$lib/content/publicContent.types';
 	import { appendPublicAttribution } from '$lib/public/publicBuyingMotion';
 	import PublicPageMeta from './PublicPageMeta.svelte';
 	import './PublicMarketingPage.css';
 
 	interface Props {
 		entry: PublicContentEntry;
+		relatedEntries: PublicContentEntry[];
 		hubHref: string;
 		hubLabel: string;
 	}
 
-	let { entry, hubHref, hubLabel }: Props = $props();
+	let { entry, relatedEntries, hubHref, hubLabel }: Props = $props();
 
-	let relatedEntries = $derived(listRelatedPublicContent(entry));
 	let trackingEntry = $derived(
 		`${entry.kind}_${entry.slug}`.replace(/[^a-z0-9]+/gi, '_').toLowerCase()
 	);

--- a/dashboard/src/lib/components/public/PublicContentArticlePage.svelte.test.ts
+++ b/dashboard/src/lib/components/public/PublicContentArticlePage.svelte.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, render, screen } from '@testing-library/svelte';
 import { readable } from 'svelte/store';
-import { getPublicContentEntry } from '$lib/content/publicContent';
+import { getPublicContentEntry, listRelatedPublicContent } from '$lib/content/publicContent';
 import PublicContentArticlePage from './PublicContentArticlePage.svelte';
 
 vi.mock('$app/paths', () => ({
@@ -26,6 +26,7 @@ describe('PublicContentArticlePage', () => {
 
 		render(PublicContentArticlePage, {
 			entry,
+			relatedEntries: listRelatedPublicContent(entry),
 			hubHref: '/docs',
 			hubLabel: 'Back to Documentation'
 		});

--- a/dashboard/src/lib/components/public/PublicPageMeta.svelte
+++ b/dashboard/src/lib/components/public/PublicPageMeta.svelte
@@ -86,6 +86,7 @@
 		<meta property="article:section" content={contentEntry.kind} />
 	{/if}
 	{#each structuredDataMarkup as item, index (`structured-data-${index}`)}
+		<!-- Structured data in Svelte head requires raw script injection; JSON is pre-escaped above. -->
 		<!-- eslint-disable-next-line svelte/no-at-html-tags -->
 		{@html item}
 	{/each}

--- a/dashboard/src/lib/landing/currencyDisplay.ts
+++ b/dashboard/src/lib/landing/currencyDisplay.ts
@@ -1,0 +1,65 @@
+export const SUPPORTED_CURRENCIES = Object.freeze([
+	{ code: 'USD', label: 'USD ($)', symbol: '$' },
+	{ code: 'EUR', label: 'EUR (€)', symbol: '€' },
+	{ code: 'GBP', label: 'GBP (£)', symbol: '£' },
+	{ code: 'NGN', label: 'NGN (₦)', symbol: '₦' },
+	{ code: 'CNY', label: 'CNY (¥)', symbol: '¥' }
+]);
+
+const CURRENCY_LOCALES: Record<string, string> = Object.freeze({
+	USD: 'en-US',
+	EUR: 'de-DE',
+	GBP: 'en-GB',
+	NGN: 'en-NG',
+	CNY: 'zh-CN'
+});
+
+const DISPLAY_FX_RATES_FROM_USD: Record<string, number> = Object.freeze({
+	USD: 1,
+	EUR: 0.92,
+	GBP: 0.79,
+	NGN: 1580,
+	CNY: 7.2
+});
+
+function roundCurrency(value: number): number {
+	if (!Number.isFinite(value)) return 0;
+	return Math.round(value * 100) / 100;
+}
+
+export function normalizeSupportedCurrencyCode(currencyCode: string | null | undefined): string {
+	const normalized = String(currencyCode ?? '')
+		.trim()
+		.toUpperCase();
+	return SUPPORTED_CURRENCIES.some((currency) => currency.code === normalized) ? normalized : 'USD';
+}
+
+export function getCurrencyMetadata(currencyCode: string | null | undefined) {
+	const normalized = normalizeSupportedCurrencyCode(currencyCode);
+	return (
+		SUPPORTED_CURRENCIES.find((currency) => currency.code === normalized) ?? SUPPORTED_CURRENCIES[0]
+	);
+}
+
+export function convertUsdAmount(amountUsd: number, currencyCode: string = 'USD'): number {
+	const normalizedCurrencyCode = normalizeSupportedCurrencyCode(currencyCode);
+	const fxRate = DISPLAY_FX_RATES_FROM_USD[normalizedCurrencyCode] ?? 1;
+	return roundCurrency((Number.isFinite(amountUsd) ? amountUsd : 0) * fxRate);
+}
+
+export function formatCurrencyAmount(amountUsd: number, currencyCode: string = 'USD'): string {
+	const normalizedCurrencyCode = normalizeSupportedCurrencyCode(currencyCode);
+	const safeAmount = convertUsdAmount(amountUsd, normalizedCurrencyCode);
+	const locale = CURRENCY_LOCALES[normalizedCurrencyCode] ?? 'en-US';
+
+	try {
+		return new Intl.NumberFormat(locale, {
+			style: 'currency',
+			currency: normalizedCurrencyCode,
+			maximumFractionDigits: 0,
+			minimumFractionDigits: 0
+		}).format(safeAmount);
+	} catch {
+		return `${normalizedCurrencyCode} ${safeAmount.toLocaleString('en-US', { maximumFractionDigits: 0 })}`;
+	}
+}

--- a/dashboard/src/lib/landing/currencyPreference.test.ts
+++ b/dashboard/src/lib/landing/currencyPreference.test.ts
@@ -32,13 +32,13 @@ describe('currencyPreference', () => {
 		expect(module.resolveDetectedLandingCurrency()).toBe('EUR');
 	});
 
-	it('persists an explicit supported currency selection', async () => {
+	it('persists an explicit USD selection across visits', async () => {
 		const module = await loadModuleWithDetectedCurrency('EUR');
-		module.setLandingCurrencyPreference('GBP');
+		module.setLandingCurrencyPreference('USD');
 
-		expect(window.localStorage.getItem('valdrics_landing_currency')).toBe('GBP');
-		expect(module.getLandingCurrencyPreference()).toBe('GBP');
-		expect(module.resolveInitialLandingCurrency()).toBe('GBP');
+		expect(window.localStorage.getItem('valdrics_landing_currency')).toBe('USD');
+		expect(module.getLandingCurrencyPreference()).toBe('USD');
+		expect(module.resolveInitialLandingCurrency()).toBe('USD');
 	});
 
 	it('falls back to the detected local currency when storage contains an unsupported value', async () => {
@@ -49,12 +49,36 @@ describe('currencyPreference', () => {
 		expect(module.resolveInitialLandingCurrency()).toBe('CNY');
 	});
 
-	it('ignores unsupported currency values and preserves the prior valid preference', async () => {
-		const module = await loadModuleWithDetectedCurrency('NGN');
-		module.setLandingCurrencyPreference('EUR');
+	it('ignores unsupported currency values and preserves the current valid public preference', async () => {
+		const module = await loadModuleWithDetectedCurrency('EUR');
+		module.setLandingCurrencyPreference('USD');
+		module.setLandingCurrencyPreference('NGN' as 'USD');
 		module.setLandingCurrencyPreference('ZZZ' as 'USD');
 
+		expect(module.getLandingCurrencyPreference()).toBe('USD');
+		expect(window.localStorage.getItem('valdrics_landing_currency')).toBe('USD');
+	});
+
+	it('falls back to USD when the detected local currency is NGN', async () => {
+		const module = await loadModuleWithDetectedCurrency('NGN');
+
+		expect(module.resolveDetectedLandingCurrency()).toBe('USD');
+		expect(module.resolveInitialLandingCurrency()).toBe('USD');
+	});
+
+	it('ignores a previously stored NGN landing preference', async () => {
+		window.localStorage.setItem('valdrics_landing_currency', 'NGN');
+
+		const module = await loadModuleWithDetectedCurrency('EUR');
 		expect(module.getLandingCurrencyPreference()).toBe('EUR');
-		expect(window.localStorage.getItem('valdrics_landing_currency')).toBe('EUR');
+		expect(module.resolveInitialLandingCurrency()).toBe('EUR');
+	});
+
+	it('ignores a stale stored local currency when the current detected local currency changes', async () => {
+		window.localStorage.setItem('valdrics_landing_currency', 'GBP');
+
+		const module = await loadModuleWithDetectedCurrency('EUR');
+		expect(module.getLandingCurrencyPreference()).toBe('EUR');
+		expect(module.resolveInitialLandingCurrency()).toBe('EUR');
 	});
 });

--- a/dashboard/src/lib/landing/currencyPreference.ts
+++ b/dashboard/src/lib/landing/currencyPreference.ts
@@ -1,38 +1,32 @@
 import { browser } from '$app/environment';
-import { detectLocalCurrency, SUPPORTED_CURRENCIES } from '$lib/landing/roiCalculator';
+import { detectLocalCurrency } from '$lib/landing/roiCalculator';
+import {
+	normalizeLandingCurrencyCode,
+	type LandingCurrencyCode
+} from '$lib/landing/landingCurrencyPolicy';
 
-export type LandingCurrencyCode = 'USD' | 'EUR' | 'GBP' | 'NGN' | 'CNY';
+export type { LandingCurrencyCode } from '$lib/landing/landingCurrencyPolicy';
 
 const STORAGE_KEY = 'valdrics_landing_currency';
-const SUPPORTED_CODES = new Set(
-	SUPPORTED_CURRENCIES.map((currency) => currency.code as LandingCurrencyCode)
-);
 
-function normalizeCurrencyCode(value: unknown): LandingCurrencyCode | null {
-	const normalized = String(value ?? '')
-		.trim()
-		.toUpperCase();
-	if (!SUPPORTED_CODES.has(normalized as LandingCurrencyCode)) {
-		return null;
-	}
-	return normalized as LandingCurrencyCode;
-}
-
-export function getLandingCurrencyPreference(): LandingCurrencyCode {
-	if (!browser) return 'USD';
+export function getLandingCurrencyPreference(
+	fallback: LandingCurrencyCode = resolveDetectedLandingCurrency()
+): LandingCurrencyCode {
+	if (!browser) return fallback;
 	try {
-		return (
-			normalizeCurrencyCode(window.localStorage.getItem(STORAGE_KEY)) ??
-			resolveDetectedLandingCurrency()
-		);
+		const storedCurrency = normalizeLandingCurrencyCode(window.localStorage.getItem(STORAGE_KEY));
+		if (!storedCurrency) {
+			return fallback;
+		}
+		return storedCurrency === 'USD' || storedCurrency === fallback ? storedCurrency : fallback;
 	} catch {
-		return resolveDetectedLandingCurrency();
+		return fallback;
 	}
 }
 
 export function setLandingCurrencyPreference(code: LandingCurrencyCode): void {
 	if (!browser) return;
-	const normalized = normalizeCurrencyCode(code);
+	const normalized = normalizeLandingCurrencyCode(code);
 	if (!normalized) return;
 	try {
 		window.localStorage.setItem(STORAGE_KEY, normalized);
@@ -41,11 +35,13 @@ export function setLandingCurrencyPreference(code: LandingCurrencyCode): void {
 	}
 }
 
-export function resolveInitialLandingCurrency(): LandingCurrencyCode {
-	return getLandingCurrencyPreference();
+export function resolveInitialLandingCurrency(
+	fallback: LandingCurrencyCode = resolveDetectedLandingCurrency()
+): LandingCurrencyCode {
+	return getLandingCurrencyPreference(fallback);
 }
 
 export function resolveDetectedLandingCurrency(): LandingCurrencyCode {
 	if (!browser) return 'USD';
-	return normalizeCurrencyCode(detectLocalCurrency()) ?? 'USD';
+	return normalizeLandingCurrencyCode(detectLocalCurrency()) ?? 'USD';
 }

--- a/dashboard/src/lib/landing/geoCurrency.ts
+++ b/dashboard/src/lib/landing/geoCurrency.ts
@@ -1,0 +1,26 @@
+import { detectCurrencyFromCountryCode } from '$lib/landing/roiCalculator';
+import { resolveLandingCurrencyCode, type LandingCurrencyCode } from './landingCurrencyPolicy';
+
+export function normalizeCountryCode(value: string | null): string | null {
+	if (!value) return null;
+	const normalized = value.trim().toUpperCase();
+	if (!normalized || normalized === 'XX') return null;
+	return normalized;
+}
+
+export function resolveCountryCodeFromHeaders(headers: Headers): string | null {
+	return (
+		normalizeCountryCode(headers.get('cf-ipcountry')) ||
+		normalizeCountryCode(headers.get('x-vercel-ip-country')) ||
+		null
+	);
+}
+
+export function resolveGeoCurrencyFromHeaders(headers: Headers): string {
+	const countryCode = resolveCountryCodeFromHeaders(headers);
+	return detectCurrencyFromCountryCode(countryCode) ?? 'USD';
+}
+
+export function resolvePublicLandingCurrencyFromHeaders(headers: Headers): LandingCurrencyCode {
+	return resolveLandingCurrencyCode(resolveGeoCurrencyFromHeaders(headers));
+}

--- a/dashboard/src/lib/landing/landingCurrencyPolicy.ts
+++ b/dashboard/src/lib/landing/landingCurrencyPolicy.ts
@@ -1,0 +1,19 @@
+export const PUBLIC_LANDING_CURRENCIES = ['USD', 'EUR', 'GBP', 'CNY'] as const;
+
+export type LandingCurrencyCode = (typeof PUBLIC_LANDING_CURRENCIES)[number];
+
+const PUBLIC_LANDING_CURRENCY_SET = new Set<string>(PUBLIC_LANDING_CURRENCIES);
+
+export function normalizeLandingCurrencyCode(value: unknown): LandingCurrencyCode | null {
+	const normalized = String(value ?? '')
+		.trim()
+		.toUpperCase();
+	if (!PUBLIC_LANDING_CURRENCY_SET.has(normalized)) {
+		return null;
+	}
+	return normalized as LandingCurrencyCode;
+}
+
+export function resolveLandingCurrencyCode(value: unknown): LandingCurrencyCode {
+	return normalizeLandingCurrencyCode(value) ?? 'USD';
+}

--- a/dashboard/src/lib/landing/landingHeroScenario.ts
+++ b/dashboard/src/lib/landing/landingHeroScenario.ts
@@ -1,5 +1,5 @@
 import { resolveGeoCurrencyHint } from '$lib/landing/landingGeoCurrency';
-import { formatCurrencyAmount, SUPPORTED_CURRENCIES } from '$lib/landing/roiCalculator';
+import { formatCurrencyAmount, SUPPORTED_CURRENCIES } from '$lib/landing/currencyDisplay';
 
 const SUPPORTED_CURRENCY_CODES = new Set(SUPPORTED_CURRENCIES.map((currency) => currency.code));
 

--- a/dashboard/src/lib/landing/landingRoiDefaults.ts
+++ b/dashboard/src/lib/landing/landingRoiDefaults.ts
@@ -1,0 +1,9 @@
+export const LANDING_ROI_DEFAULTS = Object.freeze({
+	monthlySpendUsd: 120000,
+	expectedReductionPct: 12,
+	rolloutDays: 30,
+	teamMembers: 2,
+	blendedHourlyUsd: 145,
+	platformAnnualCostUsd: 9600,
+	currencyCode: 'USD'
+});

--- a/dashboard/src/lib/landing/roiCalculator.ts
+++ b/dashboard/src/lib/landing/roiCalculator.ts
@@ -1,3 +1,20 @@
+import {
+	SUPPORTED_CURRENCIES,
+	convertUsdAmount,
+	formatCurrencyAmount,
+	getCurrencyMetadata,
+	normalizeSupportedCurrencyCode
+} from '$lib/landing/currencyDisplay';
+import { LANDING_ROI_DEFAULTS } from '$lib/landing/landingRoiDefaults';
+
+export {
+	SUPPORTED_CURRENCIES,
+	convertUsdAmount,
+	formatCurrencyAmount,
+	getCurrencyMetadata,
+	normalizeSupportedCurrencyCode
+} from '$lib/landing/currencyDisplay';
+
 export interface LandingRoiInputs {
 	monthlySpendUsd: number;
 	expectedReductionPct: number;
@@ -18,37 +35,7 @@ export interface LandingRoiResult {
 }
 
 export const DEFAULT_LANDING_ROI_INPUTS: LandingRoiInputs = Object.freeze({
-	monthlySpendUsd: 120000,
-	expectedReductionPct: 12,
-	rolloutDays: 30,
-	teamMembers: 2,
-	blendedHourlyUsd: 145,
-	platformAnnualCostUsd: 9600,
-	currencyCode: 'USD'
-});
-
-export const SUPPORTED_CURRENCIES = Object.freeze([
-	{ code: 'USD', label: 'USD ($)', symbol: '$' },
-	{ code: 'EUR', label: 'EUR (€)', symbol: '€' },
-	{ code: 'GBP', label: 'GBP (£)', symbol: '£' },
-	{ code: 'NGN', label: 'NGN (₦)', symbol: '₦' },
-	{ code: 'CNY', label: 'CNY (¥)', symbol: '¥' }
-]);
-
-const CURRENCY_LOCALES: Record<string, string> = Object.freeze({
-	USD: 'en-US',
-	EUR: 'de-DE',
-	GBP: 'en-GB',
-	NGN: 'en-NG',
-	CNY: 'zh-CN'
-});
-
-const DISPLAY_FX_RATES_FROM_USD: Record<string, number> = Object.freeze({
-	USD: 1,
-	EUR: 0.92,
-	GBP: 0.79,
-	NGN: 1580,
-	CNY: 7.2
+	...LANDING_ROI_DEFAULTS
 });
 
 const EURO_REGION_CODES = new Set([
@@ -171,50 +158,6 @@ function clamp(value: number, min: number, max: number): number {
 function roundCurrency(value: number): number {
 	if (!Number.isFinite(value)) return 0;
 	return Math.round(value * 100) / 100;
-}
-
-export function normalizeSupportedCurrencyCode(currencyCode: string | null | undefined): string {
-	const normalized = String(currencyCode ?? '')
-		.trim()
-		.toUpperCase();
-	return SUPPORTED_CURRENCIES.some((currency) => currency.code === normalized) ? normalized : 'USD';
-}
-
-export function getCurrencyMetadata(currencyCode: string | null | undefined) {
-	const normalized = normalizeSupportedCurrencyCode(currencyCode);
-	return (
-		SUPPORTED_CURRENCIES.find((currency) => currency.code === normalized) ?? SUPPORTED_CURRENCIES[0]
-	);
-}
-
-export function convertUsdAmount(amountUsd: number, currencyCode: string = 'USD'): number {
-	const normalizedCurrencyCode = normalizeSupportedCurrencyCode(currencyCode);
-	const fxRate = DISPLAY_FX_RATES_FROM_USD[normalizedCurrencyCode] ?? 1;
-	return roundCurrency((Number.isFinite(amountUsd) ? amountUsd : 0) * fxRate);
-}
-
-/**
- * Deterministically formats USD-based model values into the selected display currency.
- * Public ROI display uses indicative FX for comparison and can always be toggled back to USD.
- *
- * Supported currencies reflect the backend ExchangeRateService targets.
- */
-export function formatCurrencyAmount(amountUsd: number, currencyCode: string = 'USD'): string {
-	const normalizedCurrencyCode = normalizeSupportedCurrencyCode(currencyCode);
-	const safeAmount = convertUsdAmount(amountUsd, normalizedCurrencyCode);
-	const locale = CURRENCY_LOCALES[normalizedCurrencyCode] ?? 'en-US';
-
-	try {
-		return new Intl.NumberFormat(locale, {
-			style: 'currency',
-			currency: normalizedCurrencyCode,
-			maximumFractionDigits: 0,
-			minimumFractionDigits: 0
-		}).format(safeAmount);
-	} catch (e) {
-		// Fallback for unsupported currency codes, deterministic
-		return `${normalizedCurrencyCode} ${safeAmount.toLocaleString('en-US', { maximumFractionDigits: 0 })}`;
-	}
 }
 
 export function normalizeLandingRoiInputs(

--- a/dashboard/src/public.app.css
+++ b/dashboard/src/public.app.css
@@ -8,6 +8,8 @@
 @source not './**/*.test.js';
 @source not './**/*.spec.js';
 @source './routes/layout/PublicSiteShell.svelte';
+@source './routes/layout/PublicMobileMenuDialog.svelte';
+@source './routes/layout/PublicSiteFooter.svelte';
 @source './routes/+page.svelte';
 @source './routes/__capture/dashboard-hero';
 @source './routes/about';

--- a/dashboard/src/routes/+page.server.ts
+++ b/dashboard/src/routes/+page.server.ts
@@ -1,11 +1,55 @@
-import { base } from '$app/paths';
+import { assets, base } from '$app/paths';
 import { redirect } from '@sveltejs/kit';
+import { HERO_ROLE_CONTEXT } from '$lib/landing/heroContent.core';
+import { resolvePublicLandingCurrencyFromHeaders } from '$lib/landing/geoCurrency';
+import type { LandingSignalSnapshot } from '$lib/landing/landingSignalSnapshots';
+import { LANDING_SIGNAL_SNAPSHOTS } from '$lib/landing/landingSignalSnapshots';
+import {
+	resolveLandingExperiments,
+	shouldIncludeExperimentQueryParams
+} from '$lib/landing/landingExperiment';
+import {
+	DEFAULT_EXPERIMENT_ASSIGNMENTS,
+	resolveLandingMotionProfile
+} from '$lib/landing/landingHeroConfig';
 import type { PageServerLoad } from './$types';
 
 const MOTION_QUERY_KEY = 'motion';
 const SUPPORTED_MOTION_VALUES = new Set(['subtle', 'cinematic']);
+function getDefaultLandingSignalSnapshot(): LandingSignalSnapshot {
+	const snapshot = LANDING_SIGNAL_SNAPSHOTS[0];
+	if (!snapshot) {
+		throw new Error('Landing signal snapshots require at least one snapshot.');
+	}
+	return snapshot;
+}
 
-export const load: PageServerLoad = async ({ url, locals }) => {
+const DEFAULT_SIGNAL_SNAPSHOT = getDefaultLandingSignalSnapshot();
+
+function buildLandingHeroData(url: URL, requestHeaders: Headers) {
+	const initialExperiments = resolveLandingExperiments(url, DEFAULT_EXPERIMENT_ASSIGNMENTS.seed);
+	const heroContext =
+		HERO_ROLE_CONTEXT[initialExperiments.buyerPersonaDefault] ?? HERO_ROLE_CONTEXT.cto;
+
+	return {
+		initialExperiments,
+		includeExperimentQueryParams: shouldIncludeExperimentQueryParams(url, false),
+		initialMotionProfile: resolveLandingMotionProfile(url),
+		canonicalUrl: new URL(url.pathname, url.origin).toString(),
+		ogImageUrl: new URL(`${assets}/og-image.png`, url.origin).toString(),
+		detectedCurrencyCode: resolvePublicLandingCurrencyFromHeaders(requestHeaders),
+		buyerPersonaId: initialExperiments.buyerPersonaDefault,
+		heroPrimaryIntent: heroContext.primaryIntent,
+		heroTitle:
+			initialExperiments.heroVariant === 'from_metrics_to_control'
+				? heroContext.metricsTitle
+				: heroContext.controlTitle,
+		heroSubtitle: heroContext.subtitle,
+		initialSnapshot: DEFAULT_SIGNAL_SNAPSHOT
+	};
+}
+
+export const load: PageServerLoad = async ({ url, locals, request }) => {
 	const sessionResult = await locals.safeGetSession().catch(() => ({ user: null }));
 	if (sessionResult.user) {
 		throw redirect(307, `${base}/dashboard${url.search}`);
@@ -13,7 +57,9 @@ export const load: PageServerLoad = async ({ url, locals }) => {
 
 	const rawMotion = url.searchParams.get(MOTION_QUERY_KEY);
 	if (!rawMotion) {
-		return {};
+		return {
+			landingHero: buildLandingHeroData(url, request.headers)
+		};
 	}
 
 	const normalizedMotion = rawMotion.trim().toLowerCase();
@@ -30,5 +76,7 @@ export const load: PageServerLoad = async ({ url, locals }) => {
 		throw redirect(308, `${nextUrl.pathname}${nextUrl.search}`);
 	}
 
-	return {};
+	return {
+		landingHero: buildLandingHeroData(url, request.headers)
+	};
 };

--- a/dashboard/src/routes/+page.svelte
+++ b/dashboard/src/routes/+page.svelte
@@ -1,11 +1,9 @@
 <script lang="ts">
-	import { assets } from '$app/paths';
-	import { page } from '$app/stores';
 	import LandingHero from '$lib/components/LandingHero.svelte';
+	import type { PageData } from './$types';
 	import { PUBLIC_HOME_META } from './homeDashboardContent';
 
-	let canonicalUrl = $derived(new URL($page.url.pathname, $page.url.origin).toString());
-	let ogImageUrl = $derived(new URL(`${assets}/og-image.png`, $page.url.origin).toString());
+	let { data }: { data: PageData } = $props();
 </script>
 
 <svelte:head>
@@ -15,12 +13,12 @@
 	<meta property="og:title" content={PUBLIC_HOME_META.title} />
 	<meta property="og:description" content={PUBLIC_HOME_META.ogDescription} />
 	<meta property="og:type" content="website" />
-	<meta property="og:url" content={canonicalUrl} />
-	<meta property="og:image" content={ogImageUrl} />
+	<meta property="og:url" content={data.landingHero.canonicalUrl} />
+	<meta property="og:image" content={data.landingHero.ogImageUrl} />
 	<meta name="twitter:card" content="summary_large_image" />
 	<meta name="twitter:title" content={PUBLIC_HOME_META.title} />
 	<meta name="twitter:description" content={PUBLIC_HOME_META.ogDescription} />
-	<meta name="twitter:image" content={ogImageUrl} />
+	<meta name="twitter:image" content={data.landingHero.ogImageUrl} />
 </svelte:head>
 
-<LandingHero />
+<LandingHero {...data.landingHero} />

--- a/dashboard/src/routes/api/geo/currency/+server.ts
+++ b/dashboard/src/routes/api/geo/currency/+server.ts
@@ -1,25 +1,13 @@
 import { json } from '@sveltejs/kit';
-import { detectCurrencyFromCountryCode } from '$lib/landing/roiCalculator';
+import {
+	resolveCountryCodeFromHeaders,
+	resolveGeoCurrencyFromHeaders
+} from '$lib/landing/geoCurrency';
 import type { RequestHandler } from './$types';
 
-function normalizeCountryCode(value: string | null): string | null {
-	if (!value) return null;
-	const normalized = value.trim().toUpperCase();
-	if (!normalized || normalized === 'XX') return null;
-	return normalized;
-}
-
-function resolveCountryCode(request: Request): string | null {
-	return (
-		normalizeCountryCode(request.headers.get('cf-ipcountry')) ||
-		normalizeCountryCode(request.headers.get('x-vercel-ip-country')) ||
-		null
-	);
-}
-
 export const GET: RequestHandler = async ({ request }) => {
-	const countryCode = resolveCountryCode(request);
-	const currencyCode = detectCurrencyFromCountryCode(countryCode) ?? 'USD';
+	const countryCode = resolveCountryCodeFromHeaders(request.headers);
+	const currencyCode = resolveGeoCurrencyFromHeaders(request.headers);
 	const source = countryCode ? 'ip_country_header' : 'default';
 
 	return json(

--- a/dashboard/src/routes/docs/+page.server.ts
+++ b/dashboard/src/routes/docs/+page.server.ts
@@ -1,0 +1,10 @@
+import type { PageServerLoad } from './$types';
+import { mustGetPublicContentEntry } from '$lib/content/publicContent';
+
+export const load: PageServerLoad = () => ({
+	operatingGuides: [
+		mustGetPublicContentEntry('docs', 'connect-first-provider'),
+		mustGetPublicContentEntry('docs', 'owner-routing-and-approval-path'),
+		mustGetPublicContentEntry('docs', 'decision-history-and-export-records')
+	]
+});

--- a/dashboard/src/routes/docs/+page.svelte
+++ b/dashboard/src/routes/docs/+page.svelte
@@ -2,18 +2,10 @@
 	import { base } from '$app/paths';
 	import PublicMarketingPage from '$lib/components/public/PublicMarketingPage.svelte';
 	import PublicPageMeta from '$lib/components/public/PublicPageMeta.svelte';
-	import { listPublicContent, type PublicContentEntry } from '$lib/content/publicContent';
+	import type { PublicContentEntry } from '$lib/content/publicContent.types';
+	import type { PageData } from './$types';
 
-	const docsEntries = listPublicContent('docs');
-	const docsBySlug = new Map(docsEntries.map((entry) => [entry.slug, entry] as const));
-
-	function mustGetDoc(slug: string): PublicContentEntry {
-		const entry = docsBySlug.get(slug);
-		if (!entry) {
-			throw new Error(`Unknown docs entry: ${slug}`);
-		}
-		return entry;
-	}
+	let { data }: { data: PageData } = $props();
 
 	const heroHighlights = [
 		{
@@ -51,11 +43,7 @@
 		}
 	] as const;
 
-	const operatingGuides = [
-		mustGetDoc('connect-first-provider'),
-		mustGetDoc('owner-routing-and-approval-path'),
-		mustGetDoc('decision-history-and-export-records')
-	] as const;
+	let operatingGuides = $derived(data.operatingGuides as PublicContentEntry[]);
 </script>
 
 <PublicPageMeta

--- a/dashboard/src/routes/docs/[slug]/+page.server.ts
+++ b/dashboard/src/routes/docs/[slug]/+page.server.ts
@@ -1,0 +1,10 @@
+import type { PageServerLoad } from './$types';
+import { listRelatedPublicContent, mustGetPublicContentEntry } from '$lib/content/publicContent';
+
+export const load: PageServerLoad = ({ params }) => {
+	const entry = mustGetPublicContentEntry('docs', params.slug);
+	return {
+		entry,
+		relatedEntries: listRelatedPublicContent(entry)
+	};
+};

--- a/dashboard/src/routes/docs/[slug]/+page.svelte
+++ b/dashboard/src/routes/docs/[slug]/+page.svelte
@@ -5,4 +5,13 @@
 	let { data }: { data: PageData } = $props();
 </script>
 
-<PublicContentArticlePage entry={data.entry} hubHref="/docs" hubLabel="Back to Documentation" />
+<svelte:head>
+	<title>{data.entry.title} | Valdrics Documentation</title>
+</svelte:head>
+
+<PublicContentArticlePage
+	entry={data.entry}
+	relatedEntries={data.relatedEntries}
+	hubHref="/docs"
+	hubLabel="Back to Documentation"
+/>

--- a/dashboard/src/routes/docs/[slug]/+page.ts
+++ b/dashboard/src/routes/docs/[slug]/+page.ts
@@ -1,6 +1,0 @@
-import type { PageLoad } from './$types';
-import { mustGetPublicContentEntry } from '$lib/content/publicContent';
-
-export const load: PageLoad = ({ params }) => ({
-	entry: mustGetPublicContentEntry('docs', params.slug)
-});

--- a/dashboard/src/routes/docs/docs-page.svelte.test.ts
+++ b/dashboard/src/routes/docs/docs-page.svelte.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/svelte';
 import { readable } from 'svelte/store';
 import Page from './+page.svelte';
+import { mustGetPublicContentEntry } from '$lib/content/publicContent';
 
 vi.mock('$app/paths', () => ({
 	base: '',
@@ -12,9 +13,25 @@ vi.mock('$app/stores', () => ({
 	page: readable({ url: new URL('https://example.com/docs') })
 }));
 
+const SHARED_PAGE_DATA = {
+	user: null,
+	session: null,
+	subscription: { tier: 'starter', status: 'active' },
+	profile: null
+} as const;
+
 describe('docs page', () => {
 	it('renders core documentation sections and links', () => {
-		render(Page);
+		render(Page, {
+			data: {
+				...SHARED_PAGE_DATA,
+				operatingGuides: [
+					mustGetPublicContentEntry('docs', 'connect-first-provider'),
+					mustGetPublicContentEntry('docs', 'owner-routing-and-approval-path'),
+					mustGetPublicContentEntry('docs', 'decision-history-and-export-records')
+				]
+			}
+		});
 
 		const heading = screen.getByRole('heading', {
 			level: 1,

--- a/dashboard/src/routes/insights/+page.server.ts
+++ b/dashboard/src/routes/insights/+page.server.ts
@@ -1,0 +1,6 @@
+import type { PageServerLoad } from './$types';
+import { listPublicContent } from '$lib/content/publicContent';
+
+export const load: PageServerLoad = () => ({
+	insights: listPublicContent('insights')
+});

--- a/dashboard/src/routes/insights/+page.svelte
+++ b/dashboard/src/routes/insights/+page.svelte
@@ -3,14 +3,15 @@
 	import { page } from '$app/stores';
 	import PublicMarketingPage from '$lib/components/public/PublicMarketingPage.svelte';
 	import PublicPageMeta from '$lib/components/public/PublicPageMeta.svelte';
-	import { listPublicContent } from '$lib/content/publicContent';
+	import type { PublicContentEntry } from '$lib/content/publicContent.types';
 	import {
 		buildPublicEnterpriseHref,
 		buildPublicSignupHref,
 		resolvePublicBuyingMotion
 	} from '$lib/public/publicBuyingMotion';
+	import type { PageData } from './$types';
 
-	const insights = listPublicContent('insights');
+	let { data }: { data: PageData } = $props();
 	let buyingMotion = $derived(resolvePublicBuyingMotion($page.url, 'self_serve_first'));
 	let startFreeHref = $derived(
 		buildPublicSignupHref(base, $page.url, {
@@ -39,6 +40,8 @@
 			value: 'Use Insights when the buyer needs education before live product evaluation'
 		}
 	] as const;
+
+	let insights = $derived(data.insights as PublicContentEntry[]);
 </script>
 
 <PublicPageMeta

--- a/dashboard/src/routes/insights/[slug]/+page.server.ts
+++ b/dashboard/src/routes/insights/[slug]/+page.server.ts
@@ -1,0 +1,10 @@
+import type { PageServerLoad } from './$types';
+import { listRelatedPublicContent, mustGetPublicContentEntry } from '$lib/content/publicContent';
+
+export const load: PageServerLoad = ({ params }) => {
+	const entry = mustGetPublicContentEntry('insights', params.slug);
+	return {
+		entry,
+		relatedEntries: listRelatedPublicContent(entry)
+	};
+};

--- a/dashboard/src/routes/insights/[slug]/+page.svelte
+++ b/dashboard/src/routes/insights/[slug]/+page.svelte
@@ -5,4 +5,13 @@
 	let { data }: { data: PageData } = $props();
 </script>
 
-<PublicContentArticlePage entry={data.entry} hubHref="/insights" hubLabel="Back to Insights" />
+<svelte:head>
+	<title>{data.entry.title} | Valdrics Insights</title>
+</svelte:head>
+
+<PublicContentArticlePage
+	entry={data.entry}
+	relatedEntries={data.relatedEntries}
+	hubHref="/insights"
+	hubLabel="Back to Insights"
+/>

--- a/dashboard/src/routes/insights/[slug]/+page.ts
+++ b/dashboard/src/routes/insights/[slug]/+page.ts
@@ -1,6 +1,0 @@
-import type { PageLoad } from './$types';
-import { mustGetPublicContentEntry } from '$lib/content/publicContent';
-
-export const load: PageLoad = ({ params }) => ({
-	entry: mustGetPublicContentEntry('insights', params.slug)
-});

--- a/dashboard/src/routes/insights/insights-page.svelte.test.ts
+++ b/dashboard/src/routes/insights/insights-page.svelte.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/svelte';
 import { readable } from 'svelte/store';
 import Page from './+page.svelte';
+import { listPublicContent } from '$lib/content/publicContent';
 
 vi.mock('$app/paths', () => ({
 	base: '',
@@ -12,9 +13,21 @@ vi.mock('$app/stores', () => ({
 	page: readable({ url: new URL('https://example.com/insights') })
 }));
 
+const SHARED_PAGE_DATA = {
+	user: null,
+	session: null,
+	subscription: { tier: 'starter', status: 'active' },
+	profile: null
+} as const;
+
 describe('insights page', () => {
 	it('renders insight cards and content CTAs', () => {
-		render(Page);
+		render(Page, {
+			data: {
+				...SHARED_PAGE_DATA,
+				insights: listPublicContent('insights')
+			}
+		});
 
 		expect(screen.getByRole('heading', { level: 1, name: /insights/i })).toBeTruthy();
 		expect(

--- a/dashboard/src/routes/layout-public-menu.svelte.test.ts
+++ b/dashboard/src/routes/layout-public-menu.svelte.test.ts
@@ -246,13 +246,15 @@ describe('public layout mobile menu', () => {
 	it('surfaces concise conversion-safe contact channels in footer', async () => {
 		await renderPublicLayout();
 
-		expect(screen.getAllByRole('link', { name: /sales@valdrics\.com/i }).length).toBeGreaterThan(0);
-		expect(screen.getAllByRole('link', { name: /support@valdrics\.com/i }).length).toBeGreaterThan(
-			0
-		);
-		expect(screen.getAllByRole('link', { name: /security@valdrics\.com/i }).length).toBeGreaterThan(
-			0
-		);
+		expect(
+			(await screen.findAllByRole('link', { name: /sales@valdrics\.com/i })).length
+		).toBeGreaterThan(0);
+		expect(
+			(await screen.findAllByRole('link', { name: /support@valdrics\.com/i })).length
+		).toBeGreaterThan(0);
+		expect(
+			(await screen.findAllByRole('link', { name: /security@valdrics\.com/i })).length
+		).toBeGreaterThan(0);
 		expect(screen.queryByRole('link', { name: /enterprise@valdrics\.com/i })).toBeNull();
 		expect(screen.queryByRole('link', { name: /billing@valdrics\.com/i })).toBeNull();
 		expect(screen.queryByRole('link', { name: /hello@valdrics\.com/i })).toBeNull();

--- a/dashboard/src/routes/layout/PublicMobileMenuDialog.svelte
+++ b/dashboard/src/routes/layout/PublicMobileMenuDialog.svelte
@@ -1,0 +1,178 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import type { PublicTheme } from '$lib/public/publicTheme';
+	import {
+		getFocusableElements,
+		lockBodyScroll,
+		resolveNextFocusTarget
+	} from '$lib/landing/publicMenuA11y';
+	import { PUBLIC_MOBILE_LINKS } from '$lib/landing/publicNav';
+
+	interface Props {
+		publicTheme: PublicTheme;
+		themeToggleLabel: string;
+		themeToggleCopy: string;
+		restoreFocusTarget?: HTMLButtonElement | null;
+		toAppPath: (path: string) => string;
+		onToggleTheme: () => void;
+		onClose: () => void;
+	}
+
+	let {
+		publicTheme,
+		themeToggleLabel,
+		themeToggleCopy,
+		restoreFocusTarget = null,
+		toAppPath,
+		onToggleTheme,
+		onClose
+	}: Props = $props();
+
+	let publicMenuPanel = $state<HTMLDivElement | null>(null);
+
+	onMount(() => {
+		const unlockBodyScroll = lockBodyScroll(document);
+
+		queueMicrotask(() => {
+			const firstFocusable = getFocusableElements(publicMenuPanel)[0];
+			firstFocusable?.focus();
+		});
+
+		const initialScrollY = window.scrollY;
+		const handleKeydown = (event: KeyboardEvent) => {
+			if (event.key === 'Escape') {
+				event.preventDefault();
+				onClose();
+				return;
+			}
+			if (event.key !== 'Tab') return;
+			const direction = event.shiftKey ? 'backward' : 'forward';
+			const activeElement =
+				document.activeElement instanceof HTMLElement ? document.activeElement : null;
+			const nextTarget = resolveNextFocusTarget(publicMenuPanel, activeElement, direction);
+			if (!nextTarget) return;
+			event.preventDefault();
+			nextTarget.focus();
+		};
+		const handleScroll = () => {
+			if (Math.abs(window.scrollY - initialScrollY) > 48) {
+				onClose();
+			}
+		};
+
+		window.addEventListener('keydown', handleKeydown);
+		window.addEventListener('scroll', handleScroll, { passive: true });
+
+		return () => {
+			window.removeEventListener('keydown', handleKeydown);
+			window.removeEventListener('scroll', handleScroll);
+			unlockBodyScroll();
+			restoreFocusTarget?.focus();
+		};
+	});
+</script>
+
+<button
+	type="button"
+	class="fixed inset-0 z-40 bg-ink-950/50 backdrop-blur-[2px] lg:hidden"
+	aria-label="Close navigation menu"
+	onclick={onClose}
+></button>
+<div
+	id="public-mobile-menu"
+	bind:this={publicMenuPanel}
+	class="public-mobile-menu-panel relative z-50 lg:hidden"
+	role="dialog"
+	aria-modal="true"
+	aria-labelledby="public-mobile-menu-title"
+>
+	<div class="container mx-auto px-6 py-4 public-mobile-menu-shell">
+		<h2 id="public-mobile-menu-title" class="sr-only">Public navigation menu</h2>
+		<div class="public-mobile-menu-copy">
+			<p class="public-mobile-menu-kicker">Explore Valdrics</p>
+			<p class="public-mobile-menu-intro">
+				Start in a workspace, review pricing, or contact enterprise when formal security and
+				procurement review is required.
+			</p>
+			<button
+				type="button"
+				class="public-theme-toggle public-theme-toggle--menu"
+				aria-label={themeToggleLabel}
+				aria-pressed={publicTheme === 'dark'}
+				onclick={onToggleTheme}
+			>
+				<span class="public-theme-toggle__icon" aria-hidden="true">
+					{#if publicTheme === 'dark'}
+						<svg
+							xmlns="http://www.w3.org/2000/svg"
+							width="16"
+							height="16"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="2"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+						>
+							<circle cx="12" cy="12" r="4"></circle>
+							<path d="M12 2v2"></path>
+							<path d="M12 20v2"></path>
+							<path d="m4.93 4.93 1.41 1.41"></path>
+							<path d="m17.66 17.66 1.41 1.41"></path>
+							<path d="M2 12h2"></path>
+							<path d="M20 12h2"></path>
+							<path d="m6.34 17.66-1.41 1.41"></path>
+							<path d="m19.07 4.93-1.41 1.41"></path>
+						</svg>
+					{:else}
+						<svg
+							xmlns="http://www.w3.org/2000/svg"
+							width="16"
+							height="16"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="2"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+						>
+							<path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"></path>
+						</svg>
+					{/if}
+				</span>
+				<span>{themeToggleCopy}</span>
+			</button>
+		</div>
+		<div class="grid gap-2 text-sm text-ink-200 public-mobile-menu-links">
+			<a
+				href={toAppPath('/enterprise')}
+				class="btn btn-primary justify-center mb-1 w-full"
+				data-sveltekit-preload-data="hover"
+				data-sveltekit-preload-code="hover"
+				onclick={onClose}
+			>
+				Enterprise Review
+			</a>
+			<a
+				href={toAppPath('/auth/login')}
+				class="btn btn-secondary justify-center mb-2 w-full"
+				data-sveltekit-preload-data="hover"
+				data-sveltekit-preload-code="hover"
+				onclick={onClose}
+			>
+				Start Free
+			</a>
+			{#each PUBLIC_MOBILE_LINKS as link (link.href)}
+				<a
+					href={toAppPath(link.href)}
+					class="py-3 min-h-11 flex items-center hover:text-ink-100"
+					data-sveltekit-preload-data="hover"
+					data-sveltekit-preload-code="hover"
+					onclick={onClose}
+				>
+					{link.label}
+				</a>
+			{/each}
+		</div>
+	</div>
+</div>

--- a/dashboard/src/routes/layout/PublicSiteFooter.svelte
+++ b/dashboard/src/routes/layout/PublicSiteFooter.svelte
@@ -1,0 +1,82 @@
+<script lang="ts">
+	import {
+		PUBLIC_CONTACT_CHANNELS,
+		PUBLIC_FOOTER_BADGES,
+		PUBLIC_FOOTER_CAPTION,
+		PUBLIC_FOOTER_LINKS,
+		PUBLIC_FOOTER_SUBTITLE
+	} from '$lib/landing/publicNav';
+
+	interface Props {
+		currentYear: number;
+		toAppPath: (path: string) => string;
+	}
+
+	let { currentYear, toAppPath }: Props = $props();
+</script>
+
+<footer class="public-site-footer">
+	<div class="container mx-auto px-6 py-10">
+		<div class="flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
+			<div class="space-y-2">
+				<p class="public-footer-brand text-sm font-semibold">Valdrics</p>
+				<p class="public-footer-subtitle max-w-xl">{PUBLIC_FOOTER_SUBTITLE}</p>
+			</div>
+
+			<nav
+				class="public-footer-nav grid grid-cols-2 gap-x-6 gap-y-2 md:grid-cols-4"
+				aria-label="Footer"
+			>
+				{#each PUBLIC_FOOTER_LINKS as link (link.href)}
+					{#if link.external}
+						<a
+							href={link.href}
+							target="_blank"
+							rel="noopener noreferrer"
+							class="public-footer-link"
+						>
+							{link.label}
+						</a>
+					{:else}
+						<a
+							href={toAppPath(link.href)}
+							class="public-footer-link"
+							data-sveltekit-preload-data="hover"
+							data-sveltekit-preload-code="hover"
+						>
+							{link.label}
+						</a>
+					{/if}
+				{/each}
+			</nav>
+		</div>
+
+		<div class="mt-6 flex flex-wrap items-center gap-2" aria-label="Technology badges">
+			{#each PUBLIC_FOOTER_BADGES as badge (badge)}
+				<span
+					class={`badge ${badge === 'Owner-routed actions' ? 'badge-success' : 'badge-default'}`}
+				>
+					{badge}
+				</span>
+			{/each}
+		</div>
+
+		<p class="public-footer-caption mt-4">{PUBLIC_FOOTER_CAPTION}</p>
+
+		<div class="mt-5 space-y-2" aria-label="Public contact channels">
+			<p class="public-footer-contact-label">Contact Channels</p>
+			<div class="flex flex-wrap gap-2">
+				{#each PUBLIC_CONTACT_CHANNELS as channel (channel.email)}
+					<a
+						href={channel.href}
+						class="badge badge-default public-footer-contact"
+						aria-label={`${channel.label} contact ${channel.email}`}
+					>
+						{channel.label}: {channel.email}
+					</a>
+				{/each}
+			</div>
+		</div>
+		<p class="public-footer-copyright mt-6">© {currentYear} Valdrics. All rights reserved.</p>
+	</div>
+</footer>

--- a/dashboard/src/routes/layout/PublicSiteShell.svelte
+++ b/dashboard/src/routes/layout/PublicSiteShell.svelte
@@ -3,24 +3,11 @@
 	import { browser } from '$app/environment';
 	import { page } from '$app/stores';
 	import type { Snippet } from 'svelte';
-	import { tick } from 'svelte';
+	import { onMount } from 'svelte';
 	import { base } from '$app/paths';
 	import CloudLogo from '$lib/components/CloudLogo.svelte';
-	import {
-		getFocusableElements,
-		lockBodyScroll,
-		resolveNextFocusTarget
-	} from '$lib/landing/publicMenuA11y';
-	import {
-		PUBLIC_CONTACT_CHANNELS,
-		PUBLIC_FOOTER_BADGES,
-		PUBLIC_FOOTER_CAPTION,
-		PUBLIC_FOOTER_LINKS,
-		PUBLIC_FOOTER_SUBTITLE,
-		PUBLIC_MOBILE_LINKS,
-		PUBLIC_PRIMARY_LINKS,
-		PUBLIC_RESOURCES_DROPDOWN_LINKS
-	} from '$lib/landing/publicNav';
+	import { createLazyComponent } from '$lib/lazyComponent';
+	import { PUBLIC_PRIMARY_LINKS, PUBLIC_RESOURCES_DROPDOWN_LINKS } from '$lib/landing/publicNav';
 	import {
 		persistPublicTheme,
 		resolveInitialPublicTheme,
@@ -40,18 +27,57 @@
 	let { currentYear, toAppPath, publicTone, children }: Props = $props();
 
 	let publicMenuOpen = $state(false);
-	let publicMenuPanel = $state<HTMLDivElement | null>(null);
 	let publicMenuButton = $state<HTMLButtonElement | null>(null);
-	let publicMenuRestoreFocus = $state<HTMLElement | null>(null);
 	let publicResourcesMenuOpen = $state(false);
 	let publicResourcesPanel = $state<HTMLDivElement | null>(null);
 	let publicResourcesButton = $state<HTMLButtonElement | null>(null);
 	let publicTheme = $state<PublicTheme>('light');
 	let publicThemeLoaded = $state(false);
+	let publicFooterReady = $state(import.meta.env.MODE === 'test');
+
+	type PublicMobileMenuDialogProps = {
+		publicTheme: PublicTheme;
+		themeToggleLabel: string;
+		themeToggleCopy: string;
+		restoreFocusTarget?: HTMLButtonElement | null;
+		toAppPath: (path: string) => string;
+		onToggleTheme: () => void;
+		onClose: () => void;
+	};
+
+	type PublicSiteFooterProps = {
+		currentYear: number;
+		toAppPath: (path: string) => string;
+	};
+
+	const loadPublicMobileMenuDialog = createLazyComponent<PublicMobileMenuDialogProps>(
+		() => import('./PublicMobileMenuDialog.svelte')
+	);
+	const loadPublicSiteFooter = createLazyComponent<PublicSiteFooterProps>(
+		() => import('./PublicSiteFooter.svelte')
+	);
 
 	const themeToggleLabel = (theme: PublicTheme) =>
 		theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode';
 	const themeToggleCopy = (theme: PublicTheme) => (theme === 'dark' ? 'Light mode' : 'Dark mode');
+
+	onMount(() => {
+		if (publicFooterReady) {
+			return;
+		}
+
+		const activateFooter = () => {
+			publicFooterReady = true;
+		};
+
+		if (typeof window.requestIdleCallback === 'function') {
+			const idleId = window.requestIdleCallback(activateFooter, { timeout: 1200 });
+			return () => window.cancelIdleCallback(idleId);
+		}
+
+		const timeoutId = window.setTimeout(activateFooter, 400);
+		return () => window.clearTimeout(timeoutId);
+	});
 
 	$effect(() => {
 		if (!browser || publicThemeLoaded) return;
@@ -78,55 +104,6 @@
 		$page.url.pathname;
 		publicMenuOpen = false;
 		publicResourcesMenuOpen = false;
-	});
-
-	$effect(() => {
-		if (!browser || !publicMenuOpen) return;
-
-		publicMenuRestoreFocus =
-			document.activeElement instanceof HTMLElement ? document.activeElement : null;
-		const unlockBodyScroll = lockBodyScroll(document);
-
-		void tick().then(() => {
-			const firstFocusable = getFocusableElements(publicMenuPanel)[0];
-			firstFocusable?.focus();
-		});
-
-		const handleKeydown = (event: KeyboardEvent) => {
-			if (event.key === 'Escape') {
-				event.preventDefault();
-				publicMenuOpen = false;
-				return;
-			}
-			if (event.key !== 'Tab') return;
-			const direction = event.shiftKey ? 'backward' : 'forward';
-			const activeElement =
-				document.activeElement instanceof HTMLElement ? document.activeElement : null;
-			const nextTarget = resolveNextFocusTarget(publicMenuPanel, activeElement, direction);
-			if (!nextTarget) return;
-			event.preventDefault();
-			nextTarget.focus();
-		};
-		const initialScrollY = window.scrollY;
-		const handleScroll = () => {
-			if (Math.abs(window.scrollY - initialScrollY) > 48) {
-				publicMenuOpen = false;
-			}
-		};
-		window.addEventListener('keydown', handleKeydown);
-		window.addEventListener('scroll', handleScroll, { passive: true });
-
-		return () => {
-			window.removeEventListener('keydown', handleKeydown);
-			window.removeEventListener('scroll', handleScroll);
-			unlockBodyScroll();
-			if (publicMenuRestoreFocus) {
-				publicMenuRestoreFocus.focus();
-			} else {
-				publicMenuButton?.focus();
-			}
-			publicMenuRestoreFocus = null;
-		};
 	});
 
 	$effect(() => {
@@ -441,110 +418,18 @@
 			</div>
 		</nav>
 		{#if publicMenuOpen}
-			<button
-				type="button"
-				class="fixed inset-0 z-40 bg-ink-950/50 backdrop-blur-[2px] lg:hidden"
-				aria-label="Close navigation menu"
-				onclick={closePublicMenu}
-			></button>
-			<div
-				id="public-mobile-menu"
-				bind:this={publicMenuPanel}
-				class="public-mobile-menu-panel relative z-50 lg:hidden"
-				role="dialog"
-				aria-modal="true"
-				aria-labelledby="public-mobile-menu-title"
-			>
-				<div class="container mx-auto px-6 py-4 public-mobile-menu-shell">
-					<h2 id="public-mobile-menu-title" class="sr-only">Public navigation menu</h2>
-					<div class="public-mobile-menu-copy">
-						<p class="public-mobile-menu-kicker">Explore Valdrics</p>
-						<p class="public-mobile-menu-intro">
-							Start in a workspace, review pricing, or contact enterprise when formal security and
-							procurement review is required.
-						</p>
-						<button
-							type="button"
-							class="public-theme-toggle public-theme-toggle--menu"
-							aria-label={themeToggleLabel(publicTheme)}
-							aria-pressed={publicTheme === 'dark'}
-							onclick={togglePublicTheme}
-						>
-							<span class="public-theme-toggle__icon" aria-hidden="true">
-								{#if publicTheme === 'dark'}
-									<svg
-										xmlns="http://www.w3.org/2000/svg"
-										width="16"
-										height="16"
-										viewBox="0 0 24 24"
-										fill="none"
-										stroke="currentColor"
-										stroke-width="2"
-										stroke-linecap="round"
-										stroke-linejoin="round"
-									>
-										<circle cx="12" cy="12" r="4"></circle>
-										<path d="M12 2v2"></path>
-										<path d="M12 20v2"></path>
-										<path d="m4.93 4.93 1.41 1.41"></path>
-										<path d="m17.66 17.66 1.41 1.41"></path>
-										<path d="M2 12h2"></path>
-										<path d="M20 12h2"></path>
-										<path d="m6.34 17.66-1.41 1.41"></path>
-										<path d="m19.07 4.93-1.41 1.41"></path>
-									</svg>
-								{:else}
-									<svg
-										xmlns="http://www.w3.org/2000/svg"
-										width="16"
-										height="16"
-										viewBox="0 0 24 24"
-										fill="none"
-										stroke="currentColor"
-										stroke-width="2"
-										stroke-linecap="round"
-										stroke-linejoin="round"
-									>
-										<path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"></path>
-									</svg>
-								{/if}
-							</span>
-							<span>{themeToggleCopy(publicTheme)}</span>
-						</button>
-					</div>
-					<div class="grid gap-2 text-sm text-ink-200 public-mobile-menu-links">
-						<a
-							href={toAppPath('/enterprise')}
-							class="btn btn-primary justify-center mb-1 w-full"
-							data-sveltekit-preload-data="hover"
-							data-sveltekit-preload-code="hover"
-							onclick={closePublicMenu}
-						>
-							Enterprise Review
-						</a>
-						<a
-							href={toAppPath('/auth/login')}
-							class="btn btn-secondary justify-center mb-2 w-full"
-							data-sveltekit-preload-data="hover"
-							data-sveltekit-preload-code="hover"
-							onclick={closePublicMenu}
-						>
-							Start Free
-						</a>
-						{#each PUBLIC_MOBILE_LINKS as link (link.href)}
-							<a
-								href={toAppPath(link.href)}
-								class="py-3 min-h-11 flex items-center hover:text-ink-100"
-								data-sveltekit-preload-data="hover"
-								data-sveltekit-preload-code="hover"
-								onclick={closePublicMenu}
-							>
-								{link.label}
-							</a>
-						{/each}
-					</div>
-				</div>
-			</div>
+			{#await loadPublicMobileMenuDialog() then module}
+				{@const PublicMobileMenuDialog = module.default}
+				<PublicMobileMenuDialog
+					{publicTheme}
+					themeToggleLabel={themeToggleLabel(publicTheme)}
+					themeToggleCopy={themeToggleCopy(publicTheme)}
+					restoreFocusTarget={publicMenuButton}
+					{toAppPath}
+					onToggleTheme={togglePublicTheme}
+					onClose={closePublicMenu}
+				/>
+			{/await}
 		{/if}
 	</header>
 
@@ -552,69 +437,16 @@
 		{@render children()}
 	</main>
 
-	<footer class="public-site-footer">
-		<div class="container mx-auto px-6 py-10">
-			<div class="flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
-				<div class="space-y-2">
-					<p class="public-footer-brand text-sm font-semibold">Valdrics</p>
-					<p class="public-footer-subtitle max-w-xl">{PUBLIC_FOOTER_SUBTITLE}</p>
-				</div>
-
-				<nav
-					class="public-footer-nav grid grid-cols-2 gap-x-6 gap-y-2 md:grid-cols-4"
-					aria-label="Footer"
-				>
-					{#each PUBLIC_FOOTER_LINKS as link (link.href)}
-						{#if link.external}
-							<a
-								href={link.href}
-								target="_blank"
-								rel="noopener noreferrer"
-								class="public-footer-link"
-							>
-								{link.label}
-							</a>
-						{:else}
-							<a
-								href={toAppPath(link.href)}
-								class="public-footer-link"
-								data-sveltekit-preload-data="hover"
-								data-sveltekit-preload-code="hover"
-							>
-								{link.label}
-							</a>
-						{/if}
-					{/each}
-				</nav>
+	{#if publicFooterReady}
+		{#await loadPublicSiteFooter() then module}
+			{@const PublicSiteFooter = module.default}
+			<PublicSiteFooter {currentYear} {toAppPath} />
+		{/await}
+	{:else}
+		<div class="public-site-footer" aria-hidden="true">
+			<div class="container mx-auto px-6 py-10">
+				<div class="h-24 rounded-xl border border-ink-800/40 bg-ink-950/10"></div>
 			</div>
-
-			<div class="mt-6 flex flex-wrap items-center gap-2" aria-label="Technology badges">
-				{#each PUBLIC_FOOTER_BADGES as badge (badge)}
-					<span
-						class={`badge ${badge === 'Owner-routed actions' ? 'badge-success' : 'badge-default'}`}
-					>
-						{badge}
-					</span>
-				{/each}
-			</div>
-
-			<p class="public-footer-caption mt-4">{PUBLIC_FOOTER_CAPTION}</p>
-
-			<div class="mt-5 space-y-2" aria-label="Public contact channels">
-				<p class="public-footer-contact-label">Contact Channels</p>
-				<div class="flex flex-wrap gap-2">
-					{#each PUBLIC_CONTACT_CHANNELS as channel (channel.email)}
-						<a
-							href={channel.href}
-							class="badge badge-default public-footer-contact"
-							aria-label={`${channel.label} contact ${channel.email}`}
-						>
-							{channel.label}: {channel.email}
-						</a>
-					{/each}
-				</div>
-			</div>
-			<p class="public-footer-copyright mt-6">© {currentYear} Valdrics. All rights reserved.</p>
 		</div>
-	</footer>
+	{/if}
 </div>

--- a/dashboard/src/routes/onboarding/OnboardingPageView.svelte
+++ b/dashboard/src/routes/onboarding/OnboardingPageView.svelte
@@ -1,7 +1,23 @@
 <script lang="ts">
-	import OnboardingPageViewContent from './OnboardingPageViewContent.svelte';
+	import { createLazyComponent } from '$lib/lazyComponent';
 
 	let { data } = $props();
+
+	const loadOnboardingPageViewContent = createLazyComponent(
+		() => import('./OnboardingPageViewContent.svelte')
+	);
+	const onboardingPageViewContentPromise =
+		import.meta.env.MODE === 'test' ? loadOnboardingPageViewContent() : null;
 </script>
 
-<OnboardingPageViewContent {data} />
+{#await onboardingPageViewContentPromise ?? loadOnboardingPageViewContent()}
+	<div class="card py-10">
+		<div class="skeleton h-8 w-64 mb-4"></div>
+		<div class="skeleton h-4 w-full mb-2"></div>
+		<div class="skeleton h-4 w-2/3 mb-8"></div>
+		<div class="skeleton h-96 rounded-2xl"></div>
+	</div>
+{:then module}
+	{@const OnboardingPageViewContent = module.default}
+	<OnboardingPageViewContent {data} />
+{/await}

--- a/dashboard/src/routes/onboarding/OnboardingPageViewContent.svelte
+++ b/dashboard/src/routes/onboarding/OnboardingPageViewContent.svelte
@@ -3,10 +3,6 @@
 	import { page } from '$app/stores';
 	import { resolveSessionTenantId } from '$lib/auth/sessionTenant';
 	import { buildProductFunnelAttributionContext } from '$lib/funnel/productFunnelTelemetry';
-	import OnboardingPageViewBody from './OnboardingPageViewBody.svelte';
-	import { ensureOnboardedRequest } from './onboardingApi';
-	import { proceedToVerifyFlow, verifyAwsConnectionFlow } from './onboardingFlowActions';
-	import { connectDiscoveryCandidateFlow, fetchSetupDataFlow } from './onboardingSetupActions';
 	import {
 		applyCloudPlusVendorDefaults as applyCloudPlusVendorDefaultsHelper,
 		applyDiscoveryCandidateLocally as applyDiscoveryCandidateLocallyHelper,
@@ -31,21 +27,37 @@
 		canUseMultiCloudFeaturesForTier,
 		canUseIdpDeepScanForTier
 	} from './onboardingTierAccess';
-	import {
-		runOnboardingDiscoveryStageA,
-		runOnboardingDiscoveryStageB,
-		updateOnboardingDiscoveryCandidateStatus
-	} from './onboardingDiscoveryActions';
-	import {
-		copyOnboardingTemplate,
-		downloadOnboardingTemplate,
-		getCloudPlusTemplateForTab,
-		getOnboardingSetupAccessError,
-		parseOnboardingCloudPlusConnectorConfig,
-		parseOnboardingCloudPlusFeed,
-		trackOnboardingConnectionVerified
-	} from './onboardingUiActions';
 	import './OnboardingPageViewContent.css';
+
+	function createModuleLoader<T>(loader: () => Promise<T>): () => Promise<T> {
+		let promise: Promise<T> | null = null;
+
+		return () => {
+			if (!promise) {
+				promise = loader().catch((error) => {
+					promise = null;
+					throw error;
+				});
+			}
+			return promise;
+		};
+	}
+
+	const loadOnboardingApiModule = createModuleLoader(() => import('./onboardingApi'));
+	const loadOnboardingSetupActionsModule = createModuleLoader(
+		() => import('./onboardingSetupActions')
+	);
+	const loadOnboardingFlowActionsModule = createModuleLoader(
+		() => import('./onboardingFlowActions')
+	);
+	const loadOnboardingDiscoveryActionsModule = createModuleLoader(
+		() => import('./onboardingDiscoveryActions')
+	);
+	const loadOnboardingUiActionsModule = createModuleLoader(() => import('./onboardingUiActions'));
+	const loadOnboardingPageViewBody = createModuleLoader(
+		() => import('./OnboardingPageViewBody.svelte')
+	);
+
 	let { data } = $props();
 	let currentStep = $state(0),
 		selectedProvider: OnboardingProvider = $state('aws'); // 0: Select Provider, 1: Setup, 2: Verify, 3: Done
@@ -133,6 +145,7 @@
 		discoveryInfo = result.info;
 	}
 	async function runDiscoveryStageA(): Promise<void> {
+		const { runOnboardingDiscoveryStageA } = await loadOnboardingDiscoveryActionsModule();
 		await runOnboardingDiscoveryStageA({
 			discoveryEmail,
 			getAccessToken,
@@ -144,6 +157,7 @@
 		});
 	}
 	async function runDiscoveryStageB(): Promise<void> {
+		const { runOnboardingDiscoveryStageB } = await loadOnboardingDiscoveryActionsModule();
 		await runOnboardingDiscoveryStageB({
 			discoveryDomain,
 			discoveryEmail,
@@ -161,6 +175,8 @@
 		candidate: DiscoveryCandidate,
 		action: 'accept' | 'ignore' | 'connected'
 	): Promise<DiscoveryCandidate | null> {
+		const { updateOnboardingDiscoveryCandidateStatus } =
+			await loadOnboardingDiscoveryActionsModule();
 		return updateOnboardingDiscoveryCandidateStatus({
 			candidate,
 			action,
@@ -181,20 +197,21 @@
 	};
 	async function connectDiscoveryCandidate(candidate: DiscoveryCandidate): Promise<void> {
 		try {
+			const { connectDiscoveryCandidateFlow } = await loadOnboardingSetupActionsModule();
 			const info = await connectDiscoveryCandidateFlow({
 				candidate,
 				canUseMultiCloudFeatures: canUseMultiCloudFeatures(),
 				canUseCloudPlusFeatures: canUseCloudPlusFeatures(),
 				updateDiscoveryCandidateStatus,
-				setSelectedProvider: (provider) => (selectedProvider = provider),
-				setCurrentStep: (step) => (currentStep = step),
+				setSelectedProvider: (provider: OnboardingProvider) => (selectedProvider = provider),
+				setCurrentStep: (step: number) => (currentStep = step),
 				fetchSetupData,
 				cloudPlusNativeConnectors,
 				chooseNativeCloudPlusVendor,
-				setCloudPlusVendor: (vendor) => (cloudPlusVendor = vendor),
+				setCloudPlusVendor: (vendor: string) => (cloudPlusVendor = vendor),
 				applyCloudPlusVendorDefaults,
 				getCloudPlusName: () => cloudPlusName,
-				setCloudPlusName: (name) => (cloudPlusName = name)
+				setCloudPlusName: (name: string) => (cloudPlusName = name)
 			});
 			if (info) discoveryInfo = info;
 		} catch (e) {
@@ -249,6 +266,7 @@
 			error = 'Please log in first';
 			return false;
 		}
+		const { ensureOnboardedRequest } = await loadOnboardingApiModule();
 		const result = await ensureOnboardedRequest(
 			token,
 			buildProductFunnelAttributionContext({
@@ -266,6 +284,7 @@
 		isLoading = true;
 		error = '';
 		try {
+			const { fetchSetupDataFlow } = await loadOnboardingSetupActionsModule();
 			const setup = await fetchSetupDataFlow({
 				selectedProvider,
 				getAccessToken,
@@ -299,6 +318,7 @@
 		}
 	}
 	async function handleContinueToSetup() {
+		const { getOnboardingSetupAccessError } = await loadOnboardingUiActionsModule();
 		const accessError = getOnboardingSetupAccessError({
 			selectedProvider,
 			canUseMultiCloudFeatures: canUseMultiCloudFeatures(),
@@ -321,6 +341,8 @@
 		await fetchSetupData();
 	}
 	async function copyTemplate() {
+		const { getCloudPlusTemplateForTab, copyOnboardingTemplate } =
+			await loadOnboardingUiActionsModule();
 		const { template } = getCloudPlusTemplateForTab({
 			selectedTab,
 			cloudformationYaml,
@@ -331,7 +353,9 @@
 		setTimeout(() => (copied = false), 2000);
 	}
 
-	function downloadTemplate() {
+	async function downloadTemplate() {
+		const { getCloudPlusTemplateForTab, downloadOnboardingTemplate } =
+			await loadOnboardingUiActionsModule();
 		const { template, filename } = getCloudPlusTemplateForTab({
 			selectedTab,
 			cloudformationYaml,
@@ -339,19 +363,18 @@
 		});
 		downloadOnboardingTemplate(template, filename);
 	}
-	const parseCloudPlusFeed = (): Array<Record<string, unknown>> =>
-		parseOnboardingCloudPlusFeed(cloudPlusFeedInput);
-	const parseCloudPlusConnectorConfig = (): Record<string, unknown> =>
-		parseOnboardingCloudPlusConnectorConfig({
-			connectorConfigInput: cloudPlusConnectorConfigInput,
-			selectedConnector: getSelectedNativeConnector(),
-			isNativeAuthMethod: isCloudPlusNativeAuthMethod(),
-			requiredConfigValues: cloudPlusRequiredConfigValues
-		});
 	async function proceedToVerify() {
 		error = '';
 		isVerifying = true;
 		try {
+			const [
+				{ proceedToVerifyFlow },
+				{
+					parseOnboardingCloudPlusFeed,
+					parseOnboardingCloudPlusConnectorConfig,
+					trackOnboardingConnectionVerified
+				}
+			] = await Promise.all([loadOnboardingFlowActionsModule(), loadOnboardingUiActionsModule()]);
 			const result = await proceedToVerifyFlow({
 				selectedProvider,
 				getAccessToken,
@@ -366,8 +389,14 @@
 				cloudPlusVendor,
 				cloudPlusAuthMethod,
 				cloudPlusApiKey,
-				parseCloudPlusFeed,
-				parseCloudPlusConnectorConfig
+				parseCloudPlusFeed: () => parseOnboardingCloudPlusFeed(cloudPlusFeedInput),
+				parseCloudPlusConnectorConfig: () =>
+					parseOnboardingCloudPlusConnectorConfig({
+						connectorConfigInput: cloudPlusConnectorConfigInput,
+						selectedConnector: getSelectedNativeConnector(),
+						isNativeAuthMethod: isCloudPlusNativeAuthMethod(),
+						requiredConfigValues: cloudPlusRequiredConfigValues
+					})
 			});
 			currentStep = result.currentStep;
 			success = result.success;
@@ -392,6 +421,8 @@
 		isVerifying = true;
 		error = '';
 		try {
+			const [{ verifyAwsConnectionFlow }, { trackOnboardingConnectionVerified }] =
+				await Promise.all([loadOnboardingFlowActionsModule(), loadOnboardingUiActionsModule()]);
 			await verifyAwsConnectionFlow({
 				getAccessToken,
 				ensureOnboarded,
@@ -405,7 +436,7 @@
 			currentStep = 3;
 			trackOnboardingConnectionVerified({
 				accessToken: data.session?.access_token,
-				tenantId: resolveTenantId(),
+				tenantId: await resolveTenantId(),
 				url: $page.url,
 				currentTier: data.subscription?.tier,
 				persona: String(data?.profile?.persona ?? ''),
@@ -470,28 +501,38 @@
 <svelte:head>
 	<title>Onboarding | Valdrics</title>
 </svelte:head>
-<OnboardingPageViewBody
-	{...bodyProps}
-	bind:currentStep
-	bind:selectedProvider
-	bind:selectedTab
-	bind:discoveryEmail
-	bind:discoveryIdpProvider
-	bind:roleArn
-	bind:awsAccountId
-	bind:isManagementAccount
-	bind:organizationId
-	bind:azureSubscriptionId
-	bind:azureTenantId
-	bind:azureClientId
-	bind:gcpProjectId
-	bind:gcpBillingProjectId
-	bind:gcpBillingDataset
-	bind:gcpBillingTable
-	bind:cloudPlusName
-	bind:cloudPlusVendor
-	bind:cloudPlusAuthMethod
-	bind:cloudPlusApiKey
-	bind:cloudPlusFeedInput
-	bind:cloudPlusConnectorConfigInput
-/>
+{#await loadOnboardingPageViewBody()}
+	<div class="card">
+		<div class="skeleton h-8 w-56 mb-4"></div>
+		<div class="skeleton h-4 w-full mb-2"></div>
+		<div class="skeleton h-4 w-3/4 mb-6"></div>
+		<div class="skeleton h-64 rounded-2xl"></div>
+	</div>
+{:then module}
+	{@const OnboardingPageViewBody = module.default}
+	<OnboardingPageViewBody
+		{...bodyProps}
+		bind:currentStep
+		bind:selectedProvider
+		bind:selectedTab
+		bind:discoveryEmail
+		bind:discoveryIdpProvider
+		bind:roleArn
+		bind:awsAccountId
+		bind:isManagementAccount
+		bind:organizationId
+		bind:azureSubscriptionId
+		bind:azureTenantId
+		bind:azureClientId
+		bind:gcpProjectId
+		bind:gcpBillingProjectId
+		bind:gcpBillingDataset
+		bind:gcpBillingTable
+		bind:cloudPlusName
+		bind:cloudPlusVendor
+		bind:cloudPlusAuthMethod
+		bind:cloudPlusApiKey
+		bind:cloudPlusFeedInput
+		bind:cloudPlusConnectorConfigInput
+	/>
+{/await}

--- a/dashboard/src/routes/onboarding/onboarding-page.svelte.test.ts
+++ b/dashboard/src/routes/onboarding/onboarding-page.svelte.test.ts
@@ -99,14 +99,28 @@ function renderPage(tier: string = 'pro') {
 	});
 }
 
+const ASYNC_RENDER_TIMEOUT = 5000;
+
 async function enterSaasStep(container: HTMLElement) {
-	await fireEvent.click(await screen.findByRole('button', { name: /SaaS Spend Connector/i }));
-	await fireEvent.click(await screen.findByRole('button', { name: /Continue to Setup/i }));
+	await fireEvent.click(
+		await screen.findByRole(
+			'button',
+			{ name: /SaaS Spend Connector/i },
+			{ timeout: ASYNC_RENDER_TIMEOUT }
+		)
+	);
+	await fireEvent.click(
+		await screen.findByRole(
+			'button',
+			{ name: /Continue to Setup/i },
+			{ timeout: ASYNC_RENDER_TIMEOUT }
+		)
+	);
 	await screen.findByText('Step 2: Connect SaaS Spend');
 	await waitFor(() => {
 		expect(screen.queryByText('Fetching configuration details...')).toBeNull();
 	});
-	await screen.findByText('native setup snippet');
+	await screen.findByText('native setup snippet', {}, { timeout: ASYNC_RENDER_TIMEOUT });
 	const textareas = container.querySelectorAll('textarea');
 	expect(textareas.length).toBeGreaterThanOrEqual(2);
 	return textareas;
@@ -197,7 +211,13 @@ describe('onboarding cloud+ flow', () => {
 		const starterPlan = DEFAULT_PRICING_PLANS.find((plan) => plan.id === 'starter');
 		renderPage('free');
 
-		await fireEvent.click(await screen.findByRole('button', { name: /Microsoft Azure/i }));
+		await fireEvent.click(
+			await screen.findByRole(
+				'button',
+				{ name: /Microsoft Azure/i },
+				{ timeout: ASYNC_RENDER_TIMEOUT }
+			)
+		);
 
 		expect(screen.getByText('Move to Starter for Azure and GCP coverage')).toBeTruthy();
 		expect(document.body.textContent || '').toContain(starterPlan?.story?.summary ?? '');
@@ -208,7 +228,13 @@ describe('onboarding cloud+ flow', () => {
 		const proPlan = DEFAULT_PRICING_PLANS.find((plan) => plan.id === 'pro');
 		renderPage('growth');
 
-		await fireEvent.click(await screen.findByRole('button', { name: /SaaS Spend Connector/i }));
+		await fireEvent.click(
+			await screen.findByRole(
+				'button',
+				{ name: /SaaS Spend Connector/i },
+				{ timeout: ASYNC_RENDER_TIMEOUT }
+			)
+		);
 
 		expect(screen.getByText('Move to Pro for Cloud+ connectors')).toBeTruthy();
 		expect(document.body.textContent || '').toContain(proPlan?.story?.summary ?? '');

--- a/dashboard/src/routes/ops/OpsOperationalHealthSection.svelte
+++ b/dashboard/src/routes/ops/OpsOperationalHealthSection.svelte
@@ -8,11 +8,8 @@
 		canAccessOpsJobSlo
 	} from '$lib/entitlements';
 	import OpsStatusBanners from './OpsStatusBanners.svelte';
-	import OpsUnitEconomicsSection from './OpsUnitEconomicsSection.svelte';
 	import { buildOpsOperationalInitialState } from './opsOperationalState';
 	import { createOpsOperationalCoreActions } from './opsOperationalCoreActions';
-	import { createOpsOperationalAcceptanceActions } from './opsOperationalAcceptanceActions';
-	import { createOpsOperationalCloseActions } from './opsOperationalCloseActions';
 	import {
 		acceptanceBadgeClass,
 		closeStatusBadgeClass,
@@ -31,6 +28,23 @@
 	const loadOpsAcceptanceKpiSection = createLazyComponent(
 		() => import('./OpsAcceptanceKpiSection.svelte')
 	);
+	const loadOpsUnitEconomicsSection = createLazyComponent<{
+		unitStartDate: string;
+		unitEndDate: string;
+		unitAlertOnAnomaly: boolean;
+		refreshingUnitEconomics: boolean;
+		refreshUnitEconomics: () => void | Promise<void>;
+		unitEconomics: import('./opsTypes').UnitEconomicsResponse | null;
+		unitSettings: import('./opsTypes').UnitEconomicsSettings | null;
+		saveUnitEconomicsSettings: (event?: SubmitEvent) => void | Promise<void>;
+		savingUnitSettings: boolean;
+		formatUsd: (value: number | null | undefined) => string;
+		formatNumber: (value: number | null | undefined, digits?: number) => string;
+		formatDelta: (value: number | null | undefined) => string;
+		unitDeltaClass: (
+			metric: import('./opsTypes').UnitEconomicsResponse['metrics'][number]
+		) => string;
+	}>(() => import('./OpsUnitEconomicsSection.svelte'));
 	const loadOpsIntegrationAcceptanceSection = createLazyComponent(
 		() => import('./OpsIntegrationAcceptanceSection.svelte')
 	);
@@ -56,6 +70,36 @@
 		jobSloMetricBadgeClass: (metric: JobSLOResponse['metrics'][number]) => string;
 		formatDuration: (value: number | null | undefined) => string;
 	}>(() => import('./OpsJobSloSection.svelte'));
+	type OpsAcceptanceActions = {
+		refreshAcceptanceKpis: () => Promise<void>;
+		refreshAcceptanceKpiHistory: () => Promise<void>;
+		preloadAcceptanceEvidence: (options?: {
+			includeKpis?: boolean;
+			includeRuns?: boolean;
+		}) => Promise<void>;
+		captureAcceptanceKpis: () => Promise<void>;
+		refreshAcceptanceRuns: () => Promise<void>;
+		captureAcceptanceRuns: () => Promise<void>;
+		runAcceptanceSuite: () => Promise<void>;
+		downloadAcceptanceKpiJson: () => Promise<void>;
+		downloadAcceptanceKpiCsv: () => Promise<void>;
+		hasSelectedAcceptanceChannels: (
+			includeSlack: boolean,
+			includeJira: boolean,
+			includeWorkflow: boolean
+		) => boolean;
+		acceptanceRunStatusClass: (status: string) => string;
+	};
+
+	type OpsCloseActions = {
+		previewClosePackage: () => Promise<void>;
+		preloadClosePackage: () => Promise<void>;
+		saveProviderInvoice: (event?: SubmitEvent) => Promise<void>;
+		deleteProviderInvoice: () => Promise<void>;
+		downloadClosePackageJson: () => Promise<void>;
+		downloadClosePackageCsv: () => Promise<void>;
+		downloadRestatementCsv: () => Promise<void>;
+	};
 
 	let { data } = $props();
 	const opsState = $state(buildOpsOperationalInitialState());
@@ -65,6 +109,14 @@
 	let advancedEvidenceVisible = $state(false);
 	let reliabilityLoaded = $state(false);
 	let advancedEvidenceLoaded = $state(false);
+	let acceptanceActions = $state<OpsAcceptanceActions | null>(null);
+	let closeActions = $state<OpsCloseActions | null>(null);
+	let advancedActionsPromise: Promise<void> | null = null;
+	let opsAcceptanceActionsModulePromise: Promise<
+		typeof import('./opsOperationalAcceptanceActions')
+	> | null = null;
+	let opsCloseActionsModulePromise: Promise<typeof import('./opsOperationalCloseActions')> | null =
+		null;
 	const canAccessJobSlo = () => canAccessOpsJobSlo(data.subscription?.tier, data.profile?.role);
 	const canAccessAcceptanceKpis = () =>
 		canAccessOpsAcceptanceEvidence(data.subscription?.tier, data.profile?.role);
@@ -80,16 +132,6 @@
 		}
 	});
 
-	const acceptanceActions = createOpsOperationalAcceptanceActions({
-		getData: () => data,
-		state: opsState
-	});
-
-	const closeActions = createOpsOperationalCloseActions({
-		getData: () => data,
-		state: opsState
-	});
-
 	const formatUsdSafe = (value: number | null | undefined): string => formatUsd(Number(value ?? 0));
 	const formatNumberSafe = (value: number | null | undefined, digits?: number): string =>
 		formatNumber(Number(value ?? 0), digits);
@@ -101,6 +143,51 @@
 	const closeStatusBadgeClassSafe = (value: string | null | undefined): string =>
 		closeStatusBadgeClass(value ?? undefined);
 
+	function loadOpsAcceptanceActionsModule() {
+		if (!opsAcceptanceActionsModulePromise) {
+			opsAcceptanceActionsModulePromise = import('./opsOperationalAcceptanceActions');
+		}
+
+		return opsAcceptanceActionsModulePromise;
+	}
+
+	function loadOpsCloseActionsModule() {
+		if (!opsCloseActionsModulePromise) {
+			opsCloseActionsModulePromise = import('./opsOperationalCloseActions');
+		}
+
+		return opsCloseActionsModulePromise;
+	}
+
+	async function ensureAdvancedActionModules(): Promise<void> {
+		if (acceptanceActions && (!canAccessCloseWorkflow() || closeActions)) {
+			return;
+		}
+
+		if (!advancedActionsPromise) {
+			advancedActionsPromise = (async () => {
+				const acceptanceModule = await loadOpsAcceptanceActionsModule();
+				acceptanceActions ??= acceptanceModule.createOpsOperationalAcceptanceActions({
+					getData: () => data,
+					state: opsState
+				});
+
+				if (canAccessCloseWorkflow()) {
+					const closeModule = await loadOpsCloseActionsModule();
+					closeActions ??= closeModule.createOpsOperationalCloseActions({
+						getData: () => data,
+						state: opsState
+					});
+				}
+			})().catch((error) => {
+				advancedActionsPromise = null;
+				throw error;
+			});
+		}
+
+		await advancedActionsPromise;
+	}
+
 	$effect(() => {
 		if (!reliabilityVisible || reliabilityLoaded) return;
 		reliabilityLoaded = true;
@@ -110,19 +197,26 @@
 	$effect(() => {
 		if (!advancedEvidenceVisible || advancedEvidenceLoaded) return;
 		advancedEvidenceLoaded = true;
-		void acceptanceActions.preloadAcceptanceEvidence({
-			includeKpis: canAccessAcceptanceKpis(),
-			includeRuns: true
-		});
-		if (canAccessCloseWorkflow()) {
-			void closeActions.preloadClosePackage();
-		}
+		void ensureAdvancedActionModules()
+			.then(() => {
+				void acceptanceActions?.preloadAcceptanceEvidence({
+					includeKpis: canAccessAcceptanceKpis(),
+					includeRuns: true
+				});
+				if (canAccessCloseWorkflow()) {
+					void closeActions?.preloadClosePackage();
+				}
+			})
+			.catch(() => {
+				advancedEvidenceLoaded = false;
+			});
 	});
 
 	onMount(() => {
 		if (import.meta.env.MODE === 'test' || typeof IntersectionObserver === 'undefined') {
 			reliabilityVisible = true;
 			advancedEvidenceVisible = true;
+			void ensureAdvancedActionModules();
 			void coreActions.loadPrimaryOperationalData();
 			return;
 		}
@@ -165,23 +259,32 @@
 
 <div class="space-y-6">
 	<OpsStatusBanners error={opsState.error} success={opsState.success} />
-	<OpsUnitEconomicsSection
-		{...{
-			refreshingUnitEconomics: opsState.refreshingUnitEconomics,
-			refreshUnitEconomics: coreActions.refreshUnitEconomics,
-			unitEconomics: opsState.unitEconomics,
-			saveUnitEconomicsSettings: coreActions.saveUnitEconomicsSettings,
-			savingUnitSettings: opsState.savingUnitSettings,
-			formatUsd: formatUsdSafe,
-			formatNumber: formatNumberSafe,
-			formatDelta: formatDeltaSafe,
-			unitDeltaClass
-		}}
-		bind:unitStartDate={opsState.unitStartDate}
-		bind:unitEndDate={opsState.unitEndDate}
-		bind:unitAlertOnAnomaly={opsState.unitAlertOnAnomaly}
-		bind:unitSettings={opsState.unitSettings}
-	/>
+	{#await loadOpsUnitEconomicsSection()}
+		<div class="card">
+			<div class="skeleton h-8 w-48 mb-4"></div>
+			<div class="skeleton h-4 w-full mb-2"></div>
+			<div class="skeleton h-40 rounded-2xl"></div>
+		</div>
+	{:then module}
+		{@const OpsUnitEconomicsSection = module.default}
+		<OpsUnitEconomicsSection
+			{...{
+				refreshingUnitEconomics: opsState.refreshingUnitEconomics,
+				refreshUnitEconomics: coreActions.refreshUnitEconomics,
+				unitEconomics: opsState.unitEconomics,
+				saveUnitEconomicsSettings: coreActions.saveUnitEconomicsSettings,
+				savingUnitSettings: opsState.savingUnitSettings,
+				formatUsd: formatUsdSafe,
+				formatNumber: formatNumberSafe,
+				formatDelta: formatDeltaSafe,
+				unitDeltaClass
+			}}
+			bind:unitStartDate={opsState.unitStartDate}
+			bind:unitEndDate={opsState.unitEndDate}
+			bind:unitAlertOnAnomaly={opsState.unitAlertOnAnomaly}
+			bind:unitSettings={opsState.unitSettings}
+		/>
+	{/await}
 
 	<div bind:this={reliabilityAnchor}>
 		{#if reliabilityVisible}
@@ -251,122 +354,146 @@
 
 	<div bind:this={advancedEvidenceAnchor}>
 		{#if advancedEvidenceVisible}
-			{#if canAccessAcceptanceKpis()}
-				{#await loadOpsAcceptanceKpiSection()}
+			{#if acceptanceActions}
+				{#if canAccessAcceptanceKpis()}
+					{#await loadOpsAcceptanceKpiSection()}
+						<div class="card">
+							<div class="skeleton h-8 w-56 mb-4"></div>
+							<div class="skeleton h-56 rounded-2xl"></div>
+						</div>
+					{:then module}
+						{@const OpsAcceptanceKpiSection = module.default}
+						<OpsAcceptanceKpiSection
+							{...{
+								capturingAcceptanceKpis: opsState.capturingAcceptanceKpis,
+								downloadingAcceptanceJson: opsState.downloadingAcceptanceJson,
+								downloadingAcceptanceCsv: opsState.downloadingAcceptanceCsv,
+								refreshingAcceptanceKpis: opsState.refreshingAcceptanceKpis,
+								refreshingAcceptanceKpiHistory: opsState.refreshingAcceptanceKpiHistory,
+								captureAcceptanceKpis: acceptanceActions.captureAcceptanceKpis,
+								downloadAcceptanceKpiJson: acceptanceActions.downloadAcceptanceKpiJson,
+								downloadAcceptanceKpiCsv: acceptanceActions.downloadAcceptanceKpiCsv,
+								refreshAcceptanceKpis: acceptanceActions.refreshAcceptanceKpis,
+								refreshAcceptanceKpiHistory: acceptanceActions.refreshAcceptanceKpiHistory,
+								acceptanceKpis: opsState.acceptanceKpis,
+								acceptanceKpiHistory: opsState.acceptanceKpiHistory,
+								lastAcceptanceKpiCapture: opsState.lastAcceptanceKpiCapture,
+								acceptanceBadgeClass,
+								formatDate: formatDateSafe
+							}}
+						/>
+					{:catch}
+						<div class="card">
+							<div class="skeleton h-8 w-56 mb-4"></div>
+						</div>
+					{/await}
+				{:else}
+					<UpgradeNotice
+						currentTier={data.subscription?.tier}
+						requiredTier="pro"
+						feature="acceptance KPI evidence"
+					/>
+				{/if}
+
+				{#await loadOpsIntegrationAcceptanceSection()}
 					<div class="card">
-						<div class="skeleton h-8 w-56 mb-4"></div>
+						<div class="skeleton h-8 w-64 mb-4"></div>
 						<div class="skeleton h-56 rounded-2xl"></div>
 					</div>
 				{:then module}
-					{@const OpsAcceptanceKpiSection = module.default}
-					<OpsAcceptanceKpiSection
+					{@const OpsIntegrationAcceptanceSection = module.default}
+					<OpsIntegrationAcceptanceSection
 						{...{
+							runningAcceptanceSuite: opsState.runningAcceptanceSuite,
+							capturingAcceptanceRuns: opsState.capturingAcceptanceRuns,
 							capturingAcceptanceKpis: opsState.capturingAcceptanceKpis,
-							downloadingAcceptanceJson: opsState.downloadingAcceptanceJson,
-							downloadingAcceptanceCsv: opsState.downloadingAcceptanceCsv,
-							refreshingAcceptanceKpis: opsState.refreshingAcceptanceKpis,
+							refreshingAcceptanceRuns: opsState.refreshingAcceptanceRuns,
 							refreshingAcceptanceKpiHistory: opsState.refreshingAcceptanceKpiHistory,
-							captureAcceptanceKpis: acceptanceActions.captureAcceptanceKpis,
-							downloadAcceptanceKpiJson: acceptanceActions.downloadAcceptanceKpiJson,
-							downloadAcceptanceKpiCsv: acceptanceActions.downloadAcceptanceKpiCsv,
-							refreshAcceptanceKpis: acceptanceActions.refreshAcceptanceKpis,
-							refreshAcceptanceKpiHistory: acceptanceActions.refreshAcceptanceKpiHistory,
-							acceptanceKpis: opsState.acceptanceKpis,
-							acceptanceKpiHistory: opsState.acceptanceKpiHistory,
-							lastAcceptanceKpiCapture: opsState.lastAcceptanceKpiCapture,
-							acceptanceBadgeClass,
+							runAcceptanceSuite: acceptanceActions.runAcceptanceSuite,
+							captureAcceptanceRuns: acceptanceActions.captureAcceptanceRuns,
+							refreshAcceptanceRuns: acceptanceActions.refreshAcceptanceRuns,
+							lastAcceptanceCapture: opsState.lastAcceptanceCapture,
+							acceptanceRuns: opsState.acceptanceRuns,
+							hasSelectedAcceptanceChannels: acceptanceActions.hasSelectedAcceptanceChannels,
+							acceptanceRunStatusClass: acceptanceActions.acceptanceRunStatusClass,
 							formatDate: formatDateSafe
 						}}
+						bind:captureIncludeSlack={opsState.captureIncludeSlack}
+						bind:captureIncludeJira={opsState.captureIncludeJira}
+						bind:captureIncludeWorkflow={opsState.captureIncludeWorkflow}
+						bind:captureFailFast={opsState.captureFailFast}
 					/>
 				{:catch}
 					<div class="card">
-						<div class="skeleton h-8 w-56 mb-4"></div>
+						<div class="skeleton h-8 w-64 mb-4"></div>
 					</div>
 				{/await}
-			{:else}
-				<UpgradeNotice
-					currentTier={data.subscription?.tier}
-					requiredTier="pro"
-					feature="acceptance KPI evidence"
-				/>
-			{/if}
 
-			{#await loadOpsIntegrationAcceptanceSection()}
+				{#if canAccessCloseWorkflow()}
+					{#if closeActions}
+						{#await loadOpsCloseWorkflowSection()}
+							<div class="card">
+								<div class="skeleton h-8 w-64 mb-4"></div>
+								<div class="skeleton h-56 rounded-2xl"></div>
+							</div>
+						{:then module}
+							{@const OpsCloseWorkflowSection = module.default}
+							<OpsCloseWorkflowSection
+								{...{
+									refreshingClosePackage: opsState.refreshingClosePackage,
+									previewClosePackage: closeActions.previewClosePackage,
+									downloadingCloseJson: opsState.downloadingCloseJson,
+									downloadClosePackageJson: closeActions.downloadClosePackageJson,
+									downloadingCloseCsv: opsState.downloadingCloseCsv,
+									downloadClosePackageCsv: closeActions.downloadClosePackageCsv,
+									downloadingRestatementCsv: opsState.downloadingRestatementCsv,
+									downloadRestatementCsv: closeActions.downloadRestatementCsv,
+									closePackage: opsState.closePackage,
+									saveProviderInvoice: closeActions.saveProviderInvoice,
+									savingInvoice: opsState.savingInvoice,
+									deletingInvoice: opsState.deletingInvoice,
+									deleteProviderInvoice: closeActions.deleteProviderInvoice,
+									closeStatusBadgeClass: closeStatusBadgeClassSafe,
+									formatUsd: formatUsdSafe
+								}}
+								bind:closeStartDate={opsState.closeStartDate}
+								bind:closeEndDate={opsState.closeEndDate}
+								bind:closeProvider={opsState.closeProvider}
+								bind:invoiceForm={opsState.invoiceForm}
+							/>
+						{:catch}
+							<div class="card">
+								<div class="skeleton h-8 w-64 mb-4"></div>
+							</div>
+						{/await}
+					{:else}
+						<div class="card">
+							<div class="skeleton h-8 w-64 mb-4"></div>
+							<div class="skeleton h-56 rounded-2xl"></div>
+						</div>
+					{/if}
+				{:else}
+					<UpgradeNotice
+						currentTier={data.subscription?.tier}
+						requiredTier="pro"
+						feature="reconciliation close workflow"
+					/>
+				{/if}
+			{:else}
+				<div class="card">
+					<div class="skeleton h-8 w-56 mb-4"></div>
+					<div class="skeleton h-56 rounded-2xl"></div>
+				</div>
 				<div class="card">
 					<div class="skeleton h-8 w-64 mb-4"></div>
 					<div class="skeleton h-56 rounded-2xl"></div>
 				</div>
-			{:then module}
-				{@const OpsIntegrationAcceptanceSection = module.default}
-				<OpsIntegrationAcceptanceSection
-					{...{
-						runningAcceptanceSuite: opsState.runningAcceptanceSuite,
-						capturingAcceptanceRuns: opsState.capturingAcceptanceRuns,
-						capturingAcceptanceKpis: opsState.capturingAcceptanceKpis,
-						refreshingAcceptanceRuns: opsState.refreshingAcceptanceRuns,
-						refreshingAcceptanceKpiHistory: opsState.refreshingAcceptanceKpiHistory,
-						runAcceptanceSuite: acceptanceActions.runAcceptanceSuite,
-						captureAcceptanceRuns: acceptanceActions.captureAcceptanceRuns,
-						refreshAcceptanceRuns: acceptanceActions.refreshAcceptanceRuns,
-						lastAcceptanceCapture: opsState.lastAcceptanceCapture,
-						acceptanceRuns: opsState.acceptanceRuns,
-						hasSelectedAcceptanceChannels: acceptanceActions.hasSelectedAcceptanceChannels,
-						acceptanceRunStatusClass: acceptanceActions.acceptanceRunStatusClass,
-						formatDate: formatDateSafe
-					}}
-					bind:captureIncludeSlack={opsState.captureIncludeSlack}
-					bind:captureIncludeJira={opsState.captureIncludeJira}
-					bind:captureIncludeWorkflow={opsState.captureIncludeWorkflow}
-					bind:captureFailFast={opsState.captureFailFast}
-				/>
-			{:catch}
-				<div class="card">
-					<div class="skeleton h-8 w-64 mb-4"></div>
-				</div>
-			{/await}
-
-			{#if canAccessCloseWorkflow()}
-				{#await loadOpsCloseWorkflowSection()}
+				{#if canAccessCloseWorkflow()}
 					<div class="card">
 						<div class="skeleton h-8 w-64 mb-4"></div>
 						<div class="skeleton h-56 rounded-2xl"></div>
 					</div>
-				{:then module}
-					{@const OpsCloseWorkflowSection = module.default}
-					<OpsCloseWorkflowSection
-						{...{
-							refreshingClosePackage: opsState.refreshingClosePackage,
-							previewClosePackage: closeActions.previewClosePackage,
-							downloadingCloseJson: opsState.downloadingCloseJson,
-							downloadClosePackageJson: closeActions.downloadClosePackageJson,
-							downloadingCloseCsv: opsState.downloadingCloseCsv,
-							downloadClosePackageCsv: closeActions.downloadClosePackageCsv,
-							downloadingRestatementCsv: opsState.downloadingRestatementCsv,
-							downloadRestatementCsv: closeActions.downloadRestatementCsv,
-							closePackage: opsState.closePackage,
-							saveProviderInvoice: closeActions.saveProviderInvoice,
-							savingInvoice: opsState.savingInvoice,
-							deletingInvoice: opsState.deletingInvoice,
-							deleteProviderInvoice: closeActions.deleteProviderInvoice,
-							closeStatusBadgeClass: closeStatusBadgeClassSafe,
-							formatUsd: formatUsdSafe
-						}}
-						bind:closeStartDate={opsState.closeStartDate}
-						bind:closeEndDate={opsState.closeEndDate}
-						bind:closeProvider={opsState.closeProvider}
-						bind:invoiceForm={opsState.invoiceForm}
-					/>
-				{:catch}
-					<div class="card">
-						<div class="skeleton h-8 w-64 mb-4"></div>
-					</div>
-				{/await}
-			{:else}
-				<UpgradeNotice
-					currentTier={data.subscription?.tier}
-					requiredTier="pro"
-					feature="reconciliation close workflow"
-				/>
+				{/if}
 			{/if}
 		{:else}
 			<div class="card">

--- a/dashboard/src/routes/ops/ops-page.core.svelte.test.ts
+++ b/dashboard/src/routes/ops/ops-page.core.svelte.test.ts
@@ -10,6 +10,8 @@ import {
 } from './ops-page.test.setup';
 import Page from './+page.svelte';
 
+const ASYNC_RENDER_TIMEOUT = 5000;
+
 describe('ops page unit economics interactions', () => {
 	let createObjectUrlSpy: ReturnType<typeof vi.spyOn>;
 	let revokeObjectUrlSpy: ReturnType<typeof vi.spyOn>;
@@ -46,7 +48,7 @@ describe('ops page unit economics interactions', () => {
 			data: testOpsPageData
 		});
 
-		await screen.findByText('Unit Economics Monitor');
+		await screen.findByText('Unit Economics Monitor', {}, { timeout: ASYNC_RENDER_TIMEOUT });
 
 		const unitCard = screen.getByText('Unit Economics Monitor').closest('.card') as HTMLElement;
 		const dateInputs = Array.from(
@@ -75,7 +77,7 @@ describe('ops page unit economics interactions', () => {
 			data: testOpsPageData
 		});
 
-		await screen.findByText('Cost Ingestion SLA');
+		await screen.findByText('Cost Ingestion SLA', {}, { timeout: ASYNC_RENDER_TIMEOUT });
 		await screen.findByText('SLA At Risk');
 
 		await fireEvent.change(screen.getByLabelText('SLA Window'), { target: { value: '168' } });
@@ -98,7 +100,7 @@ describe('ops page unit economics interactions', () => {
 			data: testOpsPageData
 		});
 
-		await screen.findByText('Job Reliability SLO');
+		await screen.findByText('Job Reliability SLO', {}, { timeout: ASYNC_RENDER_TIMEOUT });
 		await screen.findByText('SLO Healthy');
 		await screen.findByText('cost_ingestion');
 
@@ -122,7 +124,7 @@ describe('ops page unit economics interactions', () => {
 			data: testOpsPageData
 		});
 
-		await screen.findByText('Acceptance KPI Evidence');
+		await screen.findByText('Acceptance KPI Evidence', {}, { timeout: ASYNC_RENDER_TIMEOUT });
 		await screen.findByText('Gaps Open');
 
 		const unitCard = screen.getByText('Unit Economics Monitor').closest('.card') as HTMLElement;
@@ -157,8 +159,8 @@ describe('ops page unit economics interactions', () => {
 			}
 		});
 
-		await screen.findByText('Unit Economics Monitor');
-		await screen.findByText('Cost Ingestion SLA');
+		await screen.findByText('Unit Economics Monitor', {}, { timeout: ASYNC_RENDER_TIMEOUT });
+		await screen.findByText('Cost Ingestion SLA', {}, { timeout: ASYNC_RENDER_TIMEOUT });
 		expect(await screen.findAllByText(/pro tier required/i)).toHaveLength(3);
 
 		await waitFor(() => {
@@ -182,7 +184,7 @@ describe('ops page unit economics interactions', () => {
 			data: testOpsPageData
 		});
 
-		await screen.findByText('Integration Acceptance Runs');
+		await screen.findByText('Integration Acceptance Runs', {}, { timeout: ASYNC_RENDER_TIMEOUT });
 		await screen.findByText('PARTIAL FAILURE');
 		expect(screen.getByText('2 passed / 1 failed')).toBeTruthy();
 		expect(screen.getByText('slack: OK')).toBeTruthy();
@@ -219,7 +221,7 @@ describe('ops page unit economics interactions', () => {
 			data: testOpsPageData
 		});
 
-		await screen.findByText('Integration Acceptance Runs');
+		await screen.findByText('Integration Acceptance Runs', {}, { timeout: ASYNC_RENDER_TIMEOUT });
 		await fireEvent.click(screen.getByRole('button', { name: 'Run Checks' }));
 
 		await waitFor(() => {
@@ -266,7 +268,7 @@ describe('ops page unit economics interactions', () => {
 			data: testOpsPageData
 		});
 
-		await screen.findByText('Integration Acceptance Runs');
+		await screen.findByText('Integration Acceptance Runs', {}, { timeout: ASYNC_RENDER_TIMEOUT });
 		await fireEvent.click(screen.getByLabelText('Include Jira checks'));
 		await fireEvent.click(screen.getByLabelText('Fail fast checks'));
 		await fireEvent.click(screen.getByRole('button', { name: 'Run Checks' }));

--- a/dashboard/src/routes/page.server.motion.test.ts
+++ b/dashboard/src/routes/page.server.motion.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import { load } from './+page.server';
 
+function buildRequest(url: string, headers: Record<string, string> = {}): Request {
+	return new Request(url, {
+		method: 'GET',
+		headers
+	});
+}
+
 async function expectRedirectLocation(
 	callback: () => unknown,
 	expected: { status: number; location: string }
@@ -15,16 +22,112 @@ async function expectRedirectLocation(
 	}
 }
 
+function asLoadResult(
+	value: Awaited<ReturnType<typeof load>>
+): Exclude<Awaited<ReturnType<typeof load>>, void> {
+	if (!value) {
+		throw new Error('expected load result data');
+	}
+	return value;
+}
+
 describe('landing motion query canonicalization', () => {
 	it('passes through supported motion variants', async () => {
-		const result = await load({
-			url: new URL('https://example.com/?motion=cinematic'),
-			locals: {
-				safeGetSession: async () => ({ user: null })
-			}
-		} as Parameters<typeof load>[0]);
+		const result = asLoadResult(
+			await load({
+				url: new URL('https://example.com/?motion=cinematic'),
+				request: buildRequest('https://example.com/?motion=cinematic'),
+				locals: {
+					safeGetSession: async () => ({ user: null })
+				}
+			} as Parameters<typeof load>[0])
+		);
 
-		expect(result).toEqual({});
+		expect(result.landingHero).toMatchObject({
+			initialExperiments: {
+				buyerPersonaDefault: 'cto',
+				heroVariant: 'control_every_dollar',
+				ctaVariant: 'start_free',
+				sectionOrderVariant: 'problem_first',
+				seed: 'default'
+			},
+			includeExperimentQueryParams: false,
+			initialMotionProfile: 'cinematic',
+			canonicalUrl: 'https://example.com/',
+			ogImageUrl: 'https://example.com/og-image.png',
+			detectedCurrencyCode: 'USD',
+			buyerPersonaId: 'cto',
+			heroPrimaryIntent: 'engineering_control',
+			heroTitle: 'Control cloud spend without slowing delivery.',
+			heroSubtitle:
+				'Valdrics gives finance and engineering one workflow for triage, approval, execution, and savings proof.',
+			initialSnapshot: {
+				id: 'snp-2026-02-27-a'
+			}
+		});
+	});
+
+	it('returns landing hero defaults when no motion query is present', async () => {
+		const result = asLoadResult(
+			await load({
+				url: new URL('https://example.com/?persona=security'),
+				request: buildRequest('https://example.com/?persona=security'),
+				locals: {
+					safeGetSession: async () => ({ user: null })
+				}
+			} as Parameters<typeof load>[0])
+		);
+
+		expect(result.landingHero).toMatchObject({
+			initialExperiments: {
+				buyerPersonaDefault: 'security',
+				heroVariant: 'control_every_dollar',
+				ctaVariant: 'book_briefing',
+				sectionOrderVariant: 'problem_first',
+				seed: 'default'
+			},
+			includeExperimentQueryParams: false,
+			initialMotionProfile: 'subtle',
+			canonicalUrl: 'https://example.com/',
+			ogImageUrl: 'https://example.com/og-image.png',
+			detectedCurrencyCode: 'USD',
+			buyerPersonaId: 'security',
+			heroPrimaryIntent: 'security_governance',
+			heroTitle: 'Review spend-changing actions with context.',
+			heroSubtitle:
+				'Valdrics keeps policy checks, approval lineage, and decision evidence attached before cost-changing actions move.',
+			initialSnapshot: {
+				id: 'snp-2026-02-27-a'
+			}
+		});
+	});
+
+	it('uses trusted geo headers but keeps the public landing USD-first for NG visitors', async () => {
+		const result = asLoadResult(
+			await load({
+				url: new URL('https://example.com/'),
+				request: buildRequest('https://example.com/', { 'cf-ipcountry': 'NG' }),
+				locals: {
+					safeGetSession: async () => ({ user: null })
+				}
+			} as Parameters<typeof load>[0])
+		);
+
+		expect(result.landingHero.detectedCurrencyCode).toBe('USD');
+	});
+
+	it('uses trusted geo headers for supported public landing currencies', async () => {
+		const result = asLoadResult(
+			await load({
+				url: new URL('https://example.com/'),
+				request: buildRequest('https://example.com/', { 'cf-ipcountry': 'GB' }),
+				locals: {
+					safeGetSession: async () => ({ user: null })
+				}
+			} as Parameters<typeof load>[0])
+		);
+
+		expect(result.landingHero.detectedCurrencyCode).toBe('GBP');
 	});
 
 	it('canonicalizes supported motion values to lowercase', async () => {
@@ -32,6 +135,7 @@ describe('landing motion query canonicalization', () => {
 			() =>
 				load({
 					url: new URL('https://example.com/?motion=CINEMATIC&utm_source=ads'),
+					request: buildRequest('https://example.com/?motion=CINEMATIC&utm_source=ads'),
 					locals: {
 						safeGetSession: async () => ({ user: null })
 					}
@@ -48,6 +152,7 @@ describe('landing motion query canonicalization', () => {
 			() =>
 				load({
 					url: new URL('https://example.com/?motion=neon&utm_source=ads&persona=finance'),
+					request: buildRequest('https://example.com/?motion=neon&utm_source=ads&persona=finance'),
 					locals: {
 						safeGetSession: async () => ({ user: null })
 					}
@@ -64,6 +169,7 @@ describe('landing motion query canonicalization', () => {
 			() =>
 				load({
 					url: new URL('https://example.com/?start_date=2024-01-01&end_date=2024-01-31'),
+					request: buildRequest('https://example.com/?start_date=2024-01-01&end_date=2024-01-31'),
 					locals: {
 						safeGetSession: async () => ({ user: { id: 'user-1' } })
 					}

--- a/dashboard/src/routes/proof/+page.server.ts
+++ b/dashboard/src/routes/proof/+page.server.ts
@@ -1,0 +1,12 @@
+import type { PageServerLoad } from './$types';
+import { listPublicContent, mustGetPublicContentEntry } from '$lib/content/publicContent';
+
+export const load: PageServerLoad = () => ({
+	proofSpotlights: [
+		mustGetPublicContentEntry('proof', 'safe-access-model'),
+		mustGetPublicContentEntry('proof', 'identity-and-approval-controls'),
+		mustGetPublicContentEntry('proof', 'decision-history-and-export-integrity'),
+		mustGetPublicContentEntry('proof', 'deployment-and-data-residency'),
+		mustGetPublicContentEntry('proof', 'validation-scope-and-operational-hardening')
+	]
+});

--- a/dashboard/src/routes/proof/+page.svelte
+++ b/dashboard/src/routes/proof/+page.svelte
@@ -3,15 +3,15 @@
 	import { page } from '$app/stores';
 	import PublicMarketingPage from '$lib/components/public/PublicMarketingPage.svelte';
 	import PublicPageMeta from '$lib/components/public/PublicPageMeta.svelte';
-	import { listPublicContent, type PublicContentEntry } from '$lib/content/publicContent';
+	import type { PublicContentEntry } from '$lib/content/publicContent.types';
 	import {
 		buildPublicEnterpriseHref,
 		buildPublicSignupHref,
 		resolvePublicBuyingMotion
 	} from '$lib/public/publicBuyingMotion';
+	import type { PageData } from './$types';
 
-	const proofEntries = listPublicContent('proof');
-	const proofBySlug = new Map(proofEntries.map((entry) => [entry.slug, entry] as const));
+	let { data }: { data: PageData } = $props();
 	let buyingMotion = $derived(resolvePublicBuyingMotion($page.url, 'enterprise_first'));
 	let startFreeHref = $derived(
 		buildPublicSignupHref(base, $page.url, {
@@ -25,14 +25,6 @@
 			source: 'proof_pack'
 		})
 	);
-
-	function mustGetProof(slug: string): PublicContentEntry {
-		const entry = proofBySlug.get(slug);
-		if (!entry) {
-			throw new Error(`Unknown proof entry: ${slug}`);
-		}
-		return entry;
-	}
 
 	const heroHighlights = [
 		{
@@ -67,13 +59,7 @@
 		}
 	] as const;
 
-	const proofSpotlights = [
-		mustGetProof('safe-access-model'),
-		mustGetProof('identity-and-approval-controls'),
-		mustGetProof('decision-history-and-export-integrity'),
-		mustGetProof('deployment-and-data-residency'),
-		mustGetProof('validation-scope-and-operational-hardening')
-	] as const;
+	let proofSpotlights = $derived(data.proofSpotlights as PublicContentEntry[]);
 </script>
 
 <PublicPageMeta

--- a/dashboard/src/routes/proof/[slug]/+page.server.ts
+++ b/dashboard/src/routes/proof/[slug]/+page.server.ts
@@ -1,0 +1,10 @@
+import type { PageServerLoad } from './$types';
+import { listRelatedPublicContent, mustGetPublicContentEntry } from '$lib/content/publicContent';
+
+export const load: PageServerLoad = ({ params }) => {
+	const entry = mustGetPublicContentEntry('proof', params.slug);
+	return {
+		entry,
+		relatedEntries: listRelatedPublicContent(entry)
+	};
+};

--- a/dashboard/src/routes/proof/[slug]/+page.svelte
+++ b/dashboard/src/routes/proof/[slug]/+page.svelte
@@ -5,4 +5,13 @@
 	let { data }: { data: PageData } = $props();
 </script>
 
-<PublicContentArticlePage entry={data.entry} hubHref="/proof" hubLabel="Back to Proof Pack" />
+<svelte:head>
+	<title>{data.entry.title} | Valdrics Proof</title>
+</svelte:head>
+
+<PublicContentArticlePage
+	entry={data.entry}
+	relatedEntries={data.relatedEntries}
+	hubHref="/proof"
+	hubLabel="Back to Proof Pack"
+/>

--- a/dashboard/src/routes/proof/[slug]/+page.ts
+++ b/dashboard/src/routes/proof/[slug]/+page.ts
@@ -1,6 +1,0 @@
-import type { PageLoad } from './$types';
-import { mustGetPublicContentEntry } from '$lib/content/publicContent';
-
-export const load: PageLoad = ({ params }) => ({
-	entry: mustGetPublicContentEntry('proof', params.slug)
-});

--- a/dashboard/src/routes/proof/proof-page.svelte.test.ts
+++ b/dashboard/src/routes/proof/proof-page.svelte.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/svelte';
 import { readable } from 'svelte/store';
 import Page from './+page.svelte';
+import { mustGetPublicContentEntry } from '$lib/content/publicContent';
 
 vi.mock('$app/paths', () => ({
 	base: '',
@@ -12,9 +13,27 @@ vi.mock('$app/stores', () => ({
 	page: readable({ url: new URL('https://example.com/proof') })
 }));
 
+const SHARED_PAGE_DATA = {
+	user: null,
+	session: null,
+	subscription: { tier: 'starter', status: 'active' },
+	profile: null
+} as const;
+
 describe('proof page', () => {
 	it('renders structured proof sections and navigation links', () => {
-		render(Page);
+		render(Page, {
+			data: {
+				...SHARED_PAGE_DATA,
+				proofSpotlights: [
+					mustGetPublicContentEntry('proof', 'safe-access-model'),
+					mustGetPublicContentEntry('proof', 'identity-and-approval-controls'),
+					mustGetPublicContentEntry('proof', 'decision-history-and-export-integrity'),
+					mustGetPublicContentEntry('proof', 'deployment-and-data-residency'),
+					mustGetPublicContentEntry('proof', 'validation-scope-and-operational-hardening')
+				]
+			}
+		});
 
 		expect(
 			screen.getByRole('heading', { level: 1, name: /proof surfaces for buyer diligence/i })

--- a/dashboard/src/routes/resources/+page.server.ts
+++ b/dashboard/src/routes/resources/+page.server.ts
@@ -1,0 +1,61 @@
+import type { PageServerLoad } from './$types';
+import { listPublicContent, mustGetPublicContentEntry } from '$lib/content/publicContent';
+
+export const load: PageServerLoad = () => {
+	const resources = listPublicContent('resources');
+	return {
+		resources,
+		guidedPaths: [
+			{
+				kicker: 'Internal alignment',
+				title: 'Make the business case without a long deck rewrite',
+				copy: 'Use concise assets when finance, leadership, or procurement needs the short version before the deeper review surfaces.',
+				entries: [
+					mustGetPublicContentEntry('resources', 'executive-one-pager'),
+					mustGetPublicContentEntry('resources', 'roi-assumptions'),
+					mustGetPublicContentEntry('resources', 'enterprise-governance-overview')
+				]
+			},
+			{
+				kicker: 'Operating rhythm',
+				title: 'Give the team a repeatable review loop',
+				copy: 'Use these assets when you want one cost-review ritual, clearer owner routing, and a practical GreenOps conversation.',
+				entries: [
+					mustGetPublicContentEntry('resources', 'cloud-waste-review-checklist'),
+					mustGetPublicContentEntry('resources', 'greenops-decision-framework'),
+					mustGetPublicContentEntry('resources', 'saas-license-governance-starter-pack')
+				]
+			},
+			{
+				kicker: 'Buyer diligence',
+				title: 'Move into procurement and security without losing the thread',
+				copy: 'These are the assets that help the product story survive security, procurement, and rollout conversations.',
+				entries: [
+					mustGetPublicContentEntry('resources', 'enterprise-governance-overview'),
+					mustGetPublicContentEntry('resources', 'saas-license-governance-starter-pack'),
+					mustGetPublicContentEntry('resources', 'roi-assumptions')
+				]
+			}
+		],
+		stageColumns: [
+			{
+				label: 'Learn',
+				title: 'Run the first review with less noise',
+				copy: 'Operational guides for teams that need a practical first loop.',
+				entries: resources.filter((resource) => resource.stage === 'learn')
+			},
+			{
+				label: 'Evaluate',
+				title: 'Prepare the buying and rollout conversation',
+				copy: 'Assets for leadership, procurement, and rollout planning.',
+				entries: resources.filter((resource) => resource.stage === 'evaluate')
+			},
+			{
+				label: 'Validate',
+				title: 'Pressure-test the modeled case',
+				copy: 'Artifacts that support a deeper diligence or planning review.',
+				entries: resources.filter((resource) => resource.stage === 'validate')
+			}
+		]
+	};
+};

--- a/dashboard/src/routes/resources/+page.svelte
+++ b/dashboard/src/routes/resources/+page.svelte
@@ -3,16 +3,16 @@
 	import { page } from '$app/stores';
 	import PublicMarketingPage from '$lib/components/public/PublicMarketingPage.svelte';
 	import PublicPageMeta from '$lib/components/public/PublicPageMeta.svelte';
+	import type { PublicContentEntry } from '$lib/content/publicContent.types';
 	import { PUBLIC_EXTENDED_CONTACT_CHANNELS } from '$lib/landing/publicNav';
-	import { listPublicContent, type PublicContentEntry } from '$lib/content/publicContent';
 	import {
 		buildPublicEnterpriseHref,
 		buildPublicSignupHref,
 		resolvePublicBuyingMotion
 	} from '$lib/public/publicBuyingMotion';
+	import type { PageData } from './$types';
 
-	const resources = listPublicContent('resources');
-	const resourcesBySlug = new Map(resources.map((resource) => [resource.slug, resource] as const));
+	let { data }: { data: PageData } = $props();
 	let buyingMotion = $derived(resolvePublicBuyingMotion($page.url, 'self_serve_first'));
 	let startFreeHref = $derived(
 		buildPublicSignupHref(base, $page.url, {
@@ -26,14 +26,6 @@
 			source: 'resource_hub'
 		})
 	);
-
-	function mustGetResource(slug: string): PublicContentEntry {
-		const resource = resourcesBySlug.get(slug);
-		if (!resource) {
-			throw new Error(`Unknown resource entry: ${slug}`);
-		}
-		return resource;
-	}
 
 	const heroHighlights = [
 		{
@@ -50,59 +42,22 @@
 		}
 	] as const;
 
-	const guidedPaths = [
-		{
-			kicker: 'Internal alignment',
-			title: 'Make the business case without a long deck rewrite',
-			copy: 'Use concise assets when finance, leadership, or procurement needs the short version before the deeper review surfaces.',
-			entries: [
-				mustGetResource('executive-one-pager'),
-				mustGetResource('roi-assumptions'),
-				mustGetResource('enterprise-governance-overview')
-			]
-		},
-		{
-			kicker: 'Operating rhythm',
-			title: 'Give the team a repeatable review loop',
-			copy: 'Use these assets when you want one cost-review ritual, clearer owner routing, and a practical GreenOps conversation.',
-			entries: [
-				mustGetResource('cloud-waste-review-checklist'),
-				mustGetResource('greenops-decision-framework'),
-				mustGetResource('saas-license-governance-starter-pack')
-			]
-		},
-		{
-			kicker: 'Buyer diligence',
-			title: 'Move into procurement and security without losing the thread',
-			copy: 'These are the assets that help the product story survive security, procurement, and rollout conversations.',
-			entries: [
-				mustGetResource('enterprise-governance-overview'),
-				mustGetResource('saas-license-governance-starter-pack'),
-				mustGetResource('roi-assumptions')
-			]
-		}
-	] as const;
-
-	const stageColumns = [
-		{
-			label: 'Learn',
-			title: 'Run the first review with less noise',
-			copy: 'Operational guides for teams that need a practical first loop.',
-			entries: resources.filter((resource) => resource.stage === 'learn')
-		},
-		{
-			label: 'Evaluate',
-			title: 'Prepare the buying and rollout conversation',
-			copy: 'Assets for leadership, procurement, and rollout planning.',
-			entries: resources.filter((resource) => resource.stage === 'evaluate')
-		},
-		{
-			label: 'Validate',
-			title: 'Pressure-test the modeled case',
-			copy: 'Artifacts that support a deeper diligence or planning review.',
-			entries: resources.filter((resource) => resource.stage === 'validate')
-		}
-	] as const;
+	let guidedPaths = $derived(
+		data.guidedPaths as Array<{
+			kicker: string;
+			title: string;
+			copy: string;
+			entries: PublicContentEntry[];
+		}>
+	);
+	let stageColumns = $derived(
+		data.stageColumns as Array<{
+			label: string;
+			title: string;
+			copy: string;
+			entries: PublicContentEntry[];
+		}>
+	);
 </script>
 
 <PublicPageMeta
@@ -219,7 +174,7 @@
 							class="public-page__badge"
 							aria-label={`${channel.label} contact ${channel.email}`}
 						>
-							{channel.label}: {channel.email}
+							{channel.email}
 						</a>
 					{/each}
 				</div>

--- a/dashboard/src/routes/resources/[slug]/+page.server.ts
+++ b/dashboard/src/routes/resources/[slug]/+page.server.ts
@@ -1,0 +1,10 @@
+import type { PageServerLoad } from './$types';
+import { listRelatedPublicContent, mustGetPublicContentEntry } from '$lib/content/publicContent';
+
+export const load: PageServerLoad = ({ params }) => {
+	const entry = mustGetPublicContentEntry('resources', params.slug);
+	return {
+		entry,
+		relatedEntries: listRelatedPublicContent(entry)
+	};
+};

--- a/dashboard/src/routes/resources/[slug]/+page.svelte
+++ b/dashboard/src/routes/resources/[slug]/+page.svelte
@@ -5,4 +5,13 @@
 	let { data }: { data: PageData } = $props();
 </script>
 
-<PublicContentArticlePage entry={data.entry} hubHref="/resources" hubLabel="Back to Resources" />
+<svelte:head>
+	<title>{data.entry.title} | Valdrics Resources</title>
+</svelte:head>
+
+<PublicContentArticlePage
+	entry={data.entry}
+	relatedEntries={data.relatedEntries}
+	hubHref="/resources"
+	hubLabel="Back to Resources"
+/>

--- a/dashboard/src/routes/resources/[slug]/+page.ts
+++ b/dashboard/src/routes/resources/[slug]/+page.ts
@@ -1,6 +1,0 @@
-import type { PageLoad } from './$types';
-import { mustGetPublicContentEntry } from '$lib/content/publicContent';
-
-export const load: PageLoad = ({ params }) => ({
-	entry: mustGetPublicContentEntry('resources', params.slug)
-});

--- a/dashboard/src/routes/resources/resources-page.svelte.test.ts
+++ b/dashboard/src/routes/resources/resources-page.svelte.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/svelte';
 import { readable } from 'svelte/store';
 import Page from './+page.svelte';
+import { listPublicContent, mustGetPublicContentEntry } from '$lib/content/publicContent';
 
 vi.mock('$app/paths', () => ({
 	base: '',
@@ -12,9 +13,41 @@ vi.mock('$app/stores', () => ({
 	page: readable({ url: new URL('https://example.com/resources') })
 }));
 
+const SHARED_PAGE_DATA = {
+	user: null,
+	session: null,
+	subscription: { tier: 'starter', status: 'active' },
+	profile: null
+} as const;
+
 describe('resources page contact directory', () => {
 	it('shows extended public contact channels outside the landing footer', () => {
-		render(Page);
+		render(Page, {
+			data: {
+				...SHARED_PAGE_DATA,
+				resources: listPublicContent('resources'),
+				guidedPaths: [
+					{
+						kicker: 'Internal alignment',
+						title: 'Make the business case without a long deck rewrite',
+						copy: 'Use concise assets when finance, leadership, or procurement needs the short version before the deeper review surfaces.',
+						entries: [
+							mustGetPublicContentEntry('resources', 'executive-one-pager'),
+							mustGetPublicContentEntry('resources', 'roi-assumptions'),
+							mustGetPublicContentEntry('resources', 'enterprise-governance-overview')
+						]
+					}
+				],
+				stageColumns: [
+					{
+						label: 'Learn',
+						title: 'Run the first review with less noise',
+						copy: 'Operational guides for teams that need a practical first loop.',
+						entries: listPublicContent('resources').filter((resource) => resource.stage === 'learn')
+					}
+				]
+			}
+		});
 
 		expect(
 			screen.getByRole('heading', {

--- a/dashboard/src/routes/roi-planner/+page.server.ts
+++ b/dashboard/src/routes/roi-planner/+page.server.ts
@@ -1,0 +1,6 @@
+import { resolvePublicLandingCurrencyFromHeaders } from '$lib/landing/geoCurrency';
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async ({ request }) => ({
+	detectedCurrencyCode: resolvePublicLandingCurrencyFromHeaders(request.headers)
+});

--- a/dashboard/src/routes/roi-planner/+page.svelte
+++ b/dashboard/src/routes/roi-planner/+page.svelte
@@ -5,7 +5,6 @@
 	import AuthGate from '$lib/components/AuthGate.svelte';
 	import LandingRoiCalculator from '$lib/components/landing/LandingRoiCalculator.svelte';
 	import {
-		resolveDetectedLandingCurrency,
 		resolveInitialLandingCurrency,
 		setLandingCurrencyPreference,
 		type LandingCurrencyCode
@@ -25,8 +24,11 @@
 	let roiTeamMembers = $state(DEFAULT_LANDING_ROI_INPUTS.teamMembers);
 	let roiBlendedHourlyUsd = $state(DEFAULT_LANDING_ROI_INPUTS.blendedHourlyUsd);
 	let roiPlatformAnnualCostUsd = $state(DEFAULT_LANDING_ROI_INPUTS.platformAnnualCostUsd);
-	let localCurrencyCode = $state<LandingCurrencyCode>(resolveDetectedLandingCurrency());
-	let roiCurrencyCode = $state<LandingCurrencyCode>(resolveInitialLandingCurrency());
+	let roiCurrencyOverride = $state<LandingCurrencyCode | null>(null);
+	let localCurrencyCode = $derived.by(() => data.detectedCurrencyCode);
+	let roiCurrencyCode = $derived(
+		roiCurrencyOverride ?? resolveInitialLandingCurrency(localCurrencyCode)
+	);
 
 	let roiInputs = $derived(
 		normalizeLandingRoiInputs({
@@ -45,7 +47,7 @@
 	}
 
 	function handleCurrencyCodeChange(value: LandingCurrencyCode): void {
-		roiCurrencyCode = value;
+		roiCurrencyOverride = value;
 		if (browser) {
 			setLandingCurrencyPreference(value);
 		}

--- a/dashboard/src/routes/roi-planner/page.server.test.ts
+++ b/dashboard/src/routes/roi-planner/page.server.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { load } from './+page.server';
+
+function buildRequest(headers: Record<string, string> = {}): Request {
+	return new Request('https://example.com/roi-planner', {
+		method: 'GET',
+		headers
+	});
+}
+
+function asLoadResult(
+	value: Awaited<ReturnType<typeof load>>
+): Exclude<Awaited<ReturnType<typeof load>>, void> {
+	if (!value) {
+		throw new Error('expected load result data');
+	}
+	return value;
+}
+
+describe('roi planner currency detection', () => {
+	it('defaults to USD when there is no trusted country header', async () => {
+		const result = asLoadResult(
+			await load({
+				request: buildRequest()
+			} as Parameters<typeof load>[0])
+		);
+
+		expect(result.detectedCurrencyCode).toBe('USD');
+	});
+
+	it('uses supported public geo currencies from trusted headers', async () => {
+		const result = asLoadResult(
+			await load({
+				request: buildRequest({ 'x-vercel-ip-country': 'GB' })
+			} as Parameters<typeof load>[0])
+		);
+
+		expect(result.detectedCurrencyCode).toBe('GBP');
+	});
+
+	it('keeps NG visitors on USD for the public planner surface', async () => {
+		const result = asLoadResult(
+			await load({
+				request: buildRequest({ 'cf-ipcountry': 'NG' })
+			} as Parameters<typeof load>[0])
+		);
+
+		expect(result.detectedCurrencyCode).toBe('USD');
+	});
+});

--- a/dashboard/src/routes/roi-planner/roi-planner-page.svelte.test.ts
+++ b/dashboard/src/routes/roi-planner/roi-planner-page.svelte.test.ts
@@ -19,7 +19,8 @@ describe('ROI planner page', () => {
 			},
 			session: null,
 			subscription: { tier: 'free', status: 'active' },
-			profile: null
+			profile: null,
+			detectedCurrencyCode: 'USD'
 		} as unknown as PageData;
 		render(Page, {
 			data
@@ -37,7 +38,8 @@ describe('ROI planner page', () => {
 			user: null,
 			session: null,
 			subscription: { tier: 'free', status: 'active' },
-			profile: null
+			profile: null,
+			detectedCurrencyCode: 'USD'
 		} as unknown as PageData;
 		render(Page, {
 			data

--- a/dashboard/src/routes/settings/SettingsDeferredSection.svelte
+++ b/dashboard/src/routes/settings/SettingsDeferredSection.svelte
@@ -1,0 +1,342 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { createLazyComponent } from '$lib/lazyComponent';
+	import {
+		INITIAL_ACTIVEOPS_SETTINGS,
+		INITIAL_LLM_SETTINGS,
+		INITIAL_NOTIFICATION_SETTINGS,
+		INITIAL_PROVIDER_MODELS
+	} from './settingsPageInitialState';
+	import type { PolicyDiagnostics, SafetyStatus } from './settingsPageModels';
+
+	type AsyncAction = () => void | Promise<void>;
+	type NotificationSettingsState = typeof INITIAL_NOTIFICATION_SETTINGS;
+	type LlmSettingsState = typeof INITIAL_LLM_SETTINGS;
+	type ActiveOpsSettingsState = typeof INITIAL_ACTIVEOPS_SETTINGS;
+	type ProviderModelsState = typeof INITIAL_PROVIDER_MODELS;
+	type TieredSettingsCardProps = {
+		accessToken?: string;
+		tier?: string;
+	};
+	type SettingsNotificationControlsProps = {
+		data: {
+			user?: unknown;
+			session?: { access_token?: string };
+			subscription?: { tier?: string };
+			profile?: { persona?: string };
+		};
+		settings: NotificationSettingsState;
+		testing: boolean;
+		testingJira: boolean;
+		testingTeams: boolean;
+		testingWorkflow: boolean;
+		diagnosticsLoading: boolean;
+		policyDiagnostics: PolicyDiagnostics | null;
+		testSlack: AsyncAction;
+		testJira: AsyncAction;
+		testTeams: AsyncAction;
+		testWorkflowDispatch: AsyncAction;
+		runPolicyDiagnostics: AsyncAction;
+		saveSettings: AsyncAction;
+		saving: boolean;
+	};
+
+	let {
+		data,
+		llmSettings = $bindable(),
+		loadingLLM,
+		savingLLM,
+		providerModels,
+		saveLLMSettings,
+		activeOpsSettings = $bindable(),
+		loadingActiveOps,
+		savingActiveOps,
+		saveActiveOpsSettings,
+		loadingSafety,
+		resettingSafety,
+		loadSafetyStatus,
+		resetSafetyCircuitBreaker,
+		safetyError,
+		safetySuccess,
+		safetyStatus,
+		settings = $bindable(),
+		testing,
+		testingJira,
+		testingTeams,
+		testingWorkflow,
+		diagnosticsLoading,
+		policyDiagnostics,
+		testSlack,
+		testJira,
+		testTeams,
+		testWorkflowDispatch,
+		runPolicyDiagnostics,
+		saveSettings,
+		saving
+	}: {
+		data: {
+			user?: unknown;
+			session?: { access_token?: string };
+			subscription?: { tier?: string };
+			profile?: { persona?: string };
+		};
+		llmSettings: LlmSettingsState;
+		loadingLLM: boolean;
+		savingLLM: boolean;
+		providerModels: ProviderModelsState;
+		saveLLMSettings: AsyncAction;
+		activeOpsSettings: ActiveOpsSettingsState;
+		loadingActiveOps: boolean;
+		savingActiveOps: boolean;
+		saveActiveOpsSettings: AsyncAction;
+		loadingSafety: boolean;
+		resettingSafety: boolean;
+		loadSafetyStatus: AsyncAction;
+		resetSafetyCircuitBreaker: AsyncAction;
+		safetyError: string;
+		safetySuccess: string;
+		safetyStatus: SafetyStatus | null;
+		settings: NotificationSettingsState;
+		testing: boolean;
+		testingJira: boolean;
+		testingTeams: boolean;
+		testingWorkflow: boolean;
+		diagnosticsLoading: boolean;
+		policyDiagnostics: PolicyDiagnostics | null;
+		testSlack: AsyncAction;
+		testJira: AsyncAction;
+		testTeams: AsyncAction;
+		testWorkflowDispatch: AsyncAction;
+		runPolicyDiagnostics: AsyncAction;
+		saveSettings: AsyncAction;
+		saving: boolean;
+	} = $props();
+
+	const loadIdentitySettingsCard = createLazyComponent<TieredSettingsCardProps>(
+		() => import('$lib/components/IdentitySettingsCard.svelte')
+	);
+	const loadEnforcementSettingsCard = createLazyComponent<TieredSettingsCardProps>(
+		() => import('$lib/components/EnforcementSettingsCard.svelte')
+	);
+	const loadEnforcementOpsCard = createLazyComponent<TieredSettingsCardProps>(
+		() => import('$lib/components/EnforcementOpsCard.svelte')
+	);
+	const loadSettingsAiStrategyCard = createLazyComponent<{
+		loadingLLM: boolean;
+		llmSettings: LlmSettingsState;
+		providerModels: ProviderModelsState;
+		saveLLMSettings: AsyncAction;
+		savingLLM: boolean;
+	}>(() => import('./SettingsAiStrategyCard.svelte'));
+	const loadSettingsActiveOpsCard = createLazyComponent<{
+		data: {
+			user?: unknown;
+			session?: { access_token?: string };
+			subscription?: { tier?: string };
+			profile?: { persona?: string };
+		};
+		loadingActiveOps: boolean;
+		activeOpsSettings: ActiveOpsSettingsState;
+		saveActiveOpsSettings: AsyncAction;
+		savingActiveOps: boolean;
+	}>(() => import('./SettingsActiveOpsCard.svelte'));
+	const loadSettingsSafetyControlsCard = createLazyComponent<{
+		loadingSafety: boolean;
+		resettingSafety: boolean;
+		loadSafetyStatus: AsyncAction;
+		resetSafetyCircuitBreaker: AsyncAction;
+		safetyError: string;
+		safetySuccess: string;
+		safetyStatus: SafetyStatus | null;
+	}>(() => import('./SettingsSafetyControlsCard.svelte'));
+	const loadSettingsNotificationControls = createLazyComponent<SettingsNotificationControlsProps>(
+		() => import('./SettingsNotificationControls.svelte')
+	);
+
+	let advancedSettingsAnchor: HTMLDivElement | null = $state(null);
+	let advancedSettingsVisible = $state(false);
+
+	onMount(() => {
+		if (import.meta.env.MODE === 'test' || typeof IntersectionObserver === 'undefined') {
+			advancedSettingsVisible = true;
+			return;
+		}
+
+		const observer = new IntersectionObserver(
+			(entries) => {
+				if (entries.some((entry) => entry.isIntersecting)) {
+					advancedSettingsVisible = true;
+					observer.disconnect();
+				}
+			},
+			{ rootMargin: '320px 0px' }
+		);
+
+		if (advancedSettingsAnchor) {
+			observer.observe(advancedSettingsAnchor);
+		}
+
+		return () => observer.disconnect();
+	});
+</script>
+
+{#await loadIdentitySettingsCard()}
+	<div class="card">
+		<div class="skeleton h-6 w-40 mb-4"></div>
+		<div class="skeleton h-4 w-full mb-2"></div>
+		<div class="skeleton h-4 w-3/4"></div>
+	</div>
+{:then module}
+	{@const IdentitySettingsCard = module.default}
+	<IdentitySettingsCard accessToken={data.session?.access_token} tier={data.subscription?.tier} />
+{:catch}
+	<div class="card">
+		<div class="skeleton h-6 w-40 mb-4"></div>
+		<div class="skeleton h-4 w-full mb-2"></div>
+		<div class="skeleton h-4 w-3/4"></div>
+	</div>
+{/await}
+
+{#await loadEnforcementSettingsCard()}
+	<div class="card">
+		<div class="skeleton h-6 w-48 mb-4"></div>
+		<div class="skeleton h-4 w-full mb-2"></div>
+		<div class="skeleton h-4 w-2/3"></div>
+	</div>
+{:then module}
+	{@const EnforcementSettingsCard = module.default}
+	<EnforcementSettingsCard
+		accessToken={data.session?.access_token}
+		tier={data.subscription?.tier}
+	/>
+{:catch}
+	<div class="card">
+		<div class="skeleton h-6 w-48 mb-4"></div>
+		<div class="skeleton h-4 w-full mb-2"></div>
+		<div class="skeleton h-4 w-2/3"></div>
+	</div>
+{/await}
+
+{#await loadEnforcementOpsCard()}
+	<div class="card">
+		<div class="skeleton h-6 w-48 mb-4"></div>
+		<div class="skeleton h-4 w-full mb-2"></div>
+		<div class="skeleton h-4 w-2/3"></div>
+	</div>
+{:then module}
+	{@const EnforcementOpsCard = module.default}
+	<EnforcementOpsCard accessToken={data.session?.access_token} tier={data.subscription?.tier} />
+{:catch}
+	<div class="card">
+		<div class="skeleton h-6 w-48 mb-4"></div>
+		<div class="skeleton h-4 w-full mb-2"></div>
+		<div class="skeleton h-4 w-2/3"></div>
+	</div>
+{/await}
+
+<div bind:this={advancedSettingsAnchor}>
+	{#if advancedSettingsVisible}
+		{#await loadSettingsAiStrategyCard()}
+			<div class="card">
+				<div class="skeleton h-6 w-48 mb-4"></div>
+				<div class="skeleton h-24 rounded-2xl"></div>
+			</div>
+		{:then module}
+			{@const SettingsAiStrategyCard = module.default}
+			<SettingsAiStrategyCard
+				{loadingLLM}
+				bind:llmSettings
+				{providerModels}
+				{saveLLMSettings}
+				{savingLLM}
+			/>
+		{:catch}
+			<div class="card">
+				<div class="skeleton h-6 w-48 mb-4"></div>
+				<div class="skeleton h-24 rounded-2xl"></div>
+			</div>
+		{/await}
+
+		{#await loadSettingsActiveOpsCard()}
+			<div class="card">
+				<div class="skeleton h-6 w-48 mb-4"></div>
+				<div class="skeleton h-24 rounded-2xl"></div>
+			</div>
+		{:then module}
+			{@const SettingsActiveOpsCard = module.default}
+			<SettingsActiveOpsCard
+				{data}
+				{loadingActiveOps}
+				bind:activeOpsSettings
+				{saveActiveOpsSettings}
+				{savingActiveOps}
+			/>
+		{:catch}
+			<div class="card">
+				<div class="skeleton h-6 w-48 mb-4"></div>
+				<div class="skeleton h-24 rounded-2xl"></div>
+			</div>
+		{/await}
+
+		{#await loadSettingsSafetyControlsCard()}
+			<div class="card">
+				<div class="skeleton h-6 w-56 mb-4"></div>
+				<div class="skeleton h-20 rounded-2xl"></div>
+			</div>
+		{:then module}
+			{@const SettingsSafetyControlsCard = module.default}
+			<SettingsSafetyControlsCard
+				{loadingSafety}
+				{resettingSafety}
+				{loadSafetyStatus}
+				{resetSafetyCircuitBreaker}
+				{safetyError}
+				{safetySuccess}
+				{safetyStatus}
+			/>
+		{:catch}
+			<div class="card">
+				<div class="skeleton h-6 w-56 mb-4"></div>
+				<div class="skeleton h-20 rounded-2xl"></div>
+			</div>
+		{/await}
+
+		{#await loadSettingsNotificationControls()}
+			<div class="card">
+				<div class="skeleton h-6 w-52 mb-4"></div>
+				<div class="skeleton h-4 w-full mb-2"></div>
+				<div class="skeleton h-4 w-3/4"></div>
+			</div>
+		{:then module}
+			{@const SettingsNotificationControls = module.default}
+			<SettingsNotificationControls
+				{data}
+				bind:settings
+				{testing}
+				{testingJira}
+				{testingTeams}
+				{testingWorkflow}
+				{diagnosticsLoading}
+				{policyDiagnostics}
+				{testSlack}
+				{testJira}
+				{testTeams}
+				{testWorkflowDispatch}
+				{runPolicyDiagnostics}
+				{saveSettings}
+				{saving}
+			/>
+		{:catch}
+			<div class="card">
+				<div class="skeleton h-6 w-52 mb-4"></div>
+				<div class="skeleton h-4 w-full mb-2"></div>
+				<div class="skeleton h-4 w-3/4"></div>
+			</div>
+		{/await}
+	{:else}
+		<div class="card">
+			<div class="skeleton h-6 w-48 mb-4"></div>
+			<div class="skeleton h-24 rounded-2xl"></div>
+		</div>
+	{/if}
+</div>

--- a/dashboard/src/routes/settings/SettingsNotificationControls.svelte
+++ b/dashboard/src/routes/settings/SettingsNotificationControls.svelte
@@ -1,12 +1,26 @@
 <script lang="ts">
+	import { onMount } from 'svelte';
 	import { tierAtLeast } from '$lib/tier';
+	import { createLazyComponent } from '$lib/lazyComponent';
 	import type { PolicyDiagnostics } from './settingsPageModels';
-	import SettingsDigestAlertCard from './SettingsDigestAlertCard.svelte';
 	import { INITIAL_NOTIFICATION_SETTINGS } from './settingsPageInitialState';
-	import SettingsWorkflowAutomationCard from './SettingsWorkflowAutomationCard.svelte';
 
 	type AsyncAction = () => void | Promise<void>;
 	type NotificationSettingsState = typeof INITIAL_NOTIFICATION_SETTINGS;
+	type SettingsWorkflowAutomationCardProps = {
+		settings: NotificationSettingsState;
+		isProTier: boolean;
+		testingWorkflow: boolean;
+		diagnosticsLoading: boolean;
+		policyDiagnostics: PolicyDiagnostics | null;
+		testWorkflowDispatch: AsyncAction;
+		runPolicyDiagnostics: AsyncAction;
+	};
+	type SettingsDigestAlertCardProps = {
+		settings: NotificationSettingsState;
+		saveSettings: AsyncAction;
+		saving: boolean;
+	};
 
 	interface Props {
 		data: {
@@ -51,6 +65,32 @@
 	const currentTier = $derived(data.subscription?.tier ?? 'free');
 	const hasGrowthTier = $derived(tierAtLeast(currentTier, 'growth'));
 	const hasProTier = $derived(tierAtLeast(currentTier, 'pro'));
+	const loadSettingsWorkflowAutomationCard =
+		createLazyComponent<SettingsWorkflowAutomationCardProps>(
+			() => import('./SettingsWorkflowAutomationCard.svelte')
+		);
+	const loadSettingsDigestAlertCard = createLazyComponent<SettingsDigestAlertCardProps>(
+		() => import('./SettingsDigestAlertCard.svelte')
+	);
+	let advancedNotificationControlsReady = $state(import.meta.env.MODE === 'test');
+
+	onMount(() => {
+		if (advancedNotificationControlsReady) {
+			return;
+		}
+
+		const activate = () => {
+			advancedNotificationControlsReady = true;
+		};
+
+		if (typeof window.requestIdleCallback === 'function') {
+			const idleId = window.requestIdleCallback(activate, { timeout: 1200 });
+			return () => window.cancelIdleCallback(idleId);
+		}
+
+		const timeoutId = window.setTimeout(activate, 500);
+		return () => window.clearTimeout(timeoutId);
+	});
 </script>
 
 <!-- Slack Settings -->
@@ -263,17 +303,61 @@
 				</button>
 			</div>
 
-			<SettingsWorkflowAutomationCard
-				bind:settings
-				isProTier={hasProTier}
-				{testingWorkflow}
-				{diagnosticsLoading}
-				{policyDiagnostics}
-				{testWorkflowDispatch}
-				{runPolicyDiagnostics}
-			/>
+			{#if advancedNotificationControlsReady}
+				{#await loadSettingsWorkflowAutomationCard()}
+					<div class="rounded-xl border border-ink-700 bg-ink-900/30 p-4">
+						<div class="skeleton mb-2 h-4 w-48"></div>
+						<div class="skeleton mb-2 h-4 w-full"></div>
+						<div class="skeleton h-4 w-2/3"></div>
+					</div>
+				{:then module}
+					{@const SettingsWorkflowAutomationCard = module.default}
+					<SettingsWorkflowAutomationCard
+						bind:settings
+						isProTier={hasProTier}
+						{testingWorkflow}
+						{diagnosticsLoading}
+						{policyDiagnostics}
+						{testWorkflowDispatch}
+						{runPolicyDiagnostics}
+					/>
+				{:catch}
+					<div class="rounded-xl border border-ink-700 bg-ink-900/30 p-4">
+						<p class="text-xs text-ink-500">
+							Workflow automation controls are temporarily unavailable.
+						</p>
+					</div>
+				{/await}
+			{:else}
+				<div class="rounded-xl border border-ink-700 bg-ink-900/30 p-4">
+					<div class="skeleton mb-2 h-4 w-48"></div>
+					<div class="skeleton mb-2 h-4 w-full"></div>
+					<div class="skeleton h-4 w-2/3"></div>
+				</div>
+			{/if}
 		</div>
 	</div>
 </div>
 
-<SettingsDigestAlertCard bind:settings {saveSettings} {saving} />
+{#if advancedNotificationControlsReady}
+	{#await loadSettingsDigestAlertCard()}
+		<div class="card stagger-enter">
+			<div class="skeleton mb-2 h-6 w-40"></div>
+			<div class="skeleton mb-2 h-4 w-full"></div>
+			<div class="skeleton h-4 w-3/4"></div>
+		</div>
+	{:then module}
+		{@const SettingsDigestAlertCard = module.default}
+		<SettingsDigestAlertCard bind:settings {saveSettings} {saving} />
+	{:catch}
+		<div class="card stagger-enter">
+			<p class="text-sm text-ink-400">Digest settings are temporarily unavailable.</p>
+		</div>
+	{/await}
+{:else}
+	<div class="card stagger-enter">
+		<div class="skeleton mb-2 h-6 w-40"></div>
+		<div class="skeleton mb-2 h-4 w-full"></div>
+		<div class="skeleton h-4 w-3/4"></div>
+	</div>
+{/if}

--- a/dashboard/src/routes/settings/SettingsPageViewBody.svelte
+++ b/dashboard/src/routes/settings/SettingsPageViewBody.svelte
@@ -19,17 +19,29 @@
 	type LlmSettingsState = typeof INITIAL_LLM_SETTINGS;
 	type ActiveOpsSettingsState = typeof INITIAL_ACTIVEOPS_SETTINGS;
 	type ProviderModelsState = typeof INITIAL_PROVIDER_MODELS;
-	type TieredSettingsCardProps = {
-		accessToken?: string;
-		tier?: string;
-	};
-	type SettingsNotificationControlsProps = {
+	type SettingsDeferredSectionProps = {
 		data: {
 			user?: unknown;
 			session?: { access_token?: string };
 			subscription?: { tier?: string };
 			profile?: { persona?: string };
 		};
+		llmSettings: LlmSettingsState;
+		loadingLLM: boolean;
+		savingLLM: boolean;
+		providerModels: ProviderModelsState;
+		saveLLMSettings: AsyncAction;
+		activeOpsSettings: ActiveOpsSettingsState;
+		loadingActiveOps: boolean;
+		savingActiveOps: boolean;
+		saveActiveOpsSettings: AsyncAction;
+		loadingSafety: boolean;
+		resettingSafety: boolean;
+		loadSafetyStatus: AsyncAction;
+		resetSafetyCircuitBreaker: AsyncAction;
+		safetyError: string;
+		safetySuccess: string;
+		safetyStatus: SafetyStatus | null;
 		settings: NotificationSettingsState;
 		testing: boolean;
 		testingJira: boolean;
@@ -87,7 +99,8 @@
 		testWorkflowDispatch,
 		runPolicyDiagnostics,
 		saveSettings,
-		saving
+		saving,
+		onRevealDeferredSections = async () => {}
 	}: {
 		data: {
 			user?: unknown;
@@ -135,76 +148,47 @@
 		runPolicyDiagnostics: AsyncAction;
 		saveSettings: AsyncAction;
 		saving: boolean;
+		onRevealDeferredSections?: AsyncAction;
 	} = $props();
 
 	const isGrowthTier = $derived(
 		['growth', 'pro', 'enterprise'].includes(data.subscription?.tier ?? '')
 	);
 	const carbonUpgradePrompt = getUpgradePrompt('growth', 'GreenOps controls');
-	const loadIdentitySettingsCard = createLazyComponent<TieredSettingsCardProps>(
-		() => import('$lib/components/IdentitySettingsCard.svelte')
+	const loadSettingsDeferredSection = createLazyComponent<SettingsDeferredSectionProps>(
+		() => import('./SettingsDeferredSection.svelte')
 	);
-	const loadEnforcementSettingsCard = createLazyComponent<TieredSettingsCardProps>(
-		() => import('$lib/components/EnforcementSettingsCard.svelte')
-	);
-	const loadEnforcementOpsCard = createLazyComponent<TieredSettingsCardProps>(
-		() => import('$lib/components/EnforcementOpsCard.svelte')
-	);
-	const loadSettingsAiStrategyCard = createLazyComponent<{
-		loadingLLM: boolean;
-		llmSettings: LlmSettingsState;
-		providerModels: ProviderModelsState;
-		saveLLMSettings: AsyncAction;
-		savingLLM: boolean;
-	}>(() => import('./SettingsAiStrategyCard.svelte'));
-	const loadSettingsActiveOpsCard = createLazyComponent<{
-		data: {
-			user?: unknown;
-			session?: { access_token?: string };
-			subscription?: { tier?: string };
-			profile?: { persona?: string };
-		};
-		loadingActiveOps: boolean;
-		activeOpsSettings: ActiveOpsSettingsState;
-		saveActiveOpsSettings: AsyncAction;
-		savingActiveOps: boolean;
-	}>(() => import('./SettingsActiveOpsCard.svelte'));
-	const loadSettingsSafetyControlsCard = createLazyComponent<{
-		loadingSafety: boolean;
-		resettingSafety: boolean;
-		loadSafetyStatus: AsyncAction;
-		resetSafetyCircuitBreaker: AsyncAction;
-		safetyError: string;
-		safetySuccess: string;
-		safetyStatus: SafetyStatus | null;
-	}>(() => import('./SettingsSafetyControlsCard.svelte'));
-	const loadSettingsNotificationControls = createLazyComponent<SettingsNotificationControlsProps>(
-		() => import('./SettingsNotificationControls.svelte')
-	);
-	let advancedSettingsAnchor: HTMLDivElement | null = $state(null);
-	let advancedSettingsVisible = $state(false);
+	let deferredSectionAnchor: HTMLDivElement | null = $state(null);
+	let deferredSectionVisible = $state(false);
+	let deferredSectionNotified = $state(false);
 
 	onMount(() => {
 		if (import.meta.env.MODE === 'test' || typeof IntersectionObserver === 'undefined') {
-			advancedSettingsVisible = true;
+			deferredSectionVisible = true;
 			return;
 		}
 
 		const observer = new IntersectionObserver(
 			(entries) => {
 				if (entries.some((entry) => entry.isIntersecting)) {
-					advancedSettingsVisible = true;
+					deferredSectionVisible = true;
 					observer.disconnect();
 				}
 			},
-			{ rootMargin: '320px 0px' }
+			{ rootMargin: '280px 0px' }
 		);
 
-		if (advancedSettingsAnchor) {
-			observer.observe(advancedSettingsAnchor);
+		if (deferredSectionAnchor) {
+			observer.observe(deferredSectionAnchor);
 		}
 
 		return () => observer.disconnect();
+	});
+
+	$effect(() => {
+		if (!deferredSectionVisible || deferredSectionNotified) return;
+		deferredSectionNotified = true;
+		void onRevealDeferredSections();
 	});
 </script>
 
@@ -396,118 +380,33 @@
 				{/if}
 			</div>
 
-			{#await loadIdentitySettingsCard()}
-				<div class="card">
-					<div class="skeleton h-6 w-40 mb-4"></div>
-					<div class="skeleton h-4 w-full mb-2"></div>
-					<div class="skeleton h-4 w-3/4"></div>
-				</div>
-			{:then module}
-				{@const IdentitySettingsCard = module.default}
-				<IdentitySettingsCard
-					accessToken={data.session?.access_token}
-					tier={data.subscription?.tier}
-				/>
-			{:catch}
-				<div class="card">
-					<div class="skeleton h-6 w-40 mb-4"></div>
-					<div class="skeleton h-4 w-full mb-2"></div>
-					<div class="skeleton h-4 w-3/4"></div>
-				</div>
-			{/await}
-
-			{#await loadEnforcementSettingsCard()}
-				<div class="card">
-					<div class="skeleton h-6 w-48 mb-4"></div>
-					<div class="skeleton h-4 w-full mb-2"></div>
-					<div class="skeleton h-4 w-2/3"></div>
-				</div>
-			{:then module}
-				{@const EnforcementSettingsCard = module.default}
-				<EnforcementSettingsCard
-					accessToken={data.session?.access_token}
-					tier={data.subscription?.tier}
-				/>
-			{:catch}
-				<div class="card">
-					<div class="skeleton h-6 w-48 mb-4"></div>
-					<div class="skeleton h-4 w-full mb-2"></div>
-					<div class="skeleton h-4 w-2/3"></div>
-				</div>
-			{/await}
-
-			{#await loadEnforcementOpsCard()}
-				<div class="card">
-					<div class="skeleton h-6 w-48 mb-4"></div>
-					<div class="skeleton h-4 w-full mb-2"></div>
-					<div class="skeleton h-4 w-2/3"></div>
-				</div>
-			{:then module}
-				{@const EnforcementOpsCard = module.default}
-				<EnforcementOpsCard
-					accessToken={data.session?.access_token}
-					tier={data.subscription?.tier}
-				/>
-			{:catch}
-				<div class="card">
-					<div class="skeleton h-6 w-48 mb-4"></div>
-					<div class="skeleton h-4 w-full mb-2"></div>
-					<div class="skeleton h-4 w-2/3"></div>
-				</div>
-			{/await}
-
-			<div bind:this={advancedSettingsAnchor}>
-				{#if advancedSettingsVisible}
-					{#await loadSettingsAiStrategyCard()}
-						<div class="card">
-							<div class="skeleton h-6 w-48 mb-4"></div>
-							<div class="skeleton h-24 rounded-2xl"></div>
+			<div bind:this={deferredSectionAnchor}>
+				{#if deferredSectionVisible}
+					{#await loadSettingsDeferredSection()}
+						<div class="space-y-8">
+							<div class="card">
+								<div class="skeleton h-6 w-40 mb-4"></div>
+								<div class="skeleton h-4 w-full mb-2"></div>
+								<div class="skeleton h-4 w-3/4"></div>
+							</div>
+							<div class="card">
+								<div class="skeleton h-6 w-48 mb-4"></div>
+								<div class="skeleton h-24 rounded-2xl"></div>
+							</div>
 						</div>
 					{:then module}
-						{@const SettingsAiStrategyCard = module.default}
-						<SettingsAiStrategyCard
-							{loadingLLM}
+						{@const SettingsDeferredSection = module.default}
+						<SettingsDeferredSection
+							{data}
 							bind:llmSettings
+							{loadingLLM}
+							{savingLLM}
 							{providerModels}
 							{saveLLMSettings}
-							{savingLLM}
-						/>
-					{:catch}
-						<div class="card">
-							<div class="skeleton h-6 w-48 mb-4"></div>
-							<div class="skeleton h-24 rounded-2xl"></div>
-						</div>
-					{/await}
-
-					{#await loadSettingsActiveOpsCard()}
-						<div class="card">
-							<div class="skeleton h-6 w-48 mb-4"></div>
-							<div class="skeleton h-24 rounded-2xl"></div>
-						</div>
-					{:then module}
-						{@const SettingsActiveOpsCard = module.default}
-						<SettingsActiveOpsCard
-							{data}
-							{loadingActiveOps}
 							bind:activeOpsSettings
-							{saveActiveOpsSettings}
+							{loadingActiveOps}
 							{savingActiveOps}
-						/>
-					{:catch}
-						<div class="card">
-							<div class="skeleton h-6 w-48 mb-4"></div>
-							<div class="skeleton h-24 rounded-2xl"></div>
-						</div>
-					{/await}
-
-					{#await loadSettingsSafetyControlsCard()}
-						<div class="card">
-							<div class="skeleton h-6 w-56 mb-4"></div>
-							<div class="skeleton h-20 rounded-2xl"></div>
-						</div>
-					{:then module}
-						{@const SettingsSafetyControlsCard = module.default}
-						<SettingsSafetyControlsCard
+							{saveActiveOpsSettings}
 							{loadingSafety}
 							{resettingSafety}
 							{loadSafetyStatus}
@@ -515,24 +414,6 @@
 							{safetyError}
 							{safetySuccess}
 							{safetyStatus}
-						/>
-					{:catch}
-						<div class="card">
-							<div class="skeleton h-6 w-56 mb-4"></div>
-							<div class="skeleton h-20 rounded-2xl"></div>
-						</div>
-					{/await}
-
-					{#await loadSettingsNotificationControls()}
-						<div class="card">
-							<div class="skeleton h-6 w-52 mb-4"></div>
-							<div class="skeleton h-4 w-full mb-2"></div>
-							<div class="skeleton h-4 w-3/4"></div>
-						</div>
-					{:then module}
-						{@const SettingsNotificationControls = module.default}
-						<SettingsNotificationControls
-							{data}
 							bind:settings
 							{testing}
 							{testingJira}
@@ -549,10 +430,16 @@
 							{saving}
 						/>
 					{:catch}
-						<div class="card">
-							<div class="skeleton h-6 w-52 mb-4"></div>
-							<div class="skeleton h-4 w-full mb-2"></div>
-							<div class="skeleton h-4 w-3/4"></div>
+						<div class="space-y-8">
+							<div class="card">
+								<div class="skeleton h-6 w-40 mb-4"></div>
+								<div class="skeleton h-4 w-full mb-2"></div>
+								<div class="skeleton h-4 w-3/4"></div>
+							</div>
+							<div class="card">
+								<div class="skeleton h-6 w-48 mb-4"></div>
+								<div class="skeleton h-24 rounded-2xl"></div>
+							</div>
 						</div>
 					{/await}
 				{:else}

--- a/dashboard/src/routes/settings/SettingsPageViewContent.svelte
+++ b/dashboard/src/routes/settings/SettingsPageViewContent.svelte
@@ -20,8 +20,25 @@
 		buildNotificationSavePayload,
 		mergeLoadedNotificationSettings
 	} from './settingsNotificationState';
-	import SettingsPageViewBody from './SettingsPageViewBody.svelte';
 	import './SettingsPageViewContent.css';
+
+	function createModuleLoader<T>(loader: () => Promise<T>): () => Promise<T> {
+		let promise: Promise<T> | null = null;
+
+		return () => {
+			if (!promise) {
+				promise = loader().catch((error) => {
+					promise = null;
+					throw error;
+				});
+			}
+			return promise;
+		};
+	}
+
+	const loadSettingsPageViewBody = createModuleLoader(
+		() => import('./SettingsPageViewBody.svelte')
+	);
 
 	let { data } = $props();
 	const SETTINGS_REQUEST_TIMEOUT_MS = 8000;
@@ -58,6 +75,8 @@
 	let persona = $derived(String(data.profile?.persona ?? 'engineering'));
 	let savingPersona = $state(false);
 	let settingsSchemasPromise: Promise<typeof import('./settingsPageSchemas')> | null = null;
+	let deferredSettingsDataPromise: Promise<void> | null = null;
+	let deferredSettingsDataLoaded = $state(false);
 
 	const getHeaders = () => ({ Authorization: `Bearer ${data.session?.access_token}` });
 
@@ -387,18 +406,46 @@
 		}
 	}
 
+	async function ensureDeferredSettingsData(): Promise<void> {
+		if (deferredSettingsDataLoaded) {
+			return;
+		}
+
+		if (!data.user) {
+			loadingLLM = false;
+			loadingActiveOps = false;
+			loadingSafety = false;
+			deferredSettingsDataLoaded = true;
+			return;
+		}
+
+		if (!deferredSettingsDataPromise) {
+			deferredSettingsDataPromise = Promise.all([
+				loadModels(),
+				loadLLMSettings(),
+				loadSafetyStatus(),
+				['growth', 'pro', 'enterprise'].includes(data.subscription?.tier)
+					? loadActiveOpsSettings()
+					: Promise.resolve().then(() => {
+							loadingActiveOps = false;
+						})
+			])
+				.then(() => {
+					deferredSettingsDataLoaded = true;
+				})
+				.catch((error) => {
+					deferredSettingsDataPromise = null;
+					throw error;
+				});
+		}
+
+		return deferredSettingsDataPromise;
+	}
+
 	onMount(() => {
 		if (data.user) {
 			void loadSettings();
 			void loadCarbonSettings();
-			void loadModels();
-			void loadLLMSettings();
-			void loadSafetyStatus();
-			if (['growth', 'pro', 'enterprise'].includes(data.subscription?.tier)) {
-				void loadActiveOpsSettings();
-			} else {
-				loadingActiveOps = false;
-			}
 		} else {
 			loading = false;
 			loadingCarbon = false;
@@ -444,7 +491,8 @@
 		testWorkflowDispatch,
 		runPolicyDiagnostics,
 		saveSettings,
-		saving
+		saving,
+		onRevealDeferredSections: ensureDeferredSettingsData
 	});
 </script>
 
@@ -452,11 +500,21 @@
 	<title>Settings | Valdrics</title>
 </svelte:head>
 
-<SettingsPageViewBody
-	{...viewProps}
-	bind:persona
-	bind:carbonSettings
-	bind:llmSettings
-	bind:activeOpsSettings
-	bind:settings
-/>
+{#await loadSettingsPageViewBody()}
+	<div class="card">
+		<div class="skeleton h-8 w-48 mb-4"></div>
+		<div class="skeleton h-4 w-full mb-2"></div>
+		<div class="skeleton h-4 w-3/4 mb-6"></div>
+		<div class="skeleton h-64 rounded-2xl"></div>
+	</div>
+{:then module}
+	{@const SettingsPageViewBody = module.default}
+	<SettingsPageViewBody
+		{...viewProps}
+		bind:persona
+		bind:carbonSettings
+		bind:llmSettings
+		bind:activeOpsSettings
+		bind:settings
+	/>
+{/await}

--- a/dashboard/src/routes/settings/settings-page.advanced.svelte.test.ts
+++ b/dashboard/src/routes/settings/settings-page.advanced.svelte.test.ts
@@ -48,7 +48,9 @@ describe('settings page integration wiring (advanced)', () => {
 			);
 		});
 
-		await fireEvent.click(screen.getByRole('button', { name: /Save ActiveOps Settings/i }));
+		await fireEvent.click(
+			await screen.findByRole('button', { name: /Save ActiveOps Settings/i }, { timeout: 5000 })
+		);
 		await waitFor(() => {
 			expect(putMock).toHaveBeenCalledWith(
 				endpoint('/settings/activeops'),
@@ -110,7 +112,7 @@ describe('settings page integration wiring (advanced)', () => {
 		await screen.findByText('Slack integration missing');
 
 		await fireEvent.click(
-			screen.getByRole('button', { name: /Run policy notification diagnostics/i })
+			await screen.findByRole('button', { name: /Run policy notification diagnostics/i })
 		);
 		await waitFor(() => {
 			expect(getMock).toHaveBeenCalledWith(

--- a/dashboard/src/routes/settings/settings-page.core.svelte.test.ts
+++ b/dashboard/src/routes/settings/settings-page.core.svelte.test.ts
@@ -28,7 +28,7 @@ describe('settings page integration wiring (core)', () => {
 	it('loads settings modules via edge-proxy contract endpoints', async () => {
 		renderPage();
 
-		await screen.findByLabelText('Slack channel ID override');
+		await screen.findByLabelText('Slack channel ID override', {}, { timeout: 5000 });
 
 		await waitFor(() => {
 			expect(getMock).toHaveBeenCalledWith(

--- a/dashboard/src/routes/settings/settings.app.css
+++ b/dashboard/src/routes/settings/settings.app.css
@@ -8,4 +8,10 @@
 @source '.';
 @source '../../lib/components/EnforcementOpsCard.svelte';
 @source '../../lib/components/EnforcementSettingsCard.svelte';
+@source '../../lib/components/EnforcementSettingsCardView.svelte';
+@source '../../lib/components/EnforcementSettingsAdvancedSection.svelte';
 @source '../../lib/components/IdentitySettingsCard.svelte';
+@source '../../lib/components/IdentitySettingsCardContent.svelte';
+@source '../../lib/components/identity/IdentityDiagnosticsSection.svelte';
+@source '../../lib/components/identity/IdentityScimSection.svelte';
+@source '../../lib/components/identity/IdentitySsoSection.svelte';

--- a/docs/ops/all_changes_categorization_2026-04-01.md
+++ b/docs/ops/all_changes_categorization_2026-04-01.md
@@ -1,0 +1,197 @@
+# All Changes Categorization (2026-04-01)
+
+Snapshot:
+- Captured at: `2026-04-01T00:00:00Z`
+- Base commit: `b21f2ebdb5447f3b5d47b29f60616e657b9c29e1`
+- Pending paths: `148`
+- Branch at snapshot: `main`
+
+## Track CU: Backend Runtime, Billing, Scheduler, Safety, and Core Regression Coverage
+Scope:
+- Group backend runtime, billing, scheduler, optimization, circuit-breaker, retry, rate-limit, session, and safety-service changes together.
+- Keep the aligned integration, security, core, DB, governance, LLM, notifications, optimization, remediation, services, shared DB, and task regression suites in the same backend review lane.
+- Treat this as the backend runtime and correctness slice of the batch.
+
+Paths:
+- `app/main.py`
+- `app/modules/billing/domain/billing/paystack_client_impl.py`
+- `app/modules/governance/domain/scheduler/orchestrator.py`
+- `app/modules/governance/domain/scheduler/processors.py`
+- `app/modules/notifications/domain/slack.py`
+- `app/modules/optimization/domain/actions/aws/rds.py`
+- `app/modules/optimization/domain/remediation_execute.py`
+- `app/shared/core/celery_app.py`
+- `app/shared/core/circuit_breaker.py`
+- `app/shared/core/currency.py`
+- `app/shared/core/performance_benchmarking.py`
+- `app/shared/core/performance_testing.py`
+- `app/shared/core/pricing_cache.py`
+- `app/shared/core/rate_limit.py`
+- `app/shared/core/retry.py`
+- `app/shared/core/safety_service.py`
+- `app/shared/core/timeout.py`
+- `app/shared/db/session.py`
+- `app/shared/llm/circuit_breaker.py`
+- `app/shared/llm/hybrid_scheduler.py`
+- `app/shared/remediation/circuit_breaker.py`
+- `app/tasks/scheduler_sweep_ops.py`
+- `app/tasks/scheduler_sweep_runtime.py`
+- `app/tasks/scheduler_tasks.py`
+- `tests/integration/test_edge_cases.py`
+- `tests/security/test_rls_security.py`
+- `tests/unit/core/test_circuit_breaker_core.py`
+- `tests/unit/core/test_circuit_breaker_distributed.py`
+- `tests/unit/core/test_currency.py`
+- `tests/unit/core/test_currency_deep.py`
+- `tests/unit/core/test_db_session_deep.py`
+- `tests/unit/core/test_main.py`
+- `tests/unit/core/test_performance_testing.py`
+- `tests/unit/core/test_pricing_cache.py`
+- `tests/unit/core/test_rate_limit_expanded.py`
+- `tests/unit/core/test_retry_utils.py`
+- `tests/unit/core/test_safety_service_audit.py`
+- `tests/unit/core/test_session_audit.py`
+- `tests/unit/core/test_timeout_utils.py`
+- `tests/unit/db/test_session_deep.py`
+- `tests/unit/db/test_session_exhaustive.py`
+- `tests/unit/governance/scheduler/test_orchestrator_branches.py`
+- `tests/unit/llm/test_circuit_breaker.py`
+- `tests/unit/llm/test_hybrid_scheduler_exhaustive.py`
+- `tests/unit/notifications/domain/test_slack_service.py`
+- `tests/unit/optimization/test_remediation_branch_coverage.py`
+- `tests/unit/remediation/test_circuit_breaker_deep.py`
+- `tests/unit/services/billing/test_currency_service.py`
+- `tests/unit/services/billing/test_paystack_billing.py`
+- `tests/unit/services/scheduler/test_scheduler_processors.py`
+- `tests/unit/services/zombies/test_remediation_service.py`
+- `tests/unit/shared/db/test_session_coverage.py`
+- `tests/unit/tasks/test_scheduler_funnel_ops.py`
+- `tests/unit/tasks/test_scheduler_sweep_runtime.py`
+- `tests/unit/tasks/test_scheduler_tasks_branch_paths_2.py`
+- `tests/unit/tasks/test_scheduler_tasks_reliability.py`
+
+Notes:
+- This track contains all `app/` changes and the aligned backend test coverage excluding script-focused tests.
+
+## Track CV: Dashboard Landing, Content, Settings, and Public Route Surfaces
+Scope:
+- Consolidate landing hero, public content, docs or insights or proof or resources routes, settings surfaces, enforcement or identity cards, and dashboard UI sections together.
+- Keep the Svelte component tests, route tests, and page-server motion coverage with the exact dashboard and public surfaces they exercise.
+- Treat this as the frontend product-surface slice of the batch.
+
+Paths:
+- `dashboard/src/lib/components/EnforcementSettingsAdvancedSection.svelte`
+- `dashboard/src/lib/components/EnforcementSettingsCard.svelte`
+- `dashboard/src/lib/components/EnforcementSettingsCard.svelte.test.ts`
+- `dashboard/src/lib/components/EnforcementSettingsCardView.svelte`
+- `dashboard/src/lib/components/FindingsTable.svelte`
+- `dashboard/src/lib/components/FindingsTable.svelte.test.ts`
+- `dashboard/src/lib/components/FindingsTableDetailBody.svelte`
+- `dashboard/src/lib/components/IdentitySettingsCard.svelte`
+- `dashboard/src/lib/components/IdentitySettingsCard.svelte.test.ts`
+- `dashboard/src/lib/components/IdentitySettingsCardContent.svelte`
+- `dashboard/src/lib/components/LandingHero.svelte`
+- `dashboard/src/lib/components/LandingHero.svelte.test.ts`
+- `dashboard/src/lib/components/identity/IdentityDiagnosticsSection.svelte`
+- `dashboard/src/lib/components/identity/IdentityScimSection.svelte`
+- `dashboard/src/lib/components/landing/LandingCurrencyToggle.svelte`
+- `dashboard/src/lib/components/landing/LandingHeroBelowFold.svelte`
+- `dashboard/src/lib/components/landing/LandingHeroRoiPlaceholder.svelte`
+- `dashboard/src/lib/components/landing/LandingHeroTrustSections.svelte`
+- `dashboard/src/lib/components/landing/LandingHeroView.svelte`
+- `dashboard/src/lib/components/landing/LandingHeroView.svelte.test.ts`
+- `dashboard/src/lib/components/landing/landing_decomposition.svelte.test.ts`
+- `dashboard/src/lib/components/public/PublicContentArticlePage.svelte`
+- `dashboard/src/lib/components/public/PublicContentArticlePage.svelte.test.ts`
+- `dashboard/src/lib/components/public/PublicPageMeta.svelte`
+- `dashboard/src/lib/landing/currencyDisplay.ts`
+- `dashboard/src/lib/landing/currencyPreference.test.ts`
+- `dashboard/src/lib/landing/currencyPreference.ts`
+- `dashboard/src/lib/landing/geoCurrency.ts`
+- `dashboard/src/lib/landing/landingCurrencyPolicy.ts`
+- `dashboard/src/lib/landing/landingHeroScenario.ts`
+- `dashboard/src/lib/landing/landingRoiDefaults.ts`
+- `dashboard/src/lib/landing/roiCalculator.ts`
+- `dashboard/src/public.app.css`
+- `dashboard/src/routes/+page.server.ts`
+- `dashboard/src/routes/+page.svelte`
+- `dashboard/src/routes/api/geo/currency/+server.ts`
+- `dashboard/src/routes/docs/+page.server.ts`
+- `dashboard/src/routes/docs/+page.svelte`
+- `dashboard/src/routes/docs/[slug]/+page.server.ts`
+- `dashboard/src/routes/docs/[slug]/+page.svelte`
+- `dashboard/src/routes/docs/[slug]/+page.ts`
+- `dashboard/src/routes/docs/docs-page.svelte.test.ts`
+- `dashboard/src/routes/insights/+page.server.ts`
+- `dashboard/src/routes/insights/+page.svelte`
+- `dashboard/src/routes/insights/[slug]/+page.server.ts`
+- `dashboard/src/routes/insights/[slug]/+page.svelte`
+- `dashboard/src/routes/insights/[slug]/+page.ts`
+- `dashboard/src/routes/insights/insights-page.svelte.test.ts`
+- `dashboard/src/routes/layout-public-menu.svelte.test.ts`
+- `dashboard/src/routes/layout/PublicMobileMenuDialog.svelte`
+- `dashboard/src/routes/layout/PublicSiteFooter.svelte`
+- `dashboard/src/routes/layout/PublicSiteShell.svelte`
+- `dashboard/src/routes/onboarding/OnboardingPageView.svelte`
+- `dashboard/src/routes/onboarding/OnboardingPageViewContent.svelte`
+- `dashboard/src/routes/onboarding/onboarding-page.svelte.test.ts`
+- `dashboard/src/routes/ops/OpsOperationalHealthSection.svelte`
+- `dashboard/src/routes/ops/ops-page.core.svelte.test.ts`
+- `dashboard/src/routes/page.server.motion.test.ts`
+- `dashboard/src/routes/proof/+page.server.ts`
+- `dashboard/src/routes/proof/+page.svelte`
+- `dashboard/src/routes/proof/[slug]/+page.server.ts`
+- `dashboard/src/routes/proof/[slug]/+page.svelte`
+- `dashboard/src/routes/proof/[slug]/+page.ts`
+- `dashboard/src/routes/proof/proof-page.svelte.test.ts`
+- `dashboard/src/routes/resources/+page.server.ts`
+- `dashboard/src/routes/resources/+page.svelte`
+- `dashboard/src/routes/resources/[slug]/+page.server.ts`
+- `dashboard/src/routes/resources/[slug]/+page.svelte`
+- `dashboard/src/routes/resources/[slug]/+page.ts`
+- `dashboard/src/routes/resources/resources-page.svelte.test.ts`
+- `dashboard/src/routes/roi-planner/+page.server.ts`
+- `dashboard/src/routes/roi-planner/+page.svelte`
+- `dashboard/src/routes/roi-planner/page.server.test.ts`
+- `dashboard/src/routes/roi-planner/roi-planner-page.svelte.test.ts`
+- `dashboard/src/routes/settings/SettingsDeferredSection.svelte`
+- `dashboard/src/routes/settings/SettingsNotificationControls.svelte`
+- `dashboard/src/routes/settings/SettingsPageViewBody.svelte`
+- `dashboard/src/routes/settings/SettingsPageViewContent.svelte`
+- `dashboard/src/routes/settings/settings-page.advanced.svelte.test.ts`
+- `dashboard/src/routes/settings/settings-page.core.svelte.test.ts`
+- `dashboard/src/routes/settings/settings.app.css`
+
+Notes:
+- This track contains all `dashboard/` path changes in the batch.
+
+## Track CW: Operational Tooling, Frontend Hygiene, SCIM Smoke, and Exchange-Rate Utilities
+Scope:
+- Batch frontend-hygiene verification, API load testing, RLS optimization, SCIM smoke scripts, and exchange-rate utility changes together.
+- Keep the direct script-focused regression suites with the tooling they validate.
+- Treat this as the operational tooling and verification slice of the batch.
+
+Paths:
+- `scripts/check_frontend_hygiene.py`
+- `scripts/load_test_api.py`
+- `scripts/run_rls_optimization.py`
+- `scripts/smoke_test_scim_helpers.py`
+- `scripts/smoke_test_scim_idp.py`
+- `scripts/update_exchange_rates.py`
+- `tests/unit/core/test_load_test_api_script.py`
+- `tests/unit/core/test_smoke_test_scim_helpers.py`
+- `tests/unit/ops/test_check_frontend_hygiene.py`
+- `tests/unit/ops/test_legacy_db_maintenance_scripts.py`
+- `tests/unit/ops/test_smoke_test_scim_idp.py`
+
+Notes:
+- This track contains the script changes and their direct script-oriented tests.
+
+## Batching Decision
+Decision:
+- Merge as one consolidated PR to `main`.
+
+Reasoning:
+- The batch is one active runtime and frontend follow-up spanning backend scheduler and safety work, public-content and settings surfaces, and operational tooling updates together.
+- The issue split preserves review accountability without fragmenting the delivery batch across overlapping runtime, frontend, and tooling surfaces.
+- No clearly unwanted tracked docs or artifacts were found in this batch; ignored `__pycache__` files were cleaned outside the tracked diff.

--- a/scripts/check_frontend_hygiene.py
+++ b/scripts/check_frontend_hygiene.py
@@ -95,6 +95,19 @@ def _strip_style_blocks(source: str) -> str:
     return STYLE_BLOCK_PATTERN.sub("", source)
 
 
+def _allows_safe_json_ld_html_injection(source: str) -> bool:
+    # Svelte head JSON-LD needs raw script markup injection; require explicit
+    # JSON serialization plus script-breakout escaping before allowing it.
+    required_fragments = (
+        '{@html',
+        'type="application/ld+json"',
+        "JSON.stringify(",
+        "replaceAll('<', '\\\\u003c')",
+        "replaceAll('</script', '<\\\\/script')",
+    )
+    return all(fragment in source for fragment in required_fragments)
+
+
 def run(repo_root: Path) -> int:
     issues: list[Issue] = []
     svelte_config = repo_root / "dashboard" / "svelte.config.js"
@@ -157,7 +170,9 @@ def run(repo_root: Path) -> int:
                 )
             )
 
-        if HTML_INJECTION_PATTERN.search(source) and "DOMPurify.sanitize(" not in source:
+        if HTML_INJECTION_PATTERN.search(source) and not (
+            "DOMPurify.sanitize(" in source or _allows_safe_json_ld_html_injection(source)
+        ):
             issues.append(
                 Issue(
                     file_path=rel_path,

--- a/scripts/load_test_api.py
+++ b/scripts/load_test_api.py
@@ -20,6 +20,7 @@ import argparse
 import asyncio
 import json
 import os
+import time
 from typing import Any
 from datetime import date, timedelta
 from datetime import datetime, timezone
@@ -59,6 +60,10 @@ LOAD_TEST_PROBE_RECOVERABLE_EXCEPTIONS = (
     TypeError,
     ValueError,
 )
+
+
+def _perf_counter() -> float:
+    return time.perf_counter()
 
 
 def _parse_args() -> argparse.Namespace:
@@ -266,12 +271,12 @@ async def _run_preflight_checks(
         for endpoint in endpoints:
             passed = False
             for attempt in range(1, attempts + 1):
-                started = datetime.now(timezone.utc)
+                started = _perf_counter()
                 try:
                     response = await client.get(f"{target_url}{endpoint}")
                     latency_ms = max(
                         0.0,
-                        (datetime.now(timezone.utc) - started).total_seconds() * 1000.0,
+                        (_perf_counter() - started) * 1000.0,
                     )
                     status_code = int(response.status_code)
                     preview = str(response.text or "").replace("\n", " ")[:140]
@@ -292,7 +297,7 @@ async def _run_preflight_checks(
                 except LOAD_TEST_PROBE_RECOVERABLE_EXCEPTIONS as exc:
                     latency_ms = max(
                         0.0,
-                        (datetime.now(timezone.utc) - started).total_seconds() * 1000.0,
+                        (_perf_counter() - started) * 1000.0,
                     )
                     checks.append(
                         {

--- a/scripts/run_rls_optimization.py
+++ b/scripts/run_rls_optimization.py
@@ -11,6 +11,10 @@ def _repo_root() -> Path:
     return Path(__file__).resolve().parents[1]
 
 
+def _perf_counter() -> float:
+    return time.perf_counter()
+
+
 def _sql_script_path() -> Path:
     path = (_repo_root() / "scripts" / "optimize_performance_and_security.sql").resolve()
     if not path.exists():
@@ -22,7 +26,7 @@ def _sql_script_path() -> Path:
 
 async def run_optimization() -> int:
     print("⚡ Starting Database Performance & Security Hardening...")
-    start_total = time.time()
+    start_total = _perf_counter()
 
     sql = _sql_script_path().read_text(encoding="utf-8")
 
@@ -36,7 +40,7 @@ async def run_optimization() -> int:
             # We use the internal driver connection to support this directly
             await raw_conn.driver_connection.execute(sql)
 
-            print(f"🏁 Total hardening time: {time.time() - start_total:.2f}s")
+            print(f"🏁 Total hardening time: {_perf_counter() - start_total:.2f}s")
             print("✅ Database Performance & Security Hardening applied successfully!")
             return 0
     except (OSError, RuntimeError, TypeError, ValueError) as e:

--- a/scripts/smoke_test_scim_helpers.py
+++ b/scripts/smoke_test_scim_helpers.py
@@ -24,6 +24,10 @@ SCIM_SMOKE_RECOVERABLE_EXCEPTIONS = (
 )
 
 
+def _perf_counter() -> float:
+    return time.perf_counter()
+
+
 @dataclass(frozen=True)
 class Check:
     name: str
@@ -82,7 +86,7 @@ def record_check(
     ok: bool,
     detail: str | None = None,
 ) -> None:
-    duration_ms = (time.time() - started) * 1000.0
+    duration_ms = (_perf_counter() - started) * 1000.0
     status_code = resp.status_code if resp is not None else None
     checks.append(
         Check(

--- a/scripts/smoke_test_scim_idp.py
+++ b/scripts/smoke_test_scim_idp.py
@@ -51,6 +51,10 @@ from scripts.smoke_test_scim_helpers import (
 )
 
 
+def _perf_counter() -> float:
+    return time.perf_counter()
+
+
 def _repo_root() -> Path:
     return repo_root_for(__file__)
 
@@ -137,7 +141,7 @@ def main(argv: list[str] | None = None) -> int:
         raise SystemExit(str(exc)) from None
 
     started_at = _now_iso()
-    start_time = time.time()
+    start_time = _perf_counter()
 
     scim_base_url = _ensure_url(
         args.scim_base_url,
@@ -158,7 +162,7 @@ def main(argv: list[str] | None = None) -> int:
     timeout = httpx.Timeout(float(args.timeout))
     with httpx.Client(timeout=timeout, headers=scim_headers) as client:
         # 1) Discovery: ServiceProviderConfig
-        t0 = time.time()
+        t0 = _perf_counter()
         resp = None
         try:
             resp = client.get(_scim_url(scim_base_url, "/ServiceProviderConfig"))
@@ -182,7 +186,7 @@ def main(argv: list[str] | None = None) -> int:
             )
 
         # 2) Discovery: Schemas
-        t0 = time.time()
+        t0 = _perf_counter()
         resp = None
         try:
             resp = client.get(_scim_url(scim_base_url, "/Schemas"))
@@ -201,7 +205,7 @@ def main(argv: list[str] | None = None) -> int:
             )
 
         # 3) Discovery: ResourceTypes
-        t0 = time.time()
+        t0 = _perf_counter()
         resp = None
         try:
             resp = client.get(_scim_url(scim_base_url, "/ResourceTypes"))
@@ -226,7 +230,7 @@ def main(argv: list[str] | None = None) -> int:
 
         if args.write_mode:
             # 4) Create User
-            t0 = time.time()
+            t0 = _perf_counter()
             resp = None
             try:
                 resp = client.post(
@@ -260,7 +264,7 @@ def main(argv: list[str] | None = None) -> int:
                 )
 
             # 5) Create Group
-            t0 = time.time()
+            t0 = _perf_counter()
             resp = None
             try:
                 resp = client.post(
@@ -295,7 +299,7 @@ def main(argv: list[str] | None = None) -> int:
 
             # 6) Add Member
             if created_group_id and created_user_id:
-                t0 = time.time()
+                t0 = _perf_counter()
                 resp = None
                 try:
                     resp = client.patch(
@@ -334,7 +338,7 @@ def main(argv: list[str] | None = None) -> int:
             # Cleanup (default on, opt-out via --no-cleanup)
             if not args.no_cleanup:
                 if created_group_id:
-                    t0 = time.time()
+                    t0 = _perf_counter()
                     resp = None
                     try:
                         resp = client.delete(
@@ -359,7 +363,7 @@ def main(argv: list[str] | None = None) -> int:
                             detail=str(exc),
                         )
                 if created_user_id:
-                    t0 = time.time()
+                    t0 = _perf_counter()
                     resp = None
                     try:
                         resp = client.delete(
@@ -386,7 +390,7 @@ def main(argv: list[str] | None = None) -> int:
 
     passed = all(c.passed for c in checks)
     completed_at = _now_iso()
-    duration_seconds = round(time.time() - start_time, 3)
+    duration_seconds = round(_perf_counter() - start_time, 3)
 
     evidence_payload: dict[str, Any] = {
         "runner": "scripts/smoke_test_scim_idp.py",

--- a/scripts/update_exchange_rates.py
+++ b/scripts/update_exchange_rates.py
@@ -13,9 +13,6 @@ from app.shared.db.session import async_session_maker
 
 logger = structlog.get_logger()
 
-# Standardized BE-FIN-01: Automated Exchange Rate Management.
-settings = get_settings()
-
 
 def _default_currencies() -> set[str]:
     return set(get_settings().SUPPORTED_CURRENCIES)

--- a/tests/integration/test_edge_cases.py
+++ b/tests/integration/test_edge_cases.py
@@ -579,8 +579,9 @@ class TestMultiTenantEdgeCases:
     async def test_cross_tenant_data_leak_prevention(self):
         """Test prevention of cross-tenant data access."""
         # This would test the RLS enforcement listener
-        with patch("app.shared.db.session.settings") as mock_settings:
-            mock_settings.TESTING = False
+        mock_settings = MagicMock()
+        mock_settings.TESTING = False
+        with patch("app.shared.db.session.get_settings", return_value=mock_settings):
 
             # Mock connection without RLS context
             mock_conn = MagicMock()

--- a/tests/security/test_rls_security.py
+++ b/tests/security/test_rls_security.py
@@ -72,12 +72,12 @@ async def test_rls_listener_emits_log_on_missing_context():
 
     try:
         # Patch the logger to verify critical was called
+        mock_settings = MagicMock()
+        mock_settings.TESTING = False
         with (
             patch("app.shared.db.session.logger") as mock_logger,
-            patch("app.shared.db.session.settings") as mock_settings_obj,
+            patch("app.shared.db.session.get_settings", return_value=mock_settings),
         ):
-            mock_settings_obj.TESTING = False
-
             from app.shared.core.exceptions import ValdricsException
 
             # Executing a query with RLS FALSE should trigger the listener and RAISE

--- a/tests/unit/core/test_circuit_breaker_core.py
+++ b/tests/unit/core/test_circuit_breaker_core.py
@@ -154,3 +154,21 @@ def test_get_circuit_breaker_registry():
     assert b1 is b2
     all_status = get_all_circuit_breakers()
     assert "api" in all_status
+
+
+def test_get_circuit_breaker_registry_rebuilds_when_config_changes():
+    original = get_circuit_breaker(
+        "api", config=CircuitBreakerConfig(name="api", failure_threshold=2)
+    )
+    refreshed = get_circuit_breaker(
+        "api", config=CircuitBreakerConfig(name="api", failure_threshold=7)
+    )
+
+    assert refreshed is not original
+    assert refreshed.config.failure_threshold == 7
+
+
+def test_get_circuit_breaker_normalizes_config_name_to_registry_key():
+    breaker = get_circuit_breaker("api", config=CircuitBreakerConfig())
+
+    assert breaker.config.name == "api"

--- a/tests/unit/core/test_circuit_breaker_distributed.py
+++ b/tests/unit/core/test_circuit_breaker_distributed.py
@@ -97,9 +97,13 @@ async def test_persist_state_to_distributed_covers_open_closed_and_half_open() -
     with patch.object(breaker, "_get_redis_client", new=AsyncMock(return_value=redis)):
         # OPEN should set both state and failure key
         breaker.metrics.last_failure_time = None
-        with patch("app.shared.core.circuit_breaker.time.time", return_value=99.0):
+        with (
+            patch("app.shared.core.circuit_breaker.time.time", return_value=99.0),
+            patch("app.shared.core.circuit_breaker._monotonic_time", return_value=77.0),
+        ):
             await breaker._persist_state_to_distributed(CircuitState.OPEN)
         assert breaker.metrics.last_failure_time == 99.0
+        assert breaker.metrics.last_failure_monotonic == 77.0
 
         # CLOSED should delete failure/probe keys
         await breaker._persist_state_to_distributed(CircuitState.CLOSED)
@@ -151,11 +155,42 @@ async def test_should_attempt_reset_logic() -> None:
     breaker.metrics.last_failure_time = None
     assert await breaker._should_attempt_reset() is True
 
+    breaker.metrics.last_failure_monotonic = 100.0
+    with patch("app.shared.core.circuit_breaker._monotonic_time", return_value=120.0):
+        assert await breaker._should_attempt_reset() is False
+    with patch("app.shared.core.circuit_breaker._monotonic_time", return_value=131.0):
+        assert await breaker._should_attempt_reset() is True
+
+    breaker.metrics.last_failure_monotonic = None
     breaker.metrics.last_failure_time = 100.0
     with patch("app.shared.core.circuit_breaker.time.time", return_value=120.0):
         assert await breaker._should_attempt_reset() is False
     with patch("app.shared.core.circuit_breaker.time.time", return_value=131.0):
         assert await breaker._should_attempt_reset() is True
+
+
+@pytest.mark.asyncio
+async def test_record_failure_and_success_capture_monotonic_markers() -> None:
+    breaker = _breaker()
+
+    with (
+        patch("app.shared.core.circuit_breaker.time.time", return_value=200.0),
+        patch("app.shared.core.circuit_breaker._monotonic_time", return_value=50.0),
+    ):
+        await breaker._record_failure(RuntimeError("boom"))
+
+    assert breaker.metrics.last_failure_time == 200.0
+    assert breaker.metrics.last_failure_monotonic == 50.0
+
+    breaker.state = CircuitState.HALF_OPEN
+    with (
+        patch("app.shared.core.circuit_breaker.time.time", return_value=300.0),
+        patch("app.shared.core.circuit_breaker._monotonic_time", return_value=75.0),
+    ):
+        await breaker._record_success()
+
+    assert breaker.metrics.last_success_time == 300.0
+    assert breaker.metrics.last_success_monotonic == 75.0
 
 
 @pytest.mark.asyncio

--- a/tests/unit/core/test_currency.py
+++ b/tests/unit/core/test_currency.py
@@ -15,7 +15,7 @@ from app.shared.core.currency import (
 @pytest.fixture(autouse=True)
 def clear_cache():
     _RATES_CACHE.clear()
-    _RATES_CACHE["USD"] = (Decimal("1.0"), time.time(), "internal")
+    _RATES_CACHE["USD"] = (Decimal("1.0"), time.monotonic(), "internal")
     with patch("app.shared.core.cache.get_cache_service") as mock_cache_cls:
         mock_cache_cls.return_value.enabled = False
         yield

--- a/tests/unit/core/test_currency_deep.py
+++ b/tests/unit/core/test_currency_deep.py
@@ -19,7 +19,7 @@ from app.shared.core.currency import (
 @pytest.fixture(autouse=True)
 def clear_cache():
     _RATES_CACHE.clear()
-    _RATES_CACHE["USD"] = (Decimal("1.0"), time.time(), "internal")
+    _RATES_CACHE["USD"] = (Decimal("1.0"), time.monotonic(), "internal")
     with patch("app.shared.core.cache.get_cache_service") as mock_cache_cls:
         mock_cache_cls.return_value.enabled = False
         yield
@@ -46,7 +46,7 @@ class TestCurrencyDeep:
 
     @pytest.mark.asyncio
     async def test_fetch_public_rates_failure_falls_back_to_l1(self):
-        _RATES_CACHE["EUR"] = (Decimal("0.91"), time.time(), "internal")
+        _RATES_CACHE["EUR"] = (Decimal("0.91"), time.monotonic(), "internal")
 
         @asynccontextmanager
         async def broken_scope(self):
@@ -75,9 +75,47 @@ class TestCurrencyDeep:
 
     @pytest.mark.asyncio
     async def test_get_exchange_rate_cached_l1(self):
-        _RATES_CACHE["EUR"] = (Decimal("0.90"), time.time(), "internal")
+        _RATES_CACHE["EUR"] = (Decimal("0.90"), time.monotonic(), "internal")
         rate = await get_exchange_rate("EUR")
         assert rate == Decimal("0.90")
+
+    @pytest.mark.asyncio
+    async def test_get_exchange_rate_l1_uses_monotonic_time_not_wall_clock(self):
+        service = ExchangeRateService()
+        _RATES_CACHE["EUR"] = (Decimal("0.90"), 1_000.0, "internal")
+
+        with (
+            patch("app.shared.core.currency.time.monotonic", return_value=1_400.5),
+            patch("app.shared.core.currency.time.time", return_value=500.0),
+            patch.object(
+                service,
+                "_read_redis_rate",
+                new=AsyncMock(return_value=(None, None, None)),
+            ),
+            patch.object(
+                service,
+                "_read_db_rate",
+                new=AsyncMock(return_value=(None, None, None)),
+            ),
+            patch.object(
+                service,
+                "_fetch_live_rate",
+                new=AsyncMock(return_value=(Decimal("1.23"), "cbn_nfem")),
+            ),
+            patch.object(
+                service,
+                "_write_redis_rate",
+                new=AsyncMock(return_value=None),
+            ),
+            patch.object(
+                service,
+                "_upsert_db_rate",
+                new=AsyncMock(return_value=None),
+            ),
+        ):
+            rate = await service.get_rate("EUR")
+
+        assert rate == Decimal("1.23")
 
     @pytest.mark.asyncio
     async def test_get_exchange_rate_redis_hit(self):

--- a/tests/unit/core/test_db_session_deep.py
+++ b/tests/unit/core/test_db_session_deep.py
@@ -108,10 +108,11 @@ class TestDBSessionDeep:
 
         conn = MagicMock()
         conn.info = {"rls_context_set": False}  # Context explicitly missing
+        mock_settings = MagicMock()
+        mock_settings.TESTING = False
 
         # Temporarily disable TESTING mode for this test
-        with patch("app.shared.db.session.settings") as mock_settings:
-            mock_settings.TESTING = False
+        with patch("app.shared.db.session.get_settings", return_value=mock_settings):
             with pytest.raises(ValdricsException) as exc:
                 check_rls_policy(
                     conn, None, "SELECT * FROM secret_data", None, None, None
@@ -122,9 +123,10 @@ class TestDBSessionDeep:
         """Test RLS policy listener allows exempt tables."""
         conn = MagicMock()
         conn.info = {"rls_context_set": False}
+        mock_settings = MagicMock()
+        mock_settings.TESTING = False
 
-        with patch("app.shared.db.session.settings") as mock_settings:
-            mock_settings.TESTING = False
+        with patch("app.shared.db.session.get_settings", return_value=mock_settings):
             # 'users' is exempt (imported from constants)
             stmt, params = check_rls_policy(
                 conn, None, "SELECT * FROM users", None, None, None
@@ -135,8 +137,9 @@ class TestDBSessionDeep:
         """Test RLS policy listener allows system queries."""
         conn = MagicMock()
         conn.info = {"rls_context_set": False}
-        with patch("app.shared.db.session.settings") as mock_settings:
-            mock_settings.TESTING = False
+        mock_settings = MagicMock()
+        mock_settings.TESTING = False
+        with patch("app.shared.db.session.get_settings", return_value=mock_settings):
             stmt, _ = check_rls_policy(conn, None, "SELECT 1", None, None, None)
             assert stmt == "SELECT 1"
 

--- a/tests/unit/core/test_load_test_api_script.py
+++ b/tests/unit/core/test_load_test_api_script.py
@@ -172,6 +172,44 @@ async def test_run_preflight_checks_failure_with_retry(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_run_preflight_checks_uses_perf_counter_for_latency(monkeypatch):
+    class DummyResponse:
+        status_code = 200
+        text = "ok"
+
+    class SuccessfulClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def get(self, url):
+            return DummyResponse()
+
+    perf_values = iter([10.0, 10.125])
+
+    class _PinnedDatetime:
+        @staticmethod
+        def now(_tz=None):
+            return "pinned-wall-clock"
+
+    monkeypatch.setattr(load_test_api.httpx, "AsyncClient", lambda *a, **k: SuccessfulClient())
+    monkeypatch.setattr(load_test_api, "_perf_counter", lambda: next(perf_values))
+    monkeypatch.setattr(load_test_api, "datetime", _PinnedDatetime)
+
+    result = await load_test_api._run_preflight_checks(
+        target_url="http://127.0.0.1:8000",
+        endpoints=["/health/live"],
+        headers={},
+        timeout_seconds=2.0,
+        attempts=1,
+    )
+
+    assert result["checks"][0]["latency_ms"] == 125.0
+
+
+@pytest.mark.asyncio
 async def test_collect_runtime_snapshot_extracts_database_engine(monkeypatch):
     class DummyResponse:
         status_code = 200

--- a/tests/unit/core/test_main.py
+++ b/tests/unit/core/test_main.py
@@ -120,21 +120,23 @@ def test_refresh_fastapi_app_metadata_updates_title_version_and_openapi_cache():
     original_version = valdrics_app.version
     original_openapi_schema = valdrics_app.openapi_schema
     original_tracker = main_module.EmissionsTracker
+    original_settings = main_module.settings
     try:
         valdrics_app.openapi_schema = {"cached": True}
+        refreshed_settings = MagicMock(APP_NAME="Valdrics Reloaded", VERSION="9.9.9")
 
-        refresh_fastapi_app_metadata(
-            MagicMock(APP_NAME="Valdrics Reloaded", VERSION="9.9.9")
-        )
+        refresh_fastapi_app_metadata(refreshed_settings)
 
         assert valdrics_app.title == "Valdrics Reloaded"
         assert valdrics_app.version == "9.9.9"
         assert valdrics_app.openapi_schema is None
+        assert main_module.settings is refreshed_settings
     finally:
         valdrics_app.title = original_title
         valdrics_app.version = original_version
         valdrics_app.openapi_schema = original_openapi_schema
         main_module.EmissionsTracker = original_tracker
+        main_module.settings = original_settings
 
 
 def test_refresh_fastapi_app_metadata_refreshes_emissions_tracker():

--- a/tests/unit/core/test_performance_testing.py
+++ b/tests/unit/core/test_performance_testing.py
@@ -120,7 +120,7 @@ async def test_simulate_user_records_failure_and_exception(monkeypatch):
 
     monkeypatch.setattr(LoadTester, "_sleep", fake_sleep)
 
-    await tester._simulate_user(0, test_start_time=time.time())
+    await tester._simulate_user(0, test_start_time=time.monotonic())
 
     assert tester.results.failed_requests == 1
     assert tester.results.errors
@@ -140,7 +140,7 @@ async def test_simulate_user_records_failure_and_exception(monkeypatch):
         "app.shared.core.http.get_http_client",
         lambda: ExplodingClient(),
     )
-    await tester2._simulate_user(0, test_start_time=time.time())
+    await tester2._simulate_user(0, test_start_time=time.monotonic())
 
     assert tester2.results.failed_requests == 1
     assert "network down" in tester2.results.errors[0]
@@ -203,7 +203,7 @@ async def test_simulate_user_records_metrics(monkeypatch):
         ) as mock_duration,
         patch("app.shared.core.performance_testing.API_ERRORS_TOTAL") as mock_errors,
     ):
-        await tester._simulate_user(0, test_start_time=time.time())
+        await tester._simulate_user(0, test_start_time=time.monotonic())
 
         mock_requests.labels.assert_any_call(
             method="GET", endpoint="/ok", status_code=200
@@ -262,7 +262,7 @@ async def test_simulate_user_records_exception_metrics(monkeypatch):
         ) as mock_duration,
         patch("app.shared.core.performance_testing.API_ERRORS_TOTAL") as mock_errors,
     ):
-        await tester._simulate_user(0, test_start_time=time.time())
+        await tester._simulate_user(0, test_start_time=time.monotonic())
 
         mock_requests.labels.assert_called_once_with(
             method="GET", endpoint="/boom", status_code="exception"
@@ -317,7 +317,7 @@ async def test_simulate_user_forwards_configured_headers(monkeypatch):
 
     monkeypatch.setattr(LoadTester, "_sleep", fake_sleep)
 
-    await tester._simulate_user(0, test_start_time=time.time())
+    await tester._simulate_user(0, test_start_time=time.monotonic())
 
     assert tester.results.successful_requests == 1
     assert captured_headers.get("Authorization") == "Bearer token-123"
@@ -337,6 +337,24 @@ async def test_performance_benchmark_async():
     assert benchmark.results[-1] is result
 
 
+@pytest.mark.asyncio
+async def test_performance_benchmark_async_uses_perf_counter_for_total_duration():
+    benchmark = PerformanceBenchmark("unit")
+
+    async def noop():
+        return None
+
+    with (
+        patch(
+            "app.shared.core.performance_benchmarking._perf_counter",
+            side_effect=[10.0, 10.1, 10.3, 10.5],
+        ),
+    ):
+        result = await benchmark.benchmark_async(noop, iterations=1, warmup_iterations=0)
+
+    assert result.total_time == pytest.approx(0.5)
+
+
 def test_performance_benchmark_sync():
     benchmark = PerformanceBenchmark("unit")
 
@@ -348,6 +366,47 @@ def test_performance_benchmark_sync():
     assert result.name == "unit_noop"
     assert result.iterations == 3
     assert benchmark.results[-1] is result
+
+
+def test_performance_benchmark_sync_uses_perf_counter_for_total_duration():
+    benchmark = PerformanceBenchmark("unit")
+
+    def noop():
+        return None
+
+    with (
+        patch(
+            "app.shared.core.performance_benchmarking._perf_counter",
+            side_effect=[20.0, 20.1, 20.3, 20.5],
+        ),
+    ):
+        result = benchmark.benchmark_sync(noop, iterations=1, warmup_iterations=0)
+
+    assert result.total_time == pytest.approx(0.5)
+
+
+@pytest.mark.asyncio
+async def test_run_load_test_uses_monotonic_for_total_duration(monkeypatch):
+    async def fake_simulate_user(self, user_id, test_start_time):
+        self.results.total_requests += 1
+        self.results.successful_requests += 1
+        self.results.total_response_time += 0.1
+        self.results.response_times.append(0.1)
+        self.results.min_response_time = min(self.results.min_response_time, 0.1)
+        self.results.max_response_time = max(self.results.max_response_time, 0.1)
+
+    monkeypatch.setattr(LoadTester, "_simulate_user", fake_simulate_user)
+
+    tester = LoadTester(LoadTestConfig(duration_seconds=1, concurrent_users=1, ramp_up_seconds=0))
+
+    with patch(
+        "app.shared.core.performance_testing._monotonic_time",
+        side_effect=[100.0, 100.5],
+    ):
+        result = await tester.run_load_test()
+
+    assert result.total_requests == 1
+    assert result.throughput_rps == pytest.approx(2.0)
 
 
 def test_performance_regression_detector_detects(tmp_path):
@@ -512,6 +571,7 @@ async def test_benchmark_cache_operations_uses_cache():
 
     async def fake_benchmark_async(self, func, *args, **kwargs):
         await func()
+        await func()
         return BenchmarkResult(name="cache_operations_cache_set_get")
 
     with (
@@ -525,8 +585,13 @@ async def test_benchmark_cache_operations_uses_cache():
 
         result = await benchmark_cache_operations()
         assert result.name == "cache_operations_cache_set_get"
-        cache.set.assert_called_once()
-        cache.get.assert_called_once()
+        assert cache.set.await_count == 2
+        assert cache.get.await_count == 2
+        first_key = cache.set.await_args_list[0].args[0]
+        second_key = cache.set.await_args_list[1].args[0]
+        assert first_key.startswith("benchmark_")
+        assert second_key.startswith("benchmark_")
+        assert first_key != second_key
 
 
 @pytest.mark.asyncio

--- a/tests/unit/core/test_pricing_cache.py
+++ b/tests/unit/core/test_pricing_cache.py
@@ -1,0 +1,60 @@
+from app.shared.core.pricing_cache import (
+    PricingTier,
+    _TENANT_TIER_CACHE_MAX_ENTRIES,
+    _tenant_tier_runtime_cache,
+    clear_tenant_tier_cache,
+    runtime_cache_get,
+    runtime_cache_set,
+)
+
+
+def setup_function() -> None:
+    clear_tenant_tier_cache()
+
+
+def teardown_function() -> None:
+    clear_tenant_tier_cache()
+
+
+def test_runtime_cache_set_evicts_oldest_cached_timestamp_not_insertion_order() -> None:
+    now = 10_000.0
+    step = 0.001
+
+    for index in range(_TENANT_TIER_CACHE_MAX_ENTRIES):
+        runtime_cache_set(
+            f"tenant-{index}",
+            PricingTier.FREE,
+            now=now + (float(index) * step),
+        )
+
+    # Refresh the first inserted key so it becomes the newest by timestamp while
+    # retaining its original dict insertion position.
+    runtime_cache_set("tenant-0", PricingTier.PRO, now=now + 50.0)
+
+    runtime_cache_set(
+        "tenant-overflow",
+        PricingTier.ENTERPRISE,
+        now=now + 55.0,
+    )
+
+    assert runtime_cache_get("tenant-0", now=now + 55.0) == PricingTier.PRO
+    assert runtime_cache_get("tenant-overflow", now=now + 55.0) == PricingTier.ENTERPRISE
+    assert runtime_cache_get("tenant-1", now=now + 55.0) is None
+
+
+def test_runtime_cache_set_prunes_expired_entries_before_oldest_eviction() -> None:
+    for index in range(_TENANT_TIER_CACHE_MAX_ENTRIES):
+        runtime_cache_set(
+            f"tenant-{index}",
+            PricingTier.STARTER,
+            now=float(index),
+        )
+
+    runtime_cache_set(
+        "tenant-overflow",
+        PricingTier.GROWTH,
+        now=120.0,
+    )
+
+    assert runtime_cache_get("tenant-overflow", now=120.0) == PricingTier.GROWTH
+    assert "tenant-0" not in _tenant_tier_runtime_cache

--- a/tests/unit/core/test_rate_limit_expanded.py
+++ b/tests/unit/core/test_rate_limit_expanded.py
@@ -131,14 +131,31 @@ async def test_check_remediation_rate_limit_memory_reset():
     action = "reset_action"
 
     with patch("app.shared.core.rate_limit.get_redis_client", return_value=None):
-        # Initial call
-        await check_remediation_rate_limit(tenant_id, action, limit=1)
-
-        # Mock time to be 2 hours later
-        future_time = time.time() + 7200
-        with patch("time.time", return_value=future_time):
+        with patch(
+            "app.shared.core.rate_limit._monotonic_time",
+            side_effect=[100.0, 100.0 + 7200.0],
+        ):
+            # Initial call
+            await check_remediation_rate_limit(tenant_id, action, limit=1)
             allowed = await check_remediation_rate_limit(tenant_id, action, limit=1)
             assert allowed is True
+
+
+@pytest.mark.asyncio
+async def test_check_remediation_rate_limit_memory_uses_monotonic_window() -> None:
+    tenant_id = "monotonic-tenant"
+    action = "monotonic-action"
+
+    with (
+        patch("app.shared.core.rate_limit.get_redis_client", return_value=None),
+        patch(
+            "app.shared.core.rate_limit._monotonic_time",
+            side_effect=[500.0, 500.0 + 3601.0],
+        ),
+        patch("app.shared.core.rate_limit.time.time", return_value=1.0),
+    ):
+        assert await check_remediation_rate_limit(tenant_id, action, limit=1) is True
+        assert await check_remediation_rate_limit(tenant_id, action, limit=1) is True
 
 
 def test_get_limiter_initialization():

--- a/tests/unit/core/test_retry_utils.py
+++ b/tests/unit/core/test_retry_utils.py
@@ -51,6 +51,10 @@ async def test_execute_with_retry_raises_after_exhaustion():
 
 def test_calculate_backoff_clamped_and_deterministic():
     manager = RetryManager("database")
+    original_min_wait = RETRY_CONFIGS["database"]["min_wait"]
+    original_max_wait = RETRY_CONFIGS["database"]["max_wait"]
+    original_multiplier = RETRY_CONFIGS["database"]["multiplier"]
+
     manager.config["min_wait"] = 0.1
     manager.config["max_wait"] = 0.2
     manager.config["multiplier"] = 2.0
@@ -58,6 +62,10 @@ def test_calculate_backoff_clamped_and_deterministic():
     with patch("app.shared.core.retry._JITTER_RNG.random", return_value=0.5):
         assert manager._calculate_backoff(0) == 0.1
         assert manager._calculate_backoff(10) == 0.2
+
+    assert RETRY_CONFIGS["database"]["min_wait"] == original_min_wait
+    assert RETRY_CONFIGS["database"]["max_wait"] == original_max_wait
+    assert RETRY_CONFIGS["database"]["multiplier"] == original_multiplier
 
 
 @pytest.mark.asyncio

--- a/tests/unit/core/test_safety_service_audit.py
+++ b/tests/unit/core/test_safety_service_audit.py
@@ -21,47 +21,88 @@ def service(mock_db):
 @pytest.mark.asyncio
 async def test_global_kill_switch_triggered(service, mock_db):
     tenant_id = uuid4()
-    # Mock settings threshold
-    service._settings.REMEDIATION_KILL_SWITCH_THRESHOLD = 500.0
-    service._settings.REMEDIATION_KILL_SWITCH_SCOPE = "tenant"
+    runtime_settings = MagicMock(
+        REMEDIATION_KILL_SWITCH_THRESHOLD=500.0,
+        REMEDIATION_KILL_SWITCH_SCOPE="tenant",
+    )
 
     # Mock DB result: already $450 saved today, impact is $60
     mock_result = MagicMock()
     mock_result.scalar.return_value = Decimal("450.0")
     mock_db.execute.return_value = mock_result
 
-    with pytest.raises(KillSwitchTriggeredError, match="Safety kill-switch triggered"):
+    with (
+        patch.object(service, "_get_settings", return_value=runtime_settings),
+        pytest.raises(KillSwitchTriggeredError, match="Safety kill-switch triggered"),
+    ):
         await service._check_global_kill_switch(tenant_id, Decimal("60.0"))
 
 
 @pytest.mark.asyncio
 async def test_global_kill_switch_allowed(service, mock_db):
     tenant_id = uuid4()
-    service._settings.REMEDIATION_KILL_SWITCH_THRESHOLD = 500.0
-    service._settings.REMEDIATION_KILL_SWITCH_SCOPE = "tenant"
+    runtime_settings = MagicMock(
+        REMEDIATION_KILL_SWITCH_THRESHOLD=500.0,
+        REMEDIATION_KILL_SWITCH_SCOPE="tenant",
+    )
 
     mock_result = MagicMock()
     mock_result.scalar.return_value = Decimal("400.0")
     mock_db.execute.return_value = mock_result
 
     # Impact $50, total $450 < $500
-    await service._check_global_kill_switch(tenant_id, Decimal("50.0"))
+    with patch.object(service, "_get_settings", return_value=runtime_settings):
+        await service._check_global_kill_switch(tenant_id, Decimal("50.0"))
 
 
 @pytest.mark.asyncio
 async def test_global_kill_switch_invalid_scope_falls_back_to_tenant(service, mock_db):
     tenant_id = uuid4()
-    service._settings.REMEDIATION_KILL_SWITCH_THRESHOLD = 500.0
-    service._settings.REMEDIATION_KILL_SWITCH_SCOPE = "invalid_scope"
+    runtime_settings = MagicMock(
+        REMEDIATION_KILL_SWITCH_THRESHOLD=500.0,
+        REMEDIATION_KILL_SWITCH_SCOPE="invalid_scope",
+    )
 
     mock_result = MagicMock()
     mock_result.scalar.return_value = Decimal("400.0")
     mock_db.execute.return_value = mock_result
 
-    await service._check_global_kill_switch(tenant_id, Decimal("50.0"))
+    with patch.object(service, "_get_settings", return_value=runtime_settings):
+        await service._check_global_kill_switch(tenant_id, Decimal("50.0"))
     stmt = mock_db.execute.await_args.args[0]
     where_text = str(stmt)
     assert "remediation_requests.tenant_id" in where_text
+
+
+@pytest.mark.asyncio
+async def test_global_kill_switch_reads_live_settings_after_service_construction(
+    service, mock_db
+):
+    tenant_id = uuid4()
+    stale_settings = MagicMock(
+        REMEDIATION_KILL_SWITCH_THRESHOLD=500.0,
+        REMEDIATION_KILL_SWITCH_SCOPE="tenant",
+    )
+    refreshed_settings = MagicMock(
+        REMEDIATION_KILL_SWITCH_THRESHOLD=200.0,
+        REMEDIATION_KILL_SWITCH_SCOPE="global",
+    )
+
+    mock_result = MagicMock()
+    mock_result.scalar.return_value = Decimal("150.0")
+    mock_db.execute.return_value = mock_result
+
+    with patch.object(
+        service,
+        "_get_settings",
+        side_effect=[stale_settings, refreshed_settings],
+    ):
+        await service._check_global_kill_switch(tenant_id, Decimal("25.0"))
+        with pytest.raises(KillSwitchTriggeredError, match="Safety kill-switch triggered"):
+            await service._check_global_kill_switch(tenant_id, Decimal("60.0"))
+
+    stmt = mock_db.execute.await_args_list[-1].args[0]
+    assert "remediation_requests.tenant_id" not in str(stmt)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/core/test_session_audit.py
+++ b/tests/unit/core/test_session_audit.py
@@ -92,9 +92,10 @@ def test_slow_query_logging():
 def test_rls_policy_enforcement_metric_increment():
     """Verify RLS violation increments prometheus metrics."""
     conn = MagicMock()
-    with patch("app.shared.db.session.settings") as mock_settings:
+    mock_settings = MagicMock()
+    mock_settings.TESTING = False
+    with patch("app.shared.db.session.get_settings", return_value=mock_settings):
         with patch("app.shared.db.session.RLS_CONTEXT_MISSING") as mock_metric:
-            mock_settings.TESTING = False
             conn.info = {"rls_context_set": False}
 
             with pytest.raises(ValdricsException):
@@ -106,41 +107,36 @@ def test_rls_policy_enforcement_metric_increment():
 
 def test_db_ssl_verify_ca_config():
     """Verify SSL context is set when verify-ca mode is used."""
-    with patch("app.shared.db.session.settings") as mock_s:
-        mock_s.DB_SSL_MODE = "verify-ca"
-        mock_s.DB_SSL_CA_CERT_PATH = "/tmp/ca.crt"
-        mock_s.DATABASE_URL = "postgresql://x"
+    mock_s = MagicMock()
+    mock_s.DB_SSL_MODE = "verify-ca"
+    mock_s.DB_SSL_CA_CERT_PATH = "/tmp/ca.crt"
+    mock_s.DATABASE_URL = "postgresql://x"
 
-        with patch("ssl.create_default_context") as mock_ssl:
-            # We need to trigger the top-level logic or a helper if we refactor
-            # Since it's top-level, we might just test the logic manually for now
-            # simulating the assignment.
-            ssl_mode = mock_s.DB_SSL_MODE.lower()
-            if ssl_mode == "verify-ca":
-                ctx = mock_ssl(cafile=mock_s.DB_SSL_CA_CERT_PATH)
-                assert ctx is not None
-                mock_ssl.assert_called_with(cafile="/tmp/ca.crt")
+    with patch("ssl.create_default_context") as mock_ssl:
+        ssl_mode = mock_s.DB_SSL_MODE.lower()
+        if ssl_mode == "verify-ca":
+            ctx = mock_ssl(cafile=mock_s.DB_SSL_CA_CERT_PATH)
+            assert ctx is not None
+            mock_ssl.assert_called_with(cafile="/tmp/ca.crt")
 
 
 def test_startup_missing_db_url():
     """Verify application exits if DATABASE_URL is missing."""
-    with patch("app.shared.db.session.settings") as mock_settings:
-        mock_settings.DATABASE_URL = None
-        with patch("sys.exit") as mock_exit:
-            # We need to trigger the code at the top of session.py
-            # Since it's already imported, we might need to use a cleaner approach
-            # but for a unit test of the logic:
-            if not mock_settings.DATABASE_URL:
-                mock_exit(1)
-            mock_exit.assert_called_with(1)
+    mock_settings = MagicMock()
+    mock_settings.DATABASE_URL = None
+    with patch("sys.exit") as mock_exit:
+        if not mock_settings.DATABASE_URL:
+            mock_exit(1)
+        mock_exit.assert_called_with(1)
 
 
 def test_rls_policy_enforcement_violation():
     """Verify that RLS enforcement raises an exception when context is missing."""
     conn = MagicMock()
     # Simulate non-testing environment where RLS is enforced
-    with patch("app.shared.db.session.settings") as mock_settings:
-        mock_settings.TESTING = False
+    mock_settings = MagicMock()
+    mock_settings.TESTING = False
+    with patch("app.shared.db.session.get_settings", return_value=mock_settings):
 
         # 1. RLS Status is False (explicitly missing context)
         conn.info = {"rls_context_set": False}
@@ -184,8 +180,9 @@ async def test_get_db_postgresql_rls_set_failed():
 def test_rls_policy_bypass_more():
     """Verify more bypass conditions for RLS."""
     conn = MagicMock()
-    with patch("app.shared.db.session.settings") as mock_settings:
-        mock_settings.TESTING = False
+    mock_settings = MagicMock()
+    mock_settings.TESTING = False
+    with patch("app.shared.db.session.get_settings", return_value=mock_settings):
         conn.info = {"rls_context_set": False}
 
         # Test bypass for 'from users'
@@ -208,16 +205,15 @@ def test_db_ssl_modes_logic():
 
     # Mode: verify-full
     with patch("ssl.create_default_context") as mock_ssl:
-        with patch("app.shared.db.session.settings") as mock_s:
-            mock_s.DB_SSL_MODE = "verify-full"
-            mock_s.DB_SSL_CA_CERT_PATH = "ca.crt"
+        mock_s = MagicMock()
+        mock_s.DB_SSL_MODE = "verify-full"
+        mock_s.DB_SSL_CA_CERT_PATH = "ca.crt"
 
-            # Logic simulation for coverages
-            ssl_mode = "verify-full"
-            if ssl_mode in ("verify-ca", "verify-full"):
-                ctx = mock_ssl(cafile=mock_s.DB_SSL_CA_CERT_PATH)
-                ctx.check_hostname = ssl_mode == "verify-full"
-                assert ctx.check_hostname is True
+        ssl_mode = "verify-full"
+        if ssl_mode in ("verify-ca", "verify-full"):
+            ctx = mock_ssl(cafile=mock_s.DB_SSL_CA_CERT_PATH)
+            ctx.check_hostname = ssl_mode == "verify-full"
+            assert ctx.check_hostname is True
 
 
 @pytest.mark.asyncio

--- a/tests/unit/core/test_smoke_test_scim_helpers.py
+++ b/tests/unit/core/test_smoke_test_scim_helpers.py
@@ -64,6 +64,28 @@ def test_record_check_appends_structured_check_with_status_code() -> None:
     assert checks[0].status_code == 200
 
 
+def test_record_check_uses_perf_counter_for_duration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    checks: list[Check] = []
+    response = httpx.Response(
+        200,
+        request=httpx.Request("GET", "https://example.com/scim/v2/Schemas"),
+    )
+    monkeypatch.setattr(scim_helpers, "_perf_counter", lambda: 10.5)
+
+    record_check(
+        checks,
+        name="scim.schemas",
+        resp=response,
+        started=10.0,
+        ok=True,
+        detail=None,
+    )
+
+    assert checks[0].duration_ms == 500.0
+
+
 def test_build_group_add_member_patch_uses_patchop_schema() -> None:
     payload = build_group_add_member_patch("abc123")
     assert payload["schemas"] == ["urn:ietf:params:scim:api:messages:2.0:PatchOp"]

--- a/tests/unit/core/test_timeout_utils.py
+++ b/tests/unit/core/test_timeout_utils.py
@@ -93,3 +93,13 @@ async def test_timeout_operation_decorator_uses_timeout_manager():
 async def test_timeout_context_allows_custom_timeout():
     async with timeout_context("llm_api", custom_timeout=12.5) as manager:
         assert manager.config["total"] == 12.5
+
+
+@pytest.mark.asyncio
+async def test_timeout_context_custom_timeout_does_not_mutate_global_config():
+    original_total = TIMEOUT_CONFIGS["llm_api"]["total"]
+
+    async with timeout_context("llm_api", custom_timeout=12.5) as manager:
+        assert manager.config["total"] == 12.5
+
+    assert TIMEOUT_CONFIGS["llm_api"]["total"] == original_total

--- a/tests/unit/db/test_session_deep.py
+++ b/tests/unit/db/test_session_deep.py
@@ -64,8 +64,9 @@ class TestSessionDeep:
                 assert mock_logger.warning.called
 
     def test_check_rls_policy_exempt(self):
-        with patch("app.shared.db.session.settings") as mock_settings:
-            mock_settings.TESTING = False
+        mock_settings = MagicMock()
+        mock_settings.TESTING = False
+        with patch("app.shared.db.session.get_settings", return_value=mock_settings):
             from app.shared.core.constants import RLS_EXEMPT_TABLES
 
             table = RLS_EXEMPT_TABLES[0]
@@ -75,8 +76,9 @@ class TestSessionDeep:
             assert stmt.startswith("SELECT")
 
     def test_check_rls_policy_violation(self):
-        with patch("app.shared.db.session.settings") as mock_settings:
-            mock_settings.TESTING = False
+        mock_settings = MagicMock()
+        mock_settings.TESTING = False
+        with patch("app.shared.db.session.get_settings", return_value=mock_settings):
             mock_conn = MagicMock()
             mock_conn.info = {"rls_context_set": False}
             with pytest.raises(ValdricsException) as exc:
@@ -86,8 +88,9 @@ class TestSessionDeep:
             assert exc.value.code == "rls_enforcement_failed"
 
     def test_check_rls_policy_allows_transaction_control_statements(self):
-        with patch("app.shared.db.session.settings") as mock_settings:
-            mock_settings.TESTING = False
+        mock_settings = MagicMock()
+        mock_settings.TESTING = False
+        with patch("app.shared.db.session.get_settings", return_value=mock_settings):
             mock_conn = MagicMock()
             mock_conn.info = {"rls_context_set": False}
             stmt, params = check_rls_policy(mock_conn, None, "BEGIN", {}, None, False)
@@ -101,8 +104,9 @@ class TestSessionDeep:
 
     @pytest.mark.asyncio
     async def test_check_rls_policy_violation_async(self):
-        with patch("app.shared.db.session.settings") as mock_settings:
-            mock_settings.TESTING = False
+        mock_settings = MagicMock()
+        mock_settings.TESTING = False
+        with patch("app.shared.db.session.get_settings", return_value=mock_settings):
             mock_conn = MagicMock()
             mock_conn.info = {"rls_context_set": False}
             with pytest.raises(ValdricsException) as exc:
@@ -124,11 +128,13 @@ class TestSessionDeep:
                 session_module._build_db_runtime()
 
     def test_ssl_config_disable(self):
-        with patch("app.shared.db.session.settings") as mock_settings:
-            mock_settings.DATABASE_URL = "postgresql://test"
-            mock_settings.DB_SSL_MODE = "disable"
-            import importlib
-            import app.shared.db.session
+        mock_settings = MagicMock()
+        mock_settings.DATABASE_URL = "postgresql://test"
+        mock_settings.DB_SSL_MODE = "disable"
+        import importlib
+        import app.shared.db.session
+
+        with patch("app.shared.core.config.get_settings", return_value=mock_settings):
             importlib.reload(app.shared.db.session)
 
     def test_ssl_config_require_prod_uses_verified_system_trust(self):

--- a/tests/unit/db/test_session_exhaustive.py
+++ b/tests/unit/db/test_session_exhaustive.py
@@ -293,9 +293,10 @@ class TestSessionExhaustive:
         """Test bypass for exempt tables and system queries."""
         mock_conn = MagicMock()
         mock_conn.info = {"rls_context_set": False}
+        mock_settings = MagicMock()
+        mock_settings.TESTING = False
 
-        with patch("app.shared.db.session.settings") as mock_settings:
-            mock_settings.TESTING = False
+        with patch("app.shared.db.session.get_settings", return_value=mock_settings):
 
             # Internal execution (True) checks should pass
             session_mod.check_rls_policy(mock_conn, None, "SELECT 1", {}, None, True)

--- a/tests/unit/governance/scheduler/test_orchestrator_branches.py
+++ b/tests/unit/governance/scheduler/test_orchestrator_branches.py
@@ -144,7 +144,10 @@ async def test_fetch_live_carbon_intensity_success_and_cache(
     client = AsyncMock()
     client.get = AsyncMock(return_value=response)
 
-    with patch.object(orchestrator_module, "get_settings", return_value=settings_obj):
+    with (
+        patch.object(orchestrator_module, "get_settings", return_value=settings_obj),
+        patch.object(orchestrator_module, "_monotonic_time", side_effect=[100.0, 150.0]),
+    ):
         with patch(
             "app.shared.core.http.get_http_client",
             return_value=client,
@@ -158,6 +161,46 @@ async def test_fetch_live_carbon_intensity_success_and_cache(
             cached_value = await orchestrator._fetch_live_carbon_intensity("us-east-1")
             assert cached_value == 97.0
             get_http_client.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_fetch_live_carbon_intensity_cache_expiry_uses_monotonic_time(
+    orchestrator: SchedulerOrchestrator,
+) -> None:
+    import app.modules.governance.domain.scheduler.orchestrator as orchestrator_module
+
+    settings_obj = SimpleNamespace(
+        ELECTRICITY_MAPS_API_KEY="abc123",
+        CARBON_INTENSITY_API_TIMEOUT_SECONDS=3,
+    )
+
+    first_response = MagicMock()
+    first_response.raise_for_status.return_value = None
+    first_response.json.return_value = {"carbonIntensity": 97}
+    second_response = MagicMock()
+    second_response.raise_for_status.return_value = None
+    second_response.json.return_value = {"carbonIntensity": 88}
+
+    client = AsyncMock()
+    client.get = AsyncMock(side_effect=[first_response, second_response])
+
+    with (
+        patch.object(orchestrator_module, "get_settings", return_value=settings_obj),
+        patch.object(
+            orchestrator_module,
+            "_monotonic_time",
+            side_effect=[100.0, 701.0],
+        ),
+        patch(
+            "app.shared.core.http.get_http_client",
+            return_value=client,
+        ),
+        patch.object(orchestrator_module.time, "time", return_value=1.0),
+    ):
+        assert await orchestrator._fetch_live_carbon_intensity("us-east-1") == 97.0
+        assert await orchestrator._fetch_live_carbon_intensity("us-east-1") == 88.0
+
+    assert client.get.await_count == 2
 
 
 @pytest.mark.asyncio

--- a/tests/unit/llm/test_circuit_breaker.py
+++ b/tests/unit/llm/test_circuit_breaker.py
@@ -132,9 +132,28 @@ class TestLLMCircuitBreaker:
         circuit.last_failure_time = datetime.now(timezone.utc) - timedelta(
             seconds=61
         )  # Past recovery timeout
+        circuit.last_failure_monotonic = None
 
         # Should transition to half-open and be available
         assert breaker.is_available("provider")
+        assert circuit.state == CircuitState.HALF_OPEN
+
+    def test_is_available_open_circuit_recovery_uses_monotonic_time(self, breaker):
+        """Recovery should use elapsed monotonic time, not wall-clock drift."""
+        for _ in range(3):
+            breaker.record_failure("provider")
+
+        circuit = breaker._get_circuit("provider")
+        circuit.last_failure_time = datetime.now(timezone.utc)
+
+        with (
+            patch("app.shared.llm.circuit_breaker.datetime") as mock_datetime,
+            patch("app.shared.llm.circuit_breaker._monotonic_time", return_value=500.0),
+        ):
+            mock_datetime.now.return_value = circuit.last_failure_time
+            circuit.last_failure_monotonic = 430.0
+            assert breaker.is_available("provider") is True
+
         assert circuit.state == CircuitState.HALF_OPEN
 
     def test_is_available_half_open_circuit(self, breaker):
@@ -279,6 +298,7 @@ class TestLLMCircuitBreaker:
 
         circuit = breaker._get_circuit("provider")
         circuit.last_failure_time = datetime.now(timezone.utc) - timedelta(seconds=61)
+        circuit.last_failure_monotonic = None
 
         with breaker.protect("provider"):
             with pytest.raises(CircuitOpenError, match="Circuit open for provider"):
@@ -483,12 +503,14 @@ class TestCircuitBreakerIntegration:
         circuit.last_failure_time = datetime.now(timezone.utc) - timedelta(
             seconds=breaker.recovery_timeout - 0.1
         )
+        circuit.last_failure_monotonic = None
         assert not breaker.is_available(provider)
 
         # At timeout - should become available
         circuit.last_failure_time = datetime.now(timezone.utc) - timedelta(
             seconds=breaker.recovery_timeout
         )
+        circuit.last_failure_monotonic = None
         assert breaker.is_available(provider)
         assert circuit.state == CircuitState.HALF_OPEN
 

--- a/tests/unit/llm/test_hybrid_scheduler_exhaustive.py
+++ b/tests/unit/llm/test_hybrid_scheduler_exhaustive.py
@@ -372,6 +372,44 @@ def test_get_analyzer_keeps_explicitly_injected_analyzer_when_provider_changes(s
     scheduler._llm_factory_create.assert_not_called()
 
 
+def test_scheduler_rebuilds_cache_and_delta_service_when_cache_backend_changes(
+    mock_db,
+) -> None:
+    cache_one = AsyncMock()
+    cache_two = AsyncMock()
+    delta_one = MagicMock()
+    delta_two = MagicMock()
+    active_cache = cache_one
+
+    def _get_live_cache():
+        return active_cache
+
+    with (
+        patch(
+            "app.shared.llm.hybrid_scheduler.get_cache_service",
+            side_effect=_get_live_cache,
+        ),
+        patch(
+            "app.shared.llm.hybrid_scheduler.DeltaAnalysisService",
+            side_effect=[delta_one, delta_two],
+        ) as mock_delta_service_cls,
+        patch("app.shared.llm.factory.LLMFactory.create"),
+        patch("app.shared.core.config.get_settings"),
+        patch("app.shared.llm.hybrid_scheduler.FinOpsAnalyzer"),
+    ):
+        scheduler = HybridAnalysisScheduler(mock_db)
+
+        assert scheduler.cache is cache_one
+        assert scheduler.delta_service is delta_one
+
+        active_cache = cache_two
+
+        assert scheduler.cache is cache_two
+        assert scheduler.delta_service is delta_two
+
+    assert mock_delta_service_cls.call_args_list == [call(cache_one), call(cache_two)]
+
+
 @pytest.mark.asyncio
 async def test_run_analysis_auto_delta_when_schedule_says_no(scheduler) -> None:
     tenant_id = uuid.uuid4()

--- a/tests/unit/notifications/domain/test_slack_service.py
+++ b/tests/unit/notifications/domain/test_slack_service.py
@@ -36,6 +36,27 @@ async def test_send_alert_deduplication(slack_service):
 
 
 @pytest.mark.asyncio
+async def test_send_alert_local_dedup_window_uses_monotonic_time(slack_service):
+    slack_service.client.chat_postMessage = AsyncMock()
+
+    with (
+        patch(
+            "app.shared.core.rate_limit.get_redis_client",
+            side_effect=RuntimeError("redis unavailable"),
+        ),
+        patch(
+            "app.modules.notifications.domain.slack._dedup_now",
+            side_effect=[1_000.0, 5_000.0],
+        ),
+    ):
+        await slack_service.send_alert("Dupe", "Msg")
+        result = await slack_service.send_alert("Dupe", "Msg")
+
+    assert result is True
+    assert slack_service.client.chat_postMessage.call_count == 2
+
+
+@pytest.mark.asyncio
 async def test_send_alert_no_deduplication_different_msg(slack_service):
     """Verifies that different messages with same title are NOT deduped."""
     slack_service.client.chat_postMessage = AsyncMock()

--- a/tests/unit/ops/test_check_frontend_hygiene.py
+++ b/tests/unit/ops/test_check_frontend_hygiene.py
@@ -152,6 +152,33 @@ def test_run_fails_when_svelte_uses_html_injection_without_sanitization(
     assert "`{@html ...}` requires DOMPurify.sanitize(...)" in capsys.readouterr().out
 
 
+def test_run_allows_preescaped_json_ld_html_injection(tmp_path: Path) -> None:
+    _seed_safe_dashboard(tmp_path)
+    _write(
+        tmp_path / "dashboard/src/lib/PublicPageMeta.svelte",
+        """
+<script lang="ts">
+  const structuredDataJson = [
+    JSON.stringify({ '@type': 'ContactPage' })
+      .replaceAll('<', '\\\\u003c')
+      .replaceAll('</script', '<\\\\/script')
+  ];
+  const structuredDataMarkup = structuredDataJson.map(
+    (value) => '<script type="application/ld+json">' + value + '</scr' + 'ipt>'
+  );
+</script>
+
+<svelte:head>
+  {#each structuredDataMarkup as item}
+    {@html item}
+  {/each}
+</svelte:head>
+""".strip(),
+    )
+
+    assert run(tmp_path) == 0
+
+
 def test_main_resolves_relative_repo_root_from_repo_when_run_outside_repo(
     tmp_path: Path,
     monkeypatch,

--- a/tests/unit/ops/test_legacy_db_maintenance_scripts.py
+++ b/tests/unit/ops/test_legacy_db_maintenance_scripts.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -52,6 +52,36 @@ def test_run_rls_optimization_uses_repo_root_sql_path(
 
     assert run_rls_optimization.main([]) == 0
     driver_connection.execute.assert_awaited_once_with("SELECT 1;")
+
+
+def test_run_rls_optimization_uses_perf_counter_for_total_runtime(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    sql_path = tmp_path / "scripts" / "optimize_performance_and_security.sql"
+    sql_path.parent.mkdir(parents=True)
+    sql_path.write_text("SELECT 1;", encoding="utf-8")
+
+    driver_connection = SimpleNamespace(execute=AsyncMock())
+    raw_conn = SimpleNamespace(driver_connection=driver_connection)
+    connection = SimpleNamespace(get_raw_connection=AsyncMock(return_value=raw_conn))
+    session = SimpleNamespace(connection=AsyncMock(return_value=connection))
+
+    monkeypatch.setattr(run_rls_optimization, "_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(
+        run_rls_optimization,
+        "async_session_maker",
+        lambda: _AsyncContextManager(session),
+    )
+    monkeypatch.setattr(
+        run_rls_optimization,
+        "_perf_counter",
+        MagicMock(side_effect=[25.0, 25.4]),
+    )
+
+    assert run_rls_optimization.main([]) == 0
+    assert "🏁 Total hardening time: 0.40s" in capsys.readouterr().out
 
 
 @pytest.mark.asyncio

--- a/tests/unit/ops/test_smoke_test_scim_idp.py
+++ b/tests/unit/ops/test_smoke_test_scim_idp.py
@@ -54,3 +54,51 @@ def test_main_rejects_directory_output_before_network(
 
     with pytest.raises(SystemExit, match="out must be a file path"):
         scim_idp.main()
+
+
+def test_main_uses_perf_counter_for_total_duration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    written: dict[str, object] = {}
+
+    class DummyResponse:
+        status_code = 200
+        text = ""
+        is_success = True
+
+        def json(self):
+            return {}
+
+    class DummyClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def get(self, url: str):
+            return DummyResponse()
+
+    perf_values = iter([10.0, 10.1, 10.2, 10.3, 10.4])
+    monkeypatch.setattr(scim_idp, "_perf_counter", lambda: next(perf_values))
+    monkeypatch.setattr(scim_idp.httpx, "Client", DummyClient)
+    monkeypatch.setattr(
+        scim_idp,
+        "_write_out",
+        lambda _path, payload: written.update(payload),
+    )
+
+    exit_code = scim_idp.main(
+        [
+            "--scim-base-url",
+            "https://example.com/scim/v2",
+            "--scim-token",
+            "token",
+        ]
+    )
+
+    assert exit_code == 0
+    assert written["duration_seconds"] == pytest.approx(0.4)

--- a/tests/unit/optimization/test_remediation_branch_coverage.py
+++ b/tests/unit/optimization/test_remediation_branch_coverage.py
@@ -62,6 +62,34 @@ async def test_backup_creation_errors_raise(service: RemediationService) -> None
 
 
 @pytest.mark.asyncio
+async def test_rds_backup_ids_use_unique_snapshot_suffixes(
+    service: RemediationService,
+) -> None:
+    rds = AsyncMock()
+
+    async def fake_client(
+        _name: str, _context: RemediationContext
+    ) -> _AsyncContextManager:
+        return _AsyncContextManager(rds)
+
+    action = AWSDeleteRdsInstanceAction()
+    action._get_client = fake_client  # type: ignore[method-assign]
+    context = RemediationContext(tenant_id=uuid4(), region="us-east-1", tier="pro")
+
+    with patch(
+        "app.modules.optimization.domain.actions.aws.rds._snapshot_suffix",
+        side_effect=["abc123def456", "fed654cba321"],
+    ):
+        first = await action.create_backup("db-1", context)
+        second = await action.create_backup("db-1", context)
+
+    assert first == "valdrics-backup-db-1-abc123def456"
+    assert second == "valdrics-backup-db-1-fed654cba321"
+    assert first != second
+    assert rds.create_db_snapshot.await_count == 2
+
+
+@pytest.mark.asyncio
 async def test_execute_action_delete_volume_detach_and_delete(
     service: RemediationService,
 ) -> None:

--- a/tests/unit/remediation/test_circuit_breaker_deep.py
+++ b/tests/unit/remediation/test_circuit_breaker_deep.py
@@ -52,6 +52,27 @@ class TestCircuitBreakerDeep:
         assert await cb.get_state() == CircuitState.HALF_OPEN
 
     @pytest.mark.asyncio
+    async def test_circuit_breaker_memory_recovery_uses_monotonic_time(self):
+        config = CircuitBreakerConfig(failure_threshold=1, recovery_timeout_seconds=30)
+        cb = CircuitBreaker("tenant-monotonic", config=config)
+
+        with (
+            patch.object(cb_module.time, "time", return_value=100.0),
+            patch.object(cb_module, "_monotonic_time", return_value=10.0),
+        ):
+            await cb.record_failure("trip")
+
+        assert await cb.get_state() == CircuitState.OPEN
+
+        with (
+            patch.object(cb_module.time, "time", return_value=100.0),
+            patch.object(cb_module, "_monotonic_time", return_value=45.0),
+        ):
+            assert await cb.can_execute() is True
+
+        assert await cb.get_state() == CircuitState.HALF_OPEN
+
+    @pytest.mark.asyncio
     async def test_circuit_breaker_half_open_success_reset(self):
         config = CircuitBreakerConfig(failure_threshold=1)
         cb = CircuitBreaker("tenant-1", config=config)

--- a/tests/unit/services/billing/test_currency_service.py
+++ b/tests/unit/services/billing/test_currency_service.py
@@ -29,7 +29,7 @@ def mock_db():
 @pytest.fixture(autouse=True)
 def clear_cache():
     _RATES_CACHE.clear()
-    _RATES_CACHE["USD"] = (Decimal("1.0"), time.time(), "internal")
+    _RATES_CACHE["USD"] = (Decimal("1.0"), time.monotonic(), "internal")
     yield
 
 

--- a/tests/unit/services/billing/test_paystack_billing.py
+++ b/tests/unit/services/billing/test_paystack_billing.py
@@ -83,6 +83,24 @@ class TestPaystackClient:
             with pytest.raises(HTTPError):
                 await client._request("GET", "test")
 
+    @pytest.mark.asyncio
+    async def test_request_reads_live_secret_after_client_construction(self, mock_settings):
+        client = PaystackClient()
+        mock_settings.PAYSTACK_SECRET_KEY = "sk_test_rotated"
+
+        async def _request(method, url, headers=None, **kwargs):
+            assert headers is not None
+            assert headers["Authorization"] == "Bearer sk_test_rotated"
+            response = MagicMock()
+            response.raise_for_status.return_value = None
+            response.json.return_value = {"status": True, "data": {}}
+            return response
+
+        with patch("httpx.AsyncClient.request", side_effect=_request):
+            result = await client._request("GET", "test")
+
+        assert result["status"] is True
+
 
 class TestBillingService:
     @pytest.mark.asyncio

--- a/tests/unit/services/scheduler/test_scheduler_processors.py
+++ b/tests/unit/services/scheduler/test_scheduler_processors.py
@@ -5,6 +5,7 @@ No existing tests for these modules.
 """
 
 from datetime import date
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
@@ -84,6 +85,66 @@ class TestAnalysisProcessor:
             )
             # Should complete without error
             assert result is None or isinstance(result, dict)
+
+    @pytest.mark.asyncio
+    async def test_process_tenant_uses_live_llm_provider_setting(
+        self, mock_db: AsyncMock, mock_tenant
+    ) -> None:
+        processor = AnalysisProcessor()
+        conn = MagicMock()
+        conn.provider = "aws"
+        conn.region = "us-east-1"
+        conn.id = uuid4()
+        mock_tenant.aws_connections = [conn]
+        mock_tenant.azure_connections = []
+        mock_tenant.gcp_connections = []
+        mock_tenant.notification_settings = MagicMock(slack_enabled=False)
+
+        usage_summary = MagicMock()
+        usage_summary.records = [MagicMock(amount=25.0, service="Amazon EC2")]
+        usage_summary.total_cost = 25.0
+
+        settings_obj = SimpleNamespace(LLM_PROVIDER="groq")
+
+        with (
+            patch(
+                "app.modules.governance.domain.scheduler.processors.get_settings",
+                return_value=settings_obj,
+            ),
+            patch(
+                "app.modules.governance.domain.scheduler.processors.AdapterFactory.get_adapter",
+            ) as get_adapter,
+            patch(
+                "app.modules.governance.domain.scheduler.processors.ZombieDetectorFactory.get_detector",
+            ) as get_detector,
+            patch(
+                "app.modules.governance.domain.scheduler.processors.LLMFactory.create"
+            ) as create_llm,
+            patch(
+                "app.modules.governance.domain.scheduler.processors.FinOpsAnalyzer"
+            ) as analyzer_cls,
+            patch(
+                "app.modules.governance.domain.scheduler.processors.CarbonCalculator"
+            ) as carbon_calc_cls,
+        ):
+            adapter = get_adapter.return_value
+            adapter.get_daily_costs = AsyncMock(return_value=usage_summary)
+            get_detector.return_value.scan_all = AsyncMock(return_value={"ec2": []})
+            analyzer_cls.return_value.analyze = AsyncMock(
+                return_value={"insights": [], "recommendations": []}
+            )
+            carbon_calc_cls.return_value.calculate_from_costs.return_value = {
+                "total_co2_kg": 1.0
+            }
+
+            await processor.process_tenant(
+                mock_db,
+                mock_tenant,
+                date.today(),
+                date.today(),
+            )
+
+        create_llm.assert_called_once_with("groq")
 
 
 class TestSavingsProcessor:

--- a/tests/unit/services/zombies/test_remediation_service.py
+++ b/tests/unit/services/zombies/test_remediation_service.py
@@ -861,6 +861,112 @@ async def test_execute_resolves_bound_finding_on_success(remediation_service, db
 
 
 @pytest.mark.asyncio
+async def test_execute_records_duration_with_perf_counter(
+    remediation_service, db_session
+):
+    request_id = uuid4()
+    tenant_id = uuid4()
+    connection_id = uuid4()
+    finding_id = uuid4()
+    finding = OptimizationFinding(
+        id=finding_id,
+        tenant_id=tenant_id,
+        source=FindingSource.ZOMBIE_SCAN,
+        status=FindingStatus.OPEN,
+        fingerprint="d" * 64,
+        provider="aws",
+        category="idle_instances",
+        connection_id=connection_id,
+        connection_name="Prod AWS",
+        resource_id="i-123",
+        resource_type="ec2_instance",
+        region="us-east-1",
+        estimated_monthly_savings=Decimal("20.0"),
+        confidence_score=Decimal("0.91"),
+        explainability_notes="Idle instance detected.",
+        requires_manual_review=False,
+        automated_action_allowed=True,
+        decision_gate=None,
+        payload={"resource_id": "i-123"},
+    )
+    req = MagicMock(spec=RemediationRequest)
+    req.id = request_id
+    req.tenant_id = tenant_id
+    req.status = RemediationStatus.APPROVED
+    req.resource_id = "i-123"
+    req.resource_type = "ec2_instance"
+    req.action = RemediationAction.STOP_INSTANCE
+    req.create_backup = False
+    req.reviewed_by_user_id = uuid4()
+    req.estimated_monthly_savings = Decimal("20.0")
+    req.provider = "aws"
+    req.connection_id = connection_id
+    req.finding_id = finding_id
+    req.finding_snapshot = {
+        "provider": "aws",
+        "connection_id": str(connection_id),
+        "region": "us-east-1",
+        "resource_id": "i-123",
+        "resource_type": "ec2_instance",
+        "fingerprint": "d" * 64,
+    }
+    req.region = "us-east-1"
+    req.action_parameters = {}
+
+    mock_res = MagicMock()
+    mock_res.scalar_one_or_none.return_value = req
+    db_session.execute.return_value = mock_res
+    remediation_service.get_by_id = AsyncMock(return_value=finding)
+    remediation_service._resolve_credentials = AsyncMock(
+        return_value={"region": "us-east-1"}
+    )
+
+    with (
+        patch(
+            "app.modules.optimization.domain.remediation.RemediationActionFactory.get_strategy"
+        ) as mock_get_strategy,
+        patch(
+            "app.modules.optimization.domain.remediation.AuditLogger.log",
+            new=AsyncMock(),
+        ),
+        patch(
+            "app.modules.optimization.domain.remediation.SafetyGuardrailService"
+        ) as mock_safety,
+        patch(
+            "app.modules.optimization.domain.remediation_execute.REMEDIATION_DURATION_SECONDS"
+        ) as mock_duration,
+        patch(
+            "app.modules.optimization.domain.remediation_execute._perf_counter",
+            side_effect=[10.0, 10.75],
+        ),
+    ):
+        mock_safety.return_value.check_all_guards = AsyncMock()
+        mock_strategy = MagicMock()
+        mock_strategy.execute = AsyncMock(
+            return_value=ExecutionResult(
+                status=ExecutionStatus.SUCCESS,
+                resource_id="i-123",
+                action_taken=RemediationAction.STOP_INSTANCE.value,
+            )
+        )
+        mock_get_strategy.return_value = mock_strategy
+
+        result = await remediation_service.execute(
+            request_id, tenant_id, bypass_grace_period=True
+        )
+
+    assert result.status == RemediationStatus.COMPLETED
+    mock_duration.labels.assert_called_once_with(
+        action=RemediationAction.STOP_INSTANCE.value,
+        provider="aws",
+    )
+    assert (
+        mock_duration.labels.return_value.observe.call_args.args[0]
+        == pytest.approx(0.75)
+    )
+
+
+@pytest.mark.asyncio
 async def test_get_client_credential_mapping(remediation_service):
     # Test with CamelCase credentials
     remediation_service.credentials = {

--- a/tests/unit/shared/db/test_session_coverage.py
+++ b/tests/unit/shared/db/test_session_coverage.py
@@ -101,10 +101,10 @@ def test_check_rls_policy_violation():
     """Test RLS policy enforcement fails when context is False."""
     mock_conn = MagicMock()
     mock_conn.info = {"rls_context_set": False}
+    mock_settings = MagicMock()
+    mock_settings.TESTING = False
 
-    with patch("app.shared.db.session.settings") as mock_settings:
-        mock_settings.TESTING = False  # Force enforcement logic
-
+    with patch("app.shared.db.session.get_settings", return_value=mock_settings):
         with pytest.raises(ValdricsException) as exc:
             check_rls_policy(
                 mock_conn, None, "SELECT * FROM sensitive_data", (), None, False
@@ -117,10 +117,10 @@ def test_check_rls_policy_exempt():
     """Test RLS policy doesn't block exempt tables."""
     mock_conn = MagicMock()
     mock_conn.info = {"rls_context_set": False}
+    mock_settings = MagicMock()
+    mock_settings.TESTING = False
 
-    with patch("app.shared.db.session.settings") as mock_settings:
-        mock_settings.TESTING = False
-
+    with patch("app.shared.db.session.get_settings", return_value=mock_settings):
         # Should not raise for exempt table
         statement = "SELECT * FROM tenants"
         res_stmt, res_params = check_rls_policy(

--- a/tests/unit/tasks/test_scheduler_funnel_ops.py
+++ b/tests/unit/tasks/test_scheduler_funnel_ops.py
@@ -77,6 +77,10 @@ async def test_refresh_landing_funnel_health_task_records_success_metrics() -> N
         ) as mock_impl,
         patch("app.tasks.scheduler_tasks.SCHEDULER_JOB_RUNS") as mock_runs,
         patch("app.tasks.scheduler_tasks.SCHEDULER_JOB_DURATION") as mock_duration,
+        patch(
+            "app.tasks.scheduler_tasks._perf_counter",
+            side_effect=[50.0, 50.25],
+        ),
     ):
         await st._refresh_landing_funnel_health_logic()
 
@@ -85,7 +89,10 @@ async def test_refresh_landing_funnel_health_task_records_success_metrics() -> N
         job_name="landing_funnel_health_refresh",
         status="success",
     )
-    mock_duration.labels.return_value.observe.assert_called_once()
+    assert (
+        mock_duration.labels.return_value.observe.call_args.args[0]
+        == pytest.approx(0.25)
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tasks/test_scheduler_sweep_runtime.py
+++ b/tests/unit/tasks/test_scheduler_sweep_runtime.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.tasks.scheduler_sweep_runtime import run_sweep_with_retries
+
+
+@pytest.mark.asyncio
+async def test_run_sweep_with_retries_uses_perf_counter_when_available() -> None:
+    run_once = AsyncMock()
+    scheduler_job_runs = MagicMock()
+    scheduler_job_duration = MagicMock()
+    logger = MagicMock()
+    time_module = SimpleNamespace(
+        perf_counter=MagicMock(side_effect=[10.0, 10.5]),
+        time=MagicMock(return_value=999.0),
+    )
+
+    await run_sweep_with_retries(
+        job_name="billing_sweep",
+        error_event="billing_sweep_failed",
+        max_retries=3,
+        time_module=time_module,
+        asyncio_module=SimpleNamespace(sleep=AsyncMock()),
+        scheduler_job_runs=scheduler_job_runs,
+        scheduler_job_duration=scheduler_job_duration,
+        logger=logger,
+        recoverable_errors=(RuntimeError,),
+        run_once=run_once,
+    )
+
+    run_once.assert_awaited_once()
+    scheduler_job_runs.labels.assert_called_once_with(
+        job_name="billing_sweep",
+        status="success",
+    )
+    assert (
+        scheduler_job_duration.labels.return_value.observe.call_args.args[0]
+        == pytest.approx(0.5)
+    )
+    time_module.time.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_run_sweep_with_retries_falls_back_to_time_without_perf_counter() -> None:
+    scheduler_job_runs = MagicMock()
+    scheduler_job_duration = MagicMock()
+    logger = MagicMock()
+    time_module = SimpleNamespace(time=MagicMock(side_effect=[2.0, 2.25]))
+
+    await run_sweep_with_retries(
+        job_name="acceptance_sweep",
+        error_event="acceptance_sweep_failed",
+        max_retries=1,
+        time_module=time_module,
+        asyncio_module=SimpleNamespace(sleep=AsyncMock()),
+        scheduler_job_runs=scheduler_job_runs,
+        scheduler_job_duration=scheduler_job_duration,
+        logger=logger,
+        recoverable_errors=(RuntimeError,),
+        run_once=AsyncMock(),
+    )
+
+    assert (
+        scheduler_job_duration.labels.return_value.observe.call_args.args[0]
+        == pytest.approx(0.25)
+    )
+    assert time_module.time.call_count == 2

--- a/tests/unit/tasks/test_scheduler_tasks_branch_paths_2.py
+++ b/tests/unit/tasks/test_scheduler_tasks_branch_paths_2.py
@@ -569,6 +569,31 @@ async def test_acceptance_sweep_retries_then_succeeds() -> None:
 
 
 @pytest.mark.asyncio
+async def test_acceptance_sweep_uses_perf_counter_for_duration_metric() -> None:
+    db = AsyncMock()
+    _configure_sync_begin(db)
+    tenant = SimpleNamespace(id=uuid4())
+    db.execute.side_effect = [_scalars_result([tenant]), _rowcount_result(1)]
+
+    with (
+        patch("app.tasks.scheduler_tasks._open_db_session", return_value=_db_cm(db)),
+        patch(
+            "app.tasks.scheduler_sweep_ops._perf_counter",
+            side_effect=[30.0, 30.4],
+        ),
+        patch("app.tasks.scheduler_tasks.BACKGROUND_JOBS_ENQUEUED"),
+        patch("app.tasks.scheduler_tasks.SCHEDULER_JOB_RUNS"),
+        patch("app.tasks.scheduler_tasks.SCHEDULER_JOB_DURATION") as mock_duration,
+    ):
+        await st._acceptance_sweep_logic()
+
+    assert (
+        mock_duration.labels.return_value.observe.call_args.args[0]
+        == pytest.approx(0.4)
+    )
+
+
+@pytest.mark.asyncio
 async def test_acceptance_sweep_final_failure_records_metric() -> None:
     db = AsyncMock()
     _configure_sync_begin(db)
@@ -753,3 +778,22 @@ def test_daily_finops_scan_logs_partial_failure_and_completion() -> None:
         successful=2,
         failed=1,
     )
+
+
+def test_daily_finops_scan_uses_perf_counter_for_duration() -> None:
+    task = MagicMock()
+    task.delay.return_value = None
+
+    with (
+        patch("app.tasks.scheduler_tasks.run_cohort_analysis", task),
+        patch(
+            "app.tasks.scheduler_tasks._perf_counter",
+            side_effect=[80.0, 80.4],
+        ),
+        patch("app.tasks.scheduler_tasks.logger") as mock_logger,
+    ):
+        st.daily_finops_scan()
+
+    completed_call = mock_logger.info.call_args_list[-1]
+    assert completed_call.args == ("daily_finops_scan_completed",)
+    assert completed_call.kwargs["duration_seconds"] == pytest.approx(0.4)

--- a/tests/unit/tasks/test_scheduler_tasks_reliability.py
+++ b/tests/unit/tasks/test_scheduler_tasks_reliability.py
@@ -110,6 +110,10 @@ class TestSchedulerTasksMetrics:
             patch("app.tasks.scheduler_tasks.SCHEDULER_JOB_RUNS") as mock_job_runs,
             patch("app.tasks.scheduler_tasks.SCHEDULER_JOB_DURATION") as mock_duration,
             patch("app.tasks.scheduler_tasks.BACKGROUND_JOBS_ENQUEUED"),
+            patch(
+                "app.tasks.scheduler_tasks._perf_counter",
+                side_effect=[100.0, 100.5],
+            ),
         ):
             mock_session = AsyncMock()
             mock_session_maker.return_value = mock_session
@@ -139,8 +143,11 @@ class TestSchedulerTasksMetrics:
             mock_job_runs.labels.assert_called_with(
                 job_name="cohort_active_enqueue", status="success"
             )
-            # Should observe duration
             mock_duration.labels.assert_called_with(job_name="cohort_active_enqueue")
+            assert (
+                mock_duration.labels.return_value.observe.call_args.args[0]
+                == pytest.approx(0.5)
+            )
 
     @pytest.mark.asyncio
     async def test_remediation_sweep_metrics(self):


### PR DESCRIPTION
## Summary
- categorize the full April 1 worktree in `docs/ops/all_changes_categorization_2026-04-01.md`
- consolidate backend runtime, frontend product surfaces, and operational tooling changes in one PR
- close the three track issues created for this batch

## Tracks
- closes #349
- closes #350
- closes #351

## Notes
- This is a consolidation PR across the current April 1 runtime and frontend follow-up snapshot.
- I cleaned ignored local `__pycache__` files before packaging the batch.
- No clearly unwanted tracked docs or artifacts were found in this batch.
- I did not run a fresh full local test suite in this batching turn before opening the PR.
