### PR TITLE
chore: categorize and consolidate follow-up changes (2026-04-06)

### DIFF
--- a/dashboard/src/lib/components/landing/LandingCookieConsent.svelte
+++ b/dashboard/src/lib/components/landing/LandingCookieConsent.svelte
@@ -52,13 +52,17 @@
 		z-index: 95;
 		width: min(26rem, calc(100vw - 1.4rem));
 		border-radius: var(--radius-xl);
-		border: 1px solid rgb(255 255 255 / 0.18);
+		border: 1px solid rgb(8 126 164 / 0.16);
 		padding: 0.9rem 0.95rem;
-		background: rgb(5 10 16 / 0.96);
+		background:
+			linear-gradient(180deg, rgb(255 255 255 / 0.97), rgb(246 250 252 / 0.95)),
+			radial-gradient(360px 140px at 12% 0%, rgb(8 126 164 / 0.08), transparent 72%);
 		backdrop-filter: blur(10px);
 		-webkit-backdrop-filter: blur(10px);
 		display: grid;
 		gap: 0.6rem;
+		color: var(--color-ink-900);
+		box-shadow: 0 18px 42px rgb(15 23 42 / 0.16);
 	}
 
 	.landing-cookie-banner__close {
@@ -68,11 +72,19 @@
 		width: 1.8rem;
 		height: 1.8rem;
 		border-radius: 9999px;
-		border: 1px solid rgb(255 255 255 / 0.14);
-		background: rgb(255 255 255 / 0.05);
-		color: var(--color-ink-100);
+		border: 1px solid rgb(8 126 164 / 0.14);
+		background: rgb(255 255 255 / 0.78);
+		color: var(--color-ink-900);
 		font-size: 1.1rem;
 		line-height: 1;
+	}
+
+	.landing-cookie-banner :global(.landing-proof-k) {
+		color: var(--color-brand-700);
+	}
+
+	.landing-cookie-banner :global(.landing-p) {
+		color: var(--color-ink-800);
 	}
 
 	.landing-cookie-banner__close:focus-visible {
@@ -96,5 +108,34 @@
 	.landing-cookie-banner__legal a {
 		color: var(--color-accent-300);
 		text-decoration: underline;
+	}
+
+	:global(.public-site-shell[data-public-theme='dark']) .landing-cookie-banner {
+		border-color: rgb(255 255 255 / 0.18);
+		background: rgb(5 10 16 / 0.96);
+		color: var(--color-ink-100);
+		box-shadow: 0 22px 48px rgb(2 8 14 / 0.34);
+	}
+
+	:global(.public-site-shell[data-public-theme='dark']) .landing-cookie-banner__close {
+		border-color: rgb(255 255 255 / 0.14);
+		background: rgb(255 255 255 / 0.05);
+		color: var(--color-ink-100);
+	}
+
+	:global(.public-site-shell[data-public-theme='dark']) .landing-cookie-banner :global(.landing-proof-k) {
+		color: var(--color-ink-100);
+	}
+
+	:global(.public-site-shell[data-public-theme='dark']) .landing-cookie-banner :global(.landing-p) {
+		color: var(--color-ink-100);
+	}
+
+	:global(.public-site-shell[data-public-theme='dark']) .landing-cookie-banner__legal {
+		color: var(--color-ink-300);
+	}
+
+	:global(.public-site-shell[data-public-theme='dark']) .landing-cookie-banner__legal a {
+		color: var(--color-accent-300);
 	}
 </style>

--- a/dashboard/src/lib/components/landing/LandingExitIntentPrompt.svelte
+++ b/dashboard/src/lib/components/landing/LandingExitIntentPrompt.svelte
@@ -246,11 +246,15 @@
 		z-index: 1;
 		width: min(32rem, 100%);
 		border-radius: var(--radius-xl);
-		border: 1px solid rgb(255 255 255 / 0.15);
+		border: 1px solid rgb(8 126 164 / 0.16);
 		padding: 1rem;
-		background: rgb(6 12 18 / 0.94);
+		background:
+			linear-gradient(180deg, rgb(255 255 255 / 0.98), rgb(246 250 252 / 0.96)),
+			radial-gradient(420px 160px at 14% 0%, rgb(8 126 164 / 0.08), transparent 72%);
 		display: grid;
 		gap: 0.75rem;
+		color: var(--color-ink-900);
+		box-shadow: 0 24px 52px rgb(15 23 42 / 0.2);
 	}
 
 	.landing-exit-close {
@@ -260,11 +264,21 @@
 		width: 2rem;
 		height: 2rem;
 		border-radius: 9999px;
-		border: 1px solid rgb(255 255 255 / 0.16);
-		background: rgb(255 255 255 / 0.06);
-		color: var(--color-ink-100);
+		border: 1px solid rgb(8 126 164 / 0.14);
+		background: rgb(255 255 255 / 0.82);
+		color: var(--color-ink-900);
 		font-size: 1.35rem;
 		line-height: 1;
+	}
+
+	.landing-exit-panel :global(.landing-proof-k) {
+		color: var(--color-brand-700);
+	}
+
+	.landing-exit-panel :global(.landing-p),
+	.landing-exit-panel :global(.landing-h3),
+	.landing-exit-panel :global(.landing-roi-label) {
+		color: var(--color-ink-900);
 	}
 
 	.landing-exit-close:focus-visible {
@@ -281,5 +295,25 @@
 		display: flex;
 		flex-wrap: wrap;
 		gap: 0.5rem;
+	}
+
+	:global(.public-site-shell[data-public-theme='dark']) .landing-exit-panel {
+		border-color: rgb(255 255 255 / 0.15);
+		background: rgb(6 12 18 / 0.94);
+		color: var(--color-ink-100);
+		box-shadow: 0 24px 52px rgb(2 8 14 / 0.34);
+	}
+
+	:global(.public-site-shell[data-public-theme='dark']) .landing-exit-close {
+		border-color: rgb(255 255 255 / 0.16);
+		background: rgb(255 255 255 / 0.06);
+		color: var(--color-ink-100);
+	}
+
+	:global(.public-site-shell[data-public-theme='dark']) .landing-exit-panel :global(.landing-proof-k),
+	:global(.public-site-shell[data-public-theme='dark']) .landing-exit-panel :global(.landing-p),
+	:global(.public-site-shell[data-public-theme='dark']) .landing-exit-panel :global(.landing-h3),
+	:global(.public-site-shell[data-public-theme='dark']) .landing-exit-panel :global(.landing-roi-label) {
+		color: var(--color-ink-100);
 	}
 </style>

--- a/dashboard/src/lib/components/landing/LandingHeroView.svelte
+++ b/dashboard/src/lib/components/landing/LandingHeroView.svelte
@@ -366,7 +366,7 @@
 		</button>
 	{/if}
 
-	{#if exitPromptReady && !cookieBannerVisible}
+	{#if exitPromptReady}
 		{#await loadLandingExitIntentPrompt() then { default: LandingExitIntentPrompt }}
 			<LandingExitIntentPrompt
 				enabled={!cookieBannerVisible}

--- a/docs/ops/all_changes_categorization_2026-04-06_followup.md
+++ b/docs/ops/all_changes_categorization_2026-04-06_followup.md
@@ -1,0 +1,25 @@
+# All Changes Categorization (2026-04-06 Follow-Up)
+
+## Scope
+
+- Worktree snapshot date: `2026-04-06`
+- Base branch at snapshot: `main`
+- Base commit at snapshot: `f1efabba14f32b9b143ef07bff8e0b90989290ad`
+- Total changed paths categorized: `3`
+- Categorization rule: every changed path in the dirty worktree is assigned to exactly one execution track.
+
+## Track Register
+
+### Track DI (`#366`)
+
+- Title: landing cookie-consent, exit-intent, and hero follow-up refinements
+- Paths: `3`
+- Scope summary: Small follow-up refinements across the landing cookie-consent surface, exit-intent prompt, and hero view.
+- Assigned paths:
+  - `dashboard/src/lib/components/landing/LandingCookieConsent.svelte`
+  - `dashboard/src/lib/components/landing/LandingExitIntentPrompt.svelte`
+  - `dashboard/src/lib/components/landing/LandingHeroView.svelte`
+
+## Cleanup Pass
+
+- No ignored cache directories, backup files, or clearly unwanted tracked docs/artifacts were part of this follow-up batch.


### PR DESCRIPTION
## Summary
- categorize the April 6 landing follow-up batch in a single register
- consolidate cookie-consent, exit-intent, and hero view refinements
- keep repo hygiene unchanged because no extra junk artifacts were introduced

## Tracking
Closes #366