### PR TITLE
Use full signer workflow for SBOM attestations

### DIFF
--- a/reports/audit/staging.audit.report.json
+++ b/reports/audit/staging.audit.report.json
@@ -19,10 +19,10 @@
   "incorrect_claims": [
     {
       "claim": "Testing has 5,358 tests",
-      "correction": "A fresh backend collection run reported 6375 tests collected.",
+      "correction": "A fresh backend collection run reported 6376 tests collected.",
       "evidence": [
         {
-          "line": 6375,
+          "line": 6376,
           "path": "pytest --collect-only"
         }
       ]
@@ -42,7 +42,7 @@
     "Live cutover evidence and operator sign-off are validated outside this repository."
   ],
   "measured_facts": {
-    "backend_tests_collected": 6375,
+    "backend_tests_collected": 6376,
     "direct_audit_logger_call_sites": 33,
     "fastapi_requirement": "~=0.128.0",
     "frontend_svelte_version": "^5.51.5",
@@ -73,7 +73,7 @@
       "The dashboard uses SvelteKit, Svelte 5, TypeScript, Tailwind CSS v4, Vitest, and Playwright."
     ],
     "important_corrections": [
-      "Backend tests collected currently total 6375, not 5358.",
+      "Backend tests collected currently total 6376, not 5358.",
       "Zombie detection plugin classes total 56 across providers, not 11."
     ],
     "overall": "Repository audit baseline refreshed from live measured facts."

--- a/scripts/verify_supply_chain_attestations.py
+++ b/scripts/verify_supply_chain_attestations.py
@@ -168,6 +168,10 @@ def build_verify_command(
     repo: str,
     signer_workflow: str,
 ) -> list[str]:
+    normalized_signer_workflow = _normalize_signer_workflow(
+        repo=repo,
+        signer_workflow=signer_workflow,
+    )
     return [
         "gh",
         "attestation",
@@ -176,10 +180,23 @@ def build_verify_command(
         "--repo",
         repo,
         "--signer-workflow",
-        signer_workflow,
+        normalized_signer_workflow,
         "--format",
         "json",
     ]
+
+
+def _normalize_signer_workflow(*, repo: str, signer_workflow: str) -> str:
+    workflow = str(signer_workflow or "").strip()
+    if not workflow:
+        raise ValueError("`signer_workflow` must be non-empty.")
+    if workflow.startswith("https://github.com/"):
+        return workflow.removeprefix("https://github.com/").split("@", 1)[0]
+    if workflow.startswith("./"):
+        workflow = workflow[2:]
+    if workflow.startswith(".github/"):
+        return f"{repo}/{workflow}"
+    return workflow
 
 
 def _assert_verification_output(stdout: str, *, artifact: Path) -> None:

--- a/tests/unit/supply_chain/test_verify_supply_chain_attestations.py
+++ b/tests/unit/supply_chain/test_verify_supply_chain_attestations.py
@@ -36,8 +36,18 @@ def test_build_verify_command_includes_repo_workflow_and_json_output() -> None:
     assert "--repo" in cmd
     assert "acme/valdrics" in cmd
     assert "--signer-workflow" in cmd
-    assert ".github/workflows/sbom.yml" in cmd
+    assert "acme/valdrics/.github/workflows/sbom.yml" in cmd
     assert cmd[-2:] == ["--format", "json"]
+
+
+def test_build_verify_command_preserves_fully_qualified_signer_workflow() -> None:
+    cmd = build_verify_command(
+        artifact=Path("/tmp/sbom.json"),
+        repo="acme/valdrics",
+        signer_workflow="acme/valdrics/.github/workflows/sbom.yml",
+    )
+
+    assert "acme/valdrics/.github/workflows/sbom.yml" in cmd
 
 
 def test_verify_attestations_requires_repo(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Normalize relative signer workflow paths to OWNER/REPO/.github/workflows/... before invoking gh attestation verify.
- Keep workflow configuration ergonomic while matching the identity format current gh expects for --signer-workflow.
- Add coverage for relative and fully qualified signer workflow values.

## Validation
- uv run pytest tests/unit/supply_chain/test_verify_supply_chain_attestations.py tests/unit/supply_chain/test_supply_chain_provenance_workflow.py -q
- uv run ruff check scripts/verify_supply_chain_attestations.py tests/unit/supply_chain/test_verify_supply_chain_attestations.py tests/unit/supply_chain/test_supply_chain_provenance_workflow.py