### PR TITLE
Run SBOM gate on verifier changes

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -7,6 +7,8 @@ on:
       - 'pyproject.toml'
       - 'uv.lock'
       - 'Dockerfile'
+      - 'scripts/generate_provenance_manifest.py'
+      - 'scripts/verify_supply_chain_attestations.py'
       - 'dashboard/package.json'
       - 'dashboard/pnpm-lock.yaml'
       - '.github/workflows/sbom.yml'

--- a/tests/unit/supply_chain/test_supply_chain_provenance_workflow.py
+++ b/tests/unit/supply_chain/test_supply_chain_provenance_workflow.py
@@ -62,6 +62,8 @@ def test_sbom_workflow_verifies_attestations_before_promotion() -> None:
 def test_sbom_workflow_push_paths_cover_frontend_dependency_surface() -> None:
     text = (REPO_ROOT / ".github/workflows/sbom.yml").read_text(encoding="utf-8")
 
+    assert "scripts/generate_provenance_manifest.py" in text
+    assert "scripts/verify_supply_chain_attestations.py" in text
     assert "dashboard/package.json" in text
     assert "dashboard/pnpm-lock.yaml" in text
     assert ".github/workflows/sbom.yml" in text


### PR DESCRIPTION
## Summary
- Add SBOM workflow path triggers for the provenance manifest generator and attestation verifier scripts that the workflow executes.
- Extend the workflow-contract test so future verifier changes do not bypass the SBOM release gate.

## Validation
- uv run pytest tests/unit/supply_chain/test_supply_chain_provenance_workflow.py -q
- uv run ruff check tests/unit/supply_chain/test_supply_chain_provenance_workflow.py