### PR TITLE
fix(ci): resolve undefined symbol and unused assignment blocking main CI

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -240,7 +240,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
                 remediation="Ensure cloud_resource_pricing seeding completed. "
                 "Optimization estimates may use stale or missing pricing until refresh succeeds.",
             )
-    app.state.demo_data_service = DemoDataService()
+    app.state.demo_data_service = None  # Guard pending DemoDataService implementation in modernization cutover
 
     from app.shared.core.http import init_http_client, close_http_client
 

--- a/app/modules/reporting/domain/carbon_scheduler.py
+++ b/app/modules/reporting/domain/carbon_scheduler.py
@@ -349,7 +349,6 @@ class CarbonAwareScheduler:
         if not candidate_regions:
             raise ValueError("No candidate regions provided")
 
-        carbon_data = asyncio.run(CarbonData.get_instance())
         ranked = sorted(
             candidate_regions,
             key=lambda r: self._get_avg_intensity(


### PR DESCRIPTION
## Summary

Resolves two  F821/F841 CI blockers on :

- **app/main.py:243** —  is referenced but not defined/imported anywhere in the codebase. Guarded the instantiation with an explicit  placeholder that matches the modernization cutover intent.
- **app/modules/reporting/domain/carbon_scheduler.py:352** —  assigned to a variable never read downstream. Removed the dead assignment.

## Checks Passed

```
$ uv run ruff check .
All checks passed!
```

## Why This Branch Exists

These are the only two known  symbol/assignment errors blocking  CI. No deploy scripts, Terraform, Cloudflare, Cloud Run, or Supabase changes are included. This is a minimal CI unblocker so subsequent release/deploy workflows can run green.

---
🤖 Generated with [Claude Code](https://claude.ai/code)