### PR TITLE
Fix mainline workflow gates

### DIFF
--- a/.github/workflows/enterprise-tdd-mainline.yml
+++ b/.github/workflows/enterprise-tdd-mainline.yml
@@ -45,6 +45,7 @@ jobs:
           --health-retries 5
     env:
       DB_SSL_MODE: "disable"
+      CSRF_SECRET_KEY: "ci-csrf-secret-key-32-chars-min-000000"
       ENTERPRISE_GATE_DATABASE_URL: "postgresql+asyncpg://postgres:postgres@127.0.0.1:5432/valdrics_enterprise_gate"
     steps:
       - name: Checkout Code

--- a/scripts/verify_supply_chain_attestations.py
+++ b/scripts/verify_supply_chain_attestations.py
@@ -19,7 +19,7 @@ from scripts.env_generation_common import (
 
 MIN_GH_VERSION: tuple[int, int, int] = (2, 67, 0)
 DEFAULT_SIGNER_WORKFLOW = ".github/workflows/sbom.yml"
-DEFAULT_VERIFY_MAX_ATTEMPTS = 4
+DEFAULT_VERIFY_MAX_ATTEMPTS = 7
 DEFAULT_VERIFY_INITIAL_RETRY_DELAY_SECONDS = 2.0
 DEFAULT_ARTIFACT_PATHS: tuple[Path, ...] = (
     Path("sbom/valdrics-python-sbom.json"),

--- a/tests/unit/supply_chain/test_supply_chain_provenance_workflow.py
+++ b/tests/unit/supply_chain/test_supply_chain_provenance_workflow.py
@@ -130,6 +130,7 @@ def test_enterprise_tdd_mainline_workflow_hosts_the_enterprise_gate() -> None:
     assert "Enterprise TDD Quality Gate" in enterprise_text
     assert "scripts/run_enterprise_tdd_gate.py" in enterprise_text
     assert "postgres:16.13-alpine" in enterprise_text
+    assert 'CSRF_SECRET_KEY: "ci-csrf-secret-key-32-chars-min-000000"' in enterprise_text
     assert "--database-url" in enterprise_text
     assert "ENTERPRISE_GATE_DATABASE_URL" in enterprise_text
     assert 'branches: [main]' in enterprise_text

--- a/tests/unit/supply_chain/test_verify_supply_chain_attestations.py
+++ b/tests/unit/supply_chain/test_verify_supply_chain_attestations.py
@@ -8,6 +8,8 @@ import pytest
 import scripts.verify_supply_chain_attestations as attestation_verifier
 from scripts.verify_supply_chain_attestations import (
     DEFAULT_ARTIFACT_PATHS,
+    DEFAULT_VERIFY_INITIAL_RETRY_DELAY_SECONDS,
+    DEFAULT_VERIFY_MAX_ATTEMPTS,
     MIN_GH_VERSION,
     _repo_slug_from_remote_url,
     _resolve_repo_from_git_remote,
@@ -450,7 +452,11 @@ def test_verify_attestations_raises_after_transient_retry_budget_exhausted(
             dry_run=False,
         )
 
-    assert sleep_delays == [2.0, 4.0, 8.0]
+    expected_delays = [
+        DEFAULT_VERIFY_INITIAL_RETRY_DELAY_SECONDS * (2**index)
+        for index in range(DEFAULT_VERIFY_MAX_ATTEMPTS - 1)
+    ]
+    assert sleep_delays == expected_delays
 
 
 def test_verify_attestations_runs_gh_commands_from_repo_root(


### PR DESCRIPTION
## Summary
- Add the standard CI CSRF secret to the Enterprise TDD mainline gate environment so runtime evidence generation can reload settings after temporary env overrides.
- Increase the SBOM attestation verification retry budget to tolerate GitHub/Sigstore indexing lag after attestations are uploaded.
- Update workflow/attestation tests to lock the behavior.

## Validation
- uv run pytest tests/unit/supply_chain/test_supply_chain_provenance_workflow.py tests/unit/supply_chain/test_verify_supply_chain_attestations.py tests/unit/ops/test_runtime_evidence_generators.py::test_generate_finance_telemetry_snapshot_emits_verifiable_artifact -q
- uv run ruff check scripts/verify_supply_chain_attestations.py tests/unit/supply_chain/test_verify_supply_chain_attestations.py tests/unit/supply_chain/test_supply_chain_provenance_workflow.py