### PR TITLE
Stabilize mainline enterprise and a11y gates

### DIFF
--- a/.github/workflows/enterprise-tdd-mainline.yml
+++ b/.github/workflows/enterprise-tdd-mainline.yml
@@ -46,6 +46,9 @@ jobs:
     env:
       DB_SSL_MODE: "disable"
       CSRF_SECRET_KEY: "ci-csrf-secret-key-32-chars-min-000000"
+      ENCRYPTION_KEY: "ci-encryption-key-32-chars-min-00000000"
+      KDF_SALT: "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY="
+      SUPABASE_JWT_SECRET: "ci-supabase-jwt-secret-32-chars-0000"
       ENTERPRISE_GATE_DATABASE_URL: "postgresql+asyncpg://postgres:postgres@127.0.0.1:5432/valdrics_enterprise_gate"
     steps:
       - name: Checkout Code

--- a/dashboard/e2e/a11y.spec.ts
+++ b/dashboard/e2e/a11y.spec.ts
@@ -37,8 +37,8 @@ async function expectNoCriticalOrSeriousViolations(
 		await enableAuthenticatedSession(page.context());
 	}
 
-	await page.goto(routeCase.path);
-	await page.waitForLoadState('networkidle');
+	await page.goto(routeCase.path, { waitUntil: 'domcontentloaded' });
+	await expect(page.locator('main')).toBeVisible({ timeout: 15000 });
 	await page.waitForTimeout(1400);
 	await injectAxe(page);
 	const violations = await getViolations(page);

--- a/tests/unit/supply_chain/test_supply_chain_provenance_workflow.py
+++ b/tests/unit/supply_chain/test_supply_chain_provenance_workflow.py
@@ -133,6 +133,8 @@ def test_enterprise_tdd_mainline_workflow_hosts_the_enterprise_gate() -> None:
     assert "scripts/run_enterprise_tdd_gate.py" in enterprise_text
     assert "postgres:16.13-alpine" in enterprise_text
     assert 'CSRF_SECRET_KEY: "ci-csrf-secret-key-32-chars-min-000000"' in enterprise_text
+    assert 'ENCRYPTION_KEY: "ci-encryption-key-32-chars-min-00000000"' in enterprise_text
+    assert 'SUPABASE_JWT_SECRET: "ci-supabase-jwt-secret-32-chars-0000"' in enterprise_text
     assert "--database-url" in enterprise_text
     assert "ENTERPRISE_GATE_DATABASE_URL" in enterprise_text
     assert 'branches: [main]' in enterprise_text


### PR DESCRIPTION
## Summary
- Add the full synthetic CI secret bundle to the Enterprise TDD mainline gate so runtime evidence generation can restore settings cleanly.
- Stop the dashboard accessibility gate from waiting on network idle; authenticated pages keep long-lived streams open, so the gate now waits for the main shell before axe injection.
- Extend workflow-contract assertions for the Enterprise TDD secret bundle.

## Validation
- uv run pytest tests/unit/supply_chain/test_supply_chain_provenance_workflow.py -q
- uv run ruff check tests/unit/supply_chain/test_supply_chain_provenance_workflow.py
- pnpm exec prettier --check e2e/a11y.spec.ts