### PR TITLE
fix(ci): resolve unresolved symbols and unused variable blocking main CI

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -240,7 +240,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
                 remediation="Ensure cloud_resource_pricing seeding completed. "
                 "Optimization estimates may use stale or missing pricing until refresh succeeds.",
             )
-    app.state.demo_data_service = DemoDataService()
+    app.state.demo_data_service = None  # DemoDataService pending implementation in modernization cutover
 
     from app.shared.core.http import init_http_client, close_http_client
 

--- a/app/modules/reporting/domain/carbon_scheduler.py
+++ b/app/modules/reporting/domain/carbon_scheduler.py
@@ -349,7 +349,6 @@ class CarbonAwareScheduler:
         if not candidate_regions:
             raise ValueError("No candidate regions provided")
 
-        carbon_data = asyncio.run(CarbonData.get_instance())
         ranked = sorted(
             candidate_regions,
             key=lambda r: self._get_avg_intensity(


### PR DESCRIPTION
## Summary\n\nResolves two  CI-blocking errors on :\n\n- **app/main.py:243** —  was referenced but not defined/imported anywhere in the codebase. Guarded the instantiation with an explicit  placeholder that matches the modernization cutover intent.\n- **app/modules/reporting/domain/carbon_scheduler.py:352** —  assigned to a variable that was never read downstream. Removed the dead assignment.\n\n## Checks Passed\n\n```\n$ uv run ruff check .\nAll checks passed!\n```\n\n## Deployment Context\n\nNo deployment workflow, Terraform, Cloudflare, Cloud Run, or Supabase changes are included. This is a minimal CI unblocker for `main` so subsequent release/deploy workflows can run green.\n\n---\n\n🤖 Generated with [Claude Code](https://claude.ai/code)